### PR TITLE
Run properly on HiDPI screens

### DIFF
--- a/muse3/muse/main.cpp
+++ b/muse3/muse/main.cpp
@@ -527,6 +527,7 @@ int main(int argc, char* argv[])
   #endif
 
         // Now create the application, and let Qt remove recognized arguments.
+        QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
         MuseApplication app(argc_copy, argv_copy);
         if(QStyle* def_style = app.style())
         {


### PR DESCRIPTION
Without this the UI is unusable on my HiDPI screen. It shouldn't impact non-HiDPI displays.

See https://doc.qt.io/qt-5/highdpi.html
