### PR TITLE
Don't draw invalid piano keys in piano roll

### DIFF
--- a/muse3/muse/midiedit/piano.cpp
+++ b/muse3/muse/midiedit/piano.cpp
@@ -289,7 +289,15 @@ static const char *mk8_xpm[] = {
     "........................................",
     "........................................",
 };
-      
+
+static const char *mke_xpm[] = {
+    "40 3 1 1",
+    "# c #000000",
+    "########################################",
+    "########################################",
+    "########################################",
+};
+
 /*
       0   1   2  3  4  5  6  7  8  9  10
       c-2 c-1 C0 C1 C2 C3 C4 C5 C6 C7 C8 - G8
@@ -349,6 +357,8 @@ Piano::Piano(QWidget* parent, int ymag, MidiEditor* editor)
       mk6 = new QPixmap(mk6_xpm);
       mk7 = new QPixmap(mk7_xpm);
       mk8 = new QPixmap(mk8_xpm);
+
+      mke = new QPixmap(mke_xpm);
       
       keyDown = -1;
       button = Qt::NoButton;
@@ -360,12 +370,20 @@ Piano::Piano(QWidget* parent, int ymag, MidiEditor* editor)
 
 void Piano::draw(QPainter& p, const QRect& mr, const QRegion&)
       {
+      const int octaveSize = 91;
+      const int pianoHeight = octaveSize * 10 + KH * 5 + 3;
+
+      QRect ur = mapDev(mr);
+      if (ur.height() > pianoHeight)
+          ur.setHeight(pianoHeight);
       // FIXME: For some reason need the expansion otherwise drawing
       //        artifacts (incomplete drawing). Can't figure out why.
-      const QRect ur = mapDev(mr).adjusted(0, -4, 0, 4);
-      
-      QPoint offset(0, KH*2);
-      p.drawTiledPixmap(ur, *octave, ur.topLeft()+offset);
+      ur.adjust(0, -4, 0, 4);
+
+      p.drawPixmap(0, -KH * 2, *octave);
+      for (int i = 0; i < 10; i++)
+          p.drawPixmap(0, (KH * 5) + (octaveSize * i), *octave);
+      p.drawPixmap(0, (KH * 5) + (octaveSize * 10), *mke);
 
       if (_curSelectedPitch != -1 && _curSelectedPitch != curPitch)
       {
@@ -421,11 +439,10 @@ void Piano::draw(QPainter& p, const QRect& mr, const QRegion&)
       p.setRenderHint(QPainter::Antialiasing);
       p.setPen(Qt::black);
       p.setFont(QFont("Arial", 7));
-      int octaveSize=91;
 
       for (int drawKey = 0; drawKey < 11; drawKey++) {
           int drawY = octaveSize * drawKey + 82 - KH*2;
-          p.drawText(23, drawY + 8, "C" + QString::number(8 - drawKey));
+          p.drawText(23, drawY + 7, "C" + QString::number(8 - drawKey));
       }
 
 

--- a/muse3/muse/midiedit/piano.h
+++ b/muse3/muse/midiedit/piano.h
@@ -59,6 +59,7 @@ class Piano : public View
       QPixmap* mk6;
       QPixmap* mk7;
       QPixmap* mk8;
+      QPixmap* mke;
       int keyDown;
       bool shift;
       int button;

--- a/muse3/muse/midiedit/prcanvas.cpp
+++ b/muse3/muse/midiedit/prcanvas.cpp
@@ -1446,10 +1446,14 @@ void PianoCanvas::drawCanvas(QPainter& p, const QRect& mr, const QRegion& mrg)
 
 void PianoCanvas::drawCanvas(QPainter& p, const QRect& mr, const QRegion& rg)
       {
+      const int pianoHeight = 91 * 10 + KH * 5 + 1;
+      QRect ur = mapDev(mr);
+      if (ur.height() > pianoHeight)
+      ur.setHeight(pianoHeight);
       // FIXME: For some reason need the expansion otherwise drawing
       //        artifacts (incomplete drawing). Can't figure out why.
-      const QRect ur = mapDev(mr).adjusted(0, -4, 0, 4);
-      
+      ur.adjust(0, -4, 0, 4);
+
       int ux = ur.x();
       if(ux < 0)
         ux = 0;


### PR DESCRIPTION
When on a small zoom level, the piano used an infinite (tiled) pixmap, so invalid keys below C-2 were visible.

Before:
![image](https://user-images.githubusercontent.com/10009541/68997354-ccfd4d80-08a5-11ea-8d35-d26278fd3e43.png)

Fix:
![image](https://user-images.githubusercontent.com/10009541/68994454-68c99200-0883-11ea-9d28-e21bb37e2975.png)
