### PR TITLE
Color setting for transport handles is ignored in themes

### DIFF
--- a/muse3/muse/transport.cpp
+++ b/muse3/muse/transport.cpp
@@ -86,15 +86,12 @@ static QToolButton* newButton(const QIcon* icon, const QString& tt,
 
 Handle::Handle(QWidget* r, QWidget* parent)
    : QWidget(parent)
-      {
-      rootWin = r;
-      setFixedWidth(20);
-      setCursor(Qt::PointingHandCursor);
-      QPalette palette;
-      palette.setColor(this->backgroundRole(), MusEGlobal::config.transportHandleColor);
-      this->setPalette(palette);
-      setAutoFillBackground(true);
-      }
+{
+    rootWin = r;
+    setFixedWidth(20);
+    setCursor(Qt::PointingHandCursor);
+    this->setStyleSheet("background-color:" + MusEGlobal::config.transportHandleColor.name());
+}
 
 //---------------------------------------------------------
 //   mouseMoveEvent


### PR DESCRIPTION
Transport handle colour is set to blue in Appearance Settings.
Theme used: Ardour.

Current state:
![muse_transport_handle_color_wrong](https://user-images.githubusercontent.com/10009541/68533796-6324f700-032d-11ea-8cf3-06d352cd8aca.png)

Fix:
![image](https://user-images.githubusercontent.com/10009541/68533789-57d1cb80-032d-11ea-9501-90c8a7bfa6a5.png)
