### PR TITLE
Add idf for CrocellKit from Drumgizmo

### DIFF
--- a/muse3/share/instruments/Drumgizmo - CrocellKit.idf
+++ b/muse3/share/instruments/Drumgizmo - CrocellKit.idf
@@ -1,0 +1,149 @@
+<?xml version="1.0"?>
+<muse version="2.1">
+  <MidiInstrument name="Drumgizmo CrocellKit">
+    <PatchGroup name="Drums">
+      <Patch name="Drums" drum="1" />
+    </PatchGroup>
+    <Drummaps>
+      <entry>
+        <drummap>
+          <entry pitch="35">
+            <name>Kick L</name>
+          </entry>
+          <entry pitch="36">
+            <name>Kick R</name>
+          </entry>
+          <entry pitch="37">
+            <name>Snare Rim</name>
+          </entry>
+          <entry pitch="38">
+            <name>Snare</name>
+          </entry>
+          <entry pitch="39">
+            <name>Snare Rest</name>
+          </entry>
+          <entry pitch="40">
+            <name>Snare Rimshot</name>
+          </entry>
+          <entry pitch="41">
+            <name>Tom 4</name>
+          </entry>
+          <entry pitch="42">
+            <name>HH Closed</name>
+          </entry>
+          <entry pitch="43">
+            <name>Tom 3</name>
+          </entry>
+          <entry pitch="44">
+            <name>HH Pedal</name>
+          </entry>
+          <entry pitch="46">
+            <name>HH OpenL</name>
+          </entry>
+          <entry pitch="47">
+            <name>Tom 2</name>
+          </entry>
+          <entry pitch="48">
+            <name>Tom 1</name>
+          </entry>
+          <entry pitch="49">
+            <name>Crash L</name>
+          </entry>
+          <entry pitch="51">
+            <name>Ride R</name>
+          </entry>
+          <entry pitch="52">
+            <name>China R</name>
+          </entry>
+          <entry pitch="53">
+            <name>Ride R Bell</name>
+          </entry>
+          <entry pitch="54">
+            <name>China L</name>
+          </entry>
+          <entry pitch="55">
+            <name>Splash L</name>
+          </entry>
+          <entry pitch="56">
+            <name>Crash L Stop</name>
+          </entry>
+          <entry pitch="57">
+            <name>Crash R</name>
+          </entry>
+          <entry pitch="58">
+            <name>Splash R</name>
+          </entry>
+          <entry pitch="59">
+            <name>Crash R Extra</name>
+          </entry>
+          <entry pitch="60">
+            <mute>1</mute>
+          </entry>
+          <entry pitch="61">
+            <mute>1</mute>
+          </entry>
+          <entry pitch="62">
+            <mute>1</mute>
+          </entry>
+          <entry pitch="63">
+            <mute>1</mute>
+          </entry>
+          <entry pitch="64">
+            <mute>1</mute>
+          </entry>
+          <entry pitch="65">
+            <mute>1</mute>
+          </entry>
+          <entry pitch="66">
+            <mute>1</mute>
+          </entry>
+          <entry pitch="67">
+            <mute>1</mute>
+          </entry>
+          <entry pitch="68">
+            <mute>1</mute>
+          </entry>
+          <entry pitch="69">
+            <mute>1</mute>
+          </entry>
+          <entry pitch="70">
+            <mute>1</mute>
+          </entry>
+          <entry pitch="71">
+            <mute>1</mute>
+          </entry>
+          <entry pitch="72">
+            <mute>1</mute>
+          </entry>
+          <entry pitch="73">
+            <name>HH Pedal Hit</name>
+          </entry>
+          <entry pitch="74">
+            <mute>1</mute>
+          </entry>
+          <entry pitch="75">
+            <name>Crash R Stop</name>
+          </entry>
+          <entry pitch="76">
+            <mute>1</mute>
+          </entry>
+          <entry pitch="77">
+            <mute>1</mute>
+          </entry>
+          <entry pitch="78">
+            <name>HH Cl No PedalL</name>
+          </entry>
+          <entry pitch="79">
+            <mute>1</mute>
+          </entry>
+          <entry pitch="80">
+            <name>HH Semi-Open</name>
+          </entry>
+          <entry pitch="81">
+            <mute>1</mute>
+          </entry>
+          </drummap>
+      </entry>
+    </Drummaps>
+  </MidiInstrument>
+</muse>


### PR DESCRIPTION
Trying to help make [this tutorial](https://www.youtube.com/watch?v=hXDCTmcBmLg) easier to work with since it's not obvious that the mapping has to be created. Also, it would be really nice if the Instrument Editor showed MIDI Note Numbers (0-127) in one of the columns rather than just showing 2 columns of musical notes. It would make future contributions like this easier since, in the case of Drumgizmo, they provide this information in their .xml files.