### PR TITLE
Fix font scaling in lower zoom level (drum editor)

### DIFF
--- a/muse3/ChangeLog
+++ b/muse3/ChangeLog
@@ -1,3 +1,7 @@
+08.11.2019
+      - Fixed missing font scaling in drum editor at lower zoom level (kybos)
+07.11.2019
+      - Add: Tooltip for current note/instrument in the midi editors (kybos)
 06.11.2019
       - Adjusted raster drawing in view.cpp so it would draw lines that didn't (rj)
         draw correctly on my rig. We'll see if anyone objects

--- a/muse3/muse/midiedit/dlist.cpp
+++ b/muse3/muse/midiedit/dlist.cpp
@@ -273,6 +273,9 @@ void DList::draw(QPainter& p, const QRect& mr, const QRegion&)
       override_col.setAlpha(64);
 
       QFont fnt(p.font());
+      QRect rtmp = map(QRect(0, 0, 0, TH));
+      if (rtmp.height() < TH)
+          fnt.setPixelSize(rtmp.height() - 1);
 
       for (int instrument = 0; instrument < ourDrumMapSize; ++instrument) {
             int yy = instrument * TH;


### PR DESCRIPTION
Current look:
![image](https://user-images.githubusercontent.com/10009541/68455238-2a850080-01fb-11ea-99a0-4b8c99c8aa4f.png)

Fix:
![image](https://user-images.githubusercontent.com/10009541/68455377-8485c600-01fb-11ea-944c-25722747f1fd.png)
