### PR TITLE
fix build if ENABLE_DSSI==FALSE

### DIFF
--- a/muse3/muse/helper.cpp
+++ b/muse3/muse/helper.cpp
@@ -642,8 +642,10 @@ QMenu* populateAddSynth(QWidget* parent)
   {
     synth = *i;
     type = synth->synthType();
+#ifdef DSSI_SUPPORT
     if (type == MusECore::Synth::DSSI_SYNTH && ((MusECore::DssiSynth*)synth)->isDssiVst() ) // Place Wine VSTs in a separate sub menu
       type = MusECore::Synth::VST_SYNTH;
+#endif
 
 #ifdef LV2_SUPPORT
     if (type == MusECore::Synth::LV2_SYNTH && !((MusECore::LV2Synth*)synth)->isSynth() ) // Place LV2 effects in a separate sub menu


### PR DESCRIPTION
if built without DSSI support, there wont be a member DssiSynth in MusECore