### PR TITLE
Force default font for popups started from mixer strip

### DIFF
--- a/muse3/muse/components/plugindialog.cpp
+++ b/muse3/muse/components/plugindialog.cpp
@@ -8,6 +8,7 @@
 #include "plugindialog.h"
 //#include "ui_plugindialogbase.h"
 #include "plugin.h"
+#include "gconfig.h"
 
 
 namespace MusEGui {
@@ -28,6 +29,7 @@ PluginDialog::PluginDialog(QWidget* parent)
   : QDialog(parent)
 {
     ui.setupUi(this);
+    this->setStyleSheet("font-size:" + QString::number(MusEGlobal::config.fonts[0].pointSize()) + "pt");
 
       group_info=NULL;
       setWindowTitle(tr("MusE: select plugin"));

--- a/muse3/muse/components/plugindialogbase.ui
+++ b/muse3/muse/components/plugindialogbase.ui
@@ -31,7 +31,10 @@
    </property>
    <item row="0" column="0">
     <layout class="QGridLayout" name="gridLayout">
-     <property name="spacing">
+     <property name="horizontalSpacing">
+      <number>10</number>
+     </property>
+     <property name="verticalSpacing">
       <number>0</number>
      </property>
      <item row="0" column="0" colspan="4">

--- a/muse3/muse/mixer/strip.cpp
+++ b/muse3/muse/mixer/strip.cpp
@@ -893,9 +893,7 @@ void Strip::changeTrackName()
   dlg.setWindowTitle(tr("Name"));
   dlg.setLabelText(tr("Enter track name:"));
   dlg.setTextValue(oldname);
-  // FIXME: Can't seem to set a larger font. Seems to pick one used by strip.
-  //dlg.setStyleSheet("");
-  //dlg.setFont(MusEGlobal::config.fonts[0]);
+  dlg.setStyleSheet("font-size:" + QString::number(MusEGlobal::config.fonts[0].pointSize()) + "pt");
 
   const int res = dlg.exec();
   if(res == QDialog::Rejected)


### PR DESCRIPTION
Popups "Change track name" and "Select plugin" had very small fonts (7pt as default), inherited from the parent mixer strip.
SetFont does not work here (somebody tried before, as seen in code comment). It has to be done with style.
Small sizing issue corrected in the Select plugin popup.