### PR TITLE
fix build without having liblo installed

### DIFF
--- a/muse3/muse/ctrl.h
+++ b/muse3/muse/ctrl.h
@@ -31,7 +31,12 @@
 #include <list>
 #include <vector>
 #include <qcolor.h>
+
+#ifdef OSC_SUPPORT
 #include <lo/lo_osc_types.h>
+#else
+#include <stdint.h>
+#endif
 
 #define AC_PLUGIN_CTL_BASE         0x1000
 #define AC_PLUGIN_CTL_BASE_POW     12


### PR DESCRIPTION
liblo is still optional, right? So just include stdint.h if there is no osc support, as it would be included by lo_osc_types.h anyway.