### PR TITLE
Mass select tracks of same type

### DIFF
--- a/muse3/muse/arranger/tlist.cpp
+++ b/muse3/muse/arranger/tlist.cpp
@@ -960,6 +960,18 @@ void TList::mouseDoubleClickEvent(QMouseEvent* ev)
                 }
               }
             }
+            else if (section == COL_TRACK_IDX) {
+                if (button == Qt::LeftButton) {
+                    // Select all tracks of the same type
+                    MusEGlobal::song->selectAllTracks(false);
+                    MusECore::TrackList* all_tl = MusEGlobal::song->tracks();
+                    foreach (MusECore::Track *other_t, *all_tl) {
+                        if (other_t->type() == t->type())
+                            other_t->setSelected(true);
+                    }
+                    MusEGlobal::song->update(SC_TRACK_SELECTION);
+                }
+            }
             else if (section == COL_OCHANNEL) {
                   // Enabled for audio tracks. And synth channels cannot be changed ATM.
                   // Default to track port if -1 and track channel if -1.

--- a/muse3/muse/components/plugindialog.cpp
+++ b/muse3/muse/components/plugindialog.cpp
@@ -8,6 +8,7 @@
 #include "plugindialog.h"
 //#include "ui_plugindialogbase.h"
 #include "plugin.h"
+#include "gconfig.h"
 
 
 namespace MusEGui {
@@ -28,6 +29,7 @@ PluginDialog::PluginDialog(QWidget* parent)
   : QDialog(parent)
 {
     ui.setupUi(this);
+    this->setStyleSheet("font-size:" + QString::number(MusEGlobal::config.fonts[0].pointSize()) + "pt");
 
       group_info=NULL;
       setWindowTitle(tr("MusE: select plugin"));

--- a/muse3/muse/components/plugindialogbase.ui
+++ b/muse3/muse/components/plugindialogbase.ui
@@ -31,7 +31,10 @@
    </property>
    <item row="0" column="0">
     <layout class="QGridLayout" name="gridLayout">
-     <property name="spacing">
+     <property name="horizontalSpacing">
+      <number>10</number>
+     </property>
+     <property name="verticalSpacing">
       <number>0</number>
      </property>
      <item row="0" column="0" colspan="4">

--- a/muse3/muse/mixer/strip.cpp
+++ b/muse3/muse/mixer/strip.cpp
@@ -893,9 +893,7 @@ void Strip::changeTrackName()
   dlg.setWindowTitle(tr("Name"));
   dlg.setLabelText(tr("Enter track name:"));
   dlg.setTextValue(oldname);
-  // FIXME: Can't seem to set a larger font. Seems to pick one used by strip.
-  //dlg.setStyleSheet("");
-  //dlg.setFont(MusEGlobal::config.fonts[0]);
+  dlg.setStyleSheet("font-size:" + QString::number(MusEGlobal::config.fonts[0].pointSize()) + "pt");
 
   const int res = dlg.exec();
   if(res == QDialog::Rejected)


### PR DESCRIPTION
Double-click on track ID selects all tracks of the same type.
Originally I did it only for Midi/Drum, but it's perhaps more consistent to have it for all types. Can be useful and should do no harm...