### PR TITLE
Restrict note tooltip to editing tools

### DIFF
--- a/muse3/muse/midiedit/dcanvas.cpp
+++ b/muse3/muse/midiedit/dcanvas.cpp
@@ -1998,11 +1998,14 @@ void DrumCanvas::mouseMove(QMouseEvent* event) {
 
     EventCanvas::mouseMove(event);
 
-    int pitch = drumEditor->get_instrument_map()[y2pitch(event->pos().y())].pitch;
-    if (track()->drummap()[pitch].name.isEmpty())
-        QToolTip::showText(event->globalPos(), MusECore::pitch2string(pitch));
-    else
-        QToolTip::showText(event->globalPos(), track()->drummap()[pitch].name);
+    if (_tool == MusEGui::PointerTool || _tool == MusEGui::PencilTool
+            || _tool == MusEGui::RubberTool || _tool == MusEGui::CursorTool) {
+        int pitch = drumEditor->get_instrument_map()[y2pitch(event->pos().y())].pitch;
+        if (track()->drummap()[pitch].name.isEmpty())
+            QToolTip::showText(event->globalPos(), MusECore::pitch2string(pitch));
+        else
+            QToolTip::showText(event->globalPos(), track()->drummap()[pitch].name);
+    }
 }
 
 } // namespace MusEGui

--- a/muse3/muse/midiedit/dcanvas.cpp
+++ b/muse3/muse/midiedit/dcanvas.cpp
@@ -1998,8 +1998,7 @@ void DrumCanvas::mouseMove(QMouseEvent* event) {
 
     EventCanvas::mouseMove(event);
 
-    if (_tool == MusEGui::PointerTool || _tool == MusEGui::PencilTool
-            || _tool == MusEGui::RubberTool || _tool == MusEGui::CursorTool) {
+    if (_tool & (MusEGui::PointerTool | MusEGui::PencilTool | MusEGui::RubberTool | MusEGui::CursorTool)) {
         int pitch = drumEditor->get_instrument_map()[y2pitch(event->pos().y())].pitch;
         if (track()->drummap()[pitch].name.isEmpty())
             QToolTip::showText(event->globalPos(), MusECore::pitch2string(pitch));

--- a/muse3/muse/midiedit/prcanvas.cpp
+++ b/muse3/muse/midiedit/prcanvas.cpp
@@ -1865,7 +1865,6 @@ void PianoCanvas::mouseMove(QMouseEvent* event) {
 
     EventCanvas::mouseMove(event);
 
-//    if (_tool == MusEGui::PointerTool || _tool == MusEGui::PencilTool || _tool == MusEGui::RubberTool) {
     if (_tool & (MusEGui::PointerTool | MusEGui::PencilTool | MusEGui::RubberTool)) {
         int pitch = y2pitch(event->pos().y());
         QToolTip::showText(event->globalPos(), MusECore::pitch2string(pitch) + " (" + QString::number(pitch) + ")" );

--- a/muse3/muse/midiedit/prcanvas.cpp
+++ b/muse3/muse/midiedit/prcanvas.cpp
@@ -1865,8 +1865,10 @@ void PianoCanvas::mouseMove(QMouseEvent* event) {
 
     EventCanvas::mouseMove(event);
 
-    int pitch = y2pitch(event->pos().y());
-    QToolTip::showText(event->globalPos(), MusECore::pitch2string(pitch) + " (" + QString::number(pitch) + ")" );
+    if (_tool == MusEGui::PointerTool || _tool == MusEGui::PencilTool || _tool == MusEGui::RubberTool) {
+        int pitch = y2pitch(event->pos().y());
+        QToolTip::showText(event->globalPos(), MusECore::pitch2string(pitch) + " (" + QString::number(pitch) + ")" );
+    }
 }
 
 } // namespace MusEGui

--- a/muse3/muse/midiedit/prcanvas.cpp
+++ b/muse3/muse/midiedit/prcanvas.cpp
@@ -1865,7 +1865,8 @@ void PianoCanvas::mouseMove(QMouseEvent* event) {
 
     EventCanvas::mouseMove(event);
 
-    if (_tool == MusEGui::PointerTool || _tool == MusEGui::PencilTool || _tool == MusEGui::RubberTool) {
+//    if (_tool == MusEGui::PointerTool || _tool == MusEGui::PencilTool || _tool == MusEGui::RubberTool) {
+    if (_tool & (MusEGui::PointerTool | MusEGui::PencilTool | MusEGui::RubberTool)) {
         int pitch = y2pitch(event->pos().y());
         QToolTip::showText(event->globalPos(), MusECore::pitch2string(pitch) + " (" + QString::number(pitch) + ")" );
     }


### PR DESCRIPTION
Improvement for #673.
Don't show the tooltips when non-editing tools like zoom, pan are active.