### PR TITLE
fix issue #369: mul/div transform len or pos

### DIFF
--- a/muse2/muse/miditransform.cpp
+++ b/muse2/muse/miditransform.cpp
@@ -623,10 +623,10 @@ void MidiTransformerDialog::transformEvent(MusECore::Event& event, MusECore::Mid
                   len -= cmt->procLenA;
                   break;
             case MusECore::Multiply:
-                  len = int(val * (cmt->procLenA/100.0) + .5);
+                  len = int(len * (cmt->procLenA/100.0) + .5);
                   break;
             case MusECore::Divide:
-                  len = int(val / (cmt->procLenA/100.0) + .5);
+                  len = int(len / (cmt->procLenA/100.0) + .5);
                   break;
             case MusECore::Fix:
                   len = cmt->procLenA;
@@ -658,10 +658,10 @@ void MidiTransformerDialog::transformEvent(MusECore::Event& event, MusECore::Mid
                   pos -= cmt->procPosA;
                   break;
             case MusECore::Multiply:
-                  pos = int(val * (cmt->procPosA/100.0) + .5);
+                  pos = int(pos * (cmt->procPosA/100.0) + .5);
                   break;
             case MusECore::Divide:
-                  pos = int(val / (cmt->procPosA/100.0) + .5);
+                  pos = int(pos / (cmt->procPosA/100.0) + .5);
                   break;
             case MusECore::Fix:
             case MusECore::Invert:


### PR DESCRIPTION
If I try to perform a Multiply or Divide transform of position or length, the midi events are incorrectly transformed.  When looking at the code in MidiTransformerDialog::transformEvent, I notice the corresponding switch statements are incorrectly using "var" as input to the these transformations, but "pos" or "len" should be used instead.  I have fixed this, compiled and tested, and verified that it is now working correctly, so please accept my pull request.