### PR TITLE
Thicker grid bar lines/fix grid update in ctrl

### DIFF
--- a/muse3/muse/components/view.cpp
+++ b/muse3/muse/components/view.cpp
@@ -951,6 +951,7 @@ void View::drawTickRaster(
 
                     //>pen.setColor(bar_color);
                   }
+                  pen.setWidth(2);
                   p.setPen(pen);
                   
                   if(scale_info._drawBar)
@@ -970,6 +971,8 @@ void View::drawTickRaster(
                       p.drawLine(mx_sm, my, mx_sm, mbottom);
                     }
                   }
+                  pen.setWidth(1); // reset
+                  p.setPen(pen);
                   
                   if(drawText)
                   {

--- a/muse3/muse/ctrl/ctrledit.h
+++ b/muse3/muse/ctrl/ctrledit.h
@@ -83,6 +83,7 @@ class CtrlEdit : public QWidget {
       // Special: We 'abuse' a controller event's length, normally 0, to indicate visual item length.
       void tagItems(MusECore::TagEventList* tag_list, const MusECore::EventTagOptionsStruct& options) const
       { if(canvas) canvas->tagItems(tag_list, options); }
+      void redrawCanvas() {canvas->redraw();}
       };
 
       

--- a/muse3/muse/midiedit/drumedit.cpp
+++ b/muse3/muse/midiedit/drumedit.cpp
@@ -1071,6 +1071,8 @@ void DrumEdit::setRaster(int val)
       _rasterInit = val;
       MidiEditor::setRaster(val);
       canvas->redrawGrid();
+      for (auto it : ctrlEditList)
+          it->redrawCanvas();
       focusCanvas();     // give back focus after kb input
       }
 

--- a/muse3/muse/midiedit/pianoroll.cpp
+++ b/muse3/muse/midiedit/pianoroll.cpp
@@ -1306,6 +1306,8 @@ void PianoRoll::setRaster(int val)
       _rasterInit = val;
       MidiEditor::setRaster(val);
       canvas->redrawGrid();
+      for (auto it : ctrlEditList)
+          it->redrawCanvas();
       focusCanvas();     // give back focus after kb input
       }
 


### PR DESCRIPTION
I was trying to solve the problem of the 3 kinds of (vertical) grid lines not being clearly distinguishable (bar, beat and sub-beat, relevant for pianoroll and drum edit). So I made the bar line a little thicker, and the beat line black in my settings, now it seems much clearer to me (there is no customization option for the sub-beat lines, unfortunately).
Please check if it looks OK for you. I am not sure about a low-resolution screen, as  I don't have any.

![image](https://user-images.githubusercontent.com/10009541/69354205-03f5a980-0c80-11ea-8ba7-c941f73ceecb.png)

I noticed another issue: When the raster was changed (from the snap dropdown on the toolbar), then only the pianoroll/drum canvas was updated, but not the control area(s) below it. This is also fixed here.