### PR TITLE
Replace deprecated WFlags references with WindowFlags

### DIFF
--- a/muse3/muse/instruments/midictrledit.cpp
+++ b/muse3/muse/instruments/midictrledit.cpp
@@ -102,7 +102,7 @@ void MidiControllerEditDialog::addControllerToView(MidiController* mctrl)
 //   MidiControllerEditDialog
 //---------------------------------------------------------
 
-MidiControllerEditDialog::MidiControllerEditDialog(QWidget* parent, const char* name, bool modal, Qt::WFlags fl)
+MidiControllerEditDialog::MidiControllerEditDialog(QWidget* parent, const char* name, bool modal, Qt::WindowFlags fl)
    : MidiControllerEditDialogBase(parent, name, modal, fl)
       {
       _lastPort = midiPortsList->currentItem();

--- a/muse3/muse/instruments/midictrledit.h
+++ b/muse3/muse/instruments/midictrledit.h
@@ -63,7 +63,7 @@ class MidiControllerEditDialog : public MidiControllerEditDialogBase {
       void songChanged(MusECore::SongChangedFlags_t);
 
    public:
-      MidiControllerEditDialog(QWidget* parent = 0, const char* name = 0, bool modal = false, Qt::WFlags fl = 0);
+      MidiControllerEditDialog(QWidget* parent = 0, const char* name = 0, bool modal = false, Qt::WindowFlags fl = 0);
       };
 
 extern MidiControllerEditDialog* midiControllerEditDialog;

--- a/muse3/muse/mplugins/rhythm.cpp
+++ b/muse3/muse/mplugins/rhythm.cpp
@@ -35,7 +35,7 @@ namespace MusEGui {
 //   RhythmGen
 //---------------------------------------------------------
 
-RhythmGen::RhythmGen(QWidget* parent, Qt::WFlags fo)
+RhythmGen::RhythmGen(QWidget* parent, Qt::WindowFlags fo)
    : QMainWindow(parent, fo)
       {
       setupUi(this);
@@ -235,7 +235,7 @@ static const char* const image1_data[] = {
  *  The dialog will by default be modeless, unless you set 'modal' to
  *  TRUE to construct a modal dialog.
  */
-RhythmGenerator::RhythmGenerator( QWidget* parent,  const char* name, bool modal, Qt::WFlags fl )
+RhythmGenerator::RhythmGenerator( QWidget* parent,  const char* name, bool modal, Qt::WindowFlags fl )
     : QDialog( parent, name, modal, fl )
 {
     QPixmap image0( ( const char** ) image0_data );

--- a/muse3/muse/mplugins/rhythm.h
+++ b/muse3/muse/mplugins/rhythm.h
@@ -207,7 +207,7 @@ class RhythmGen : public QMainWindow, public Ui::RhythmBase
    public:
 //      virtual void OnMenuCommand(int id);
 //      virtual void OnSize(int w, int h);
-      RhythmGen(QWidget* parent = 0, Qt::WFlags fo = Qt::Window);
+      RhythmGen(QWidget* parent = 0, Qt::WindowFlags fo = Qt::Window);
       virtual ~RhythmGen();
 //      void OnPaint();
 //      void GenRhythm();


### PR DESCRIPTION
As of this pr, muse doesn't compile with the latest Qt version due to the deprecated `Qt::WFlags` type having been removed.

It was synonymous to `Qt::WindowFlags`. I replaced the few instances in muse, and the build was able to continue.