### PR TITLE
Fix build failure

### DIFF
--- a/muse3/muse/lv2Support/sord-0.14.0/src/sord.c
+++ b/muse3/muse/lv2Support/sord-0.14.0/src/sord.c
@@ -1060,7 +1060,7 @@ sord_new_literal_counted(SordWorld*     world,
 	key.meta.lit.datatype = sord_node_copy(datatype);
 	memset(key.meta.lit.lang, 0, sizeof(key.meta.lit.lang));
 	if (lang) {
-		strncpy(key.meta.lit.lang, lang, sizeof(key.meta.lit.lang));
+		strncpy(key.meta.lit.lang, lang, sizeof(key.meta.lit.lang) - 1);
 	}
 
 	return sord_insert_node(world, &key, true);


### PR DESCRIPTION
I had to do this in order to build because of the build with -Werror.

```
[ 10%] Building C object muse/lv2Support/CMakeFiles/lv2_support.dir/sord-0.14.0/src/sord.o
/home/hub/source/muse/muse3/muse/lv2Support/sord-0.14.0/src/sord.c: In function ‘sord_new_literal_counted’:
/home/hub/source/muse/muse3/muse/lv2Support/sord-0.14.0/src/sord.c:1063:3: error: ‘strncpy’ specified bound 16 equals destination size [-Werror=stringop-truncation]
   strncpy(key.meta.lit.lang, lang, sizeof(key.meta.lit.lang));
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[2]: *** [muse/lv2Support/CMakeFiles/lv2_support.dir/build.make:314: muse/lv2Support/CMakeFiles/lv2_support.dir/sord-0.14.0/src/sord.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:2475: muse/lv2Support/CMakeFiles/lv2_support.dir/all] Error 2
make: *** [Makefile:152: all] Error 2
```