### PR TITLE
Fixes compile issue with QButtonGroup

### DIFF
--- a/muse3/muse/widgets/genset.cpp
+++ b/muse3/muse/widgets/genset.cpp
@@ -29,7 +29,6 @@
 #include <QRect>
 #include <QShowEvent>
 #include <QString>
-#include <QButtonGroup>
 
 #include "genset.h"
 #include "app.h"

--- a/muse3/muse/widgets/genset.h
+++ b/muse3/muse/widgets/genset.h
@@ -29,6 +29,7 @@
 #include "cobject.h"
 #include "mdisettings.h"
 
+#include <QButtonGroup>
 #include <QShowEvent>
 #include <list>
 


### PR DESCRIPTION
Fixes a compile-time error in `genset.h`.
```
error: invalid use of incomplete type 'class QButtonGroup'
```

This bug was seen in the [ArchLinux AUR package for muse](https://aur.archlinux.org/packages/muse/), top comment by "aufhaengbar commented on 2018-06-09 05:55" provides more information.

I also ran into the issue on ArchLinux.

The fix was to move the QButtonGroup include from `muse3/muse/widgets/genset.cpp` to `muse3/muse/widgets/genset.h`.

**Relevant versions:**

- ArchLinux as of 2018-09-14
- Muse 3.0.2 (obtained from GitHub releases, the one on the AUR is out of date.)
- GCC 8.2.1
- Qt 5.11.1