### PR TITLE
added more editable colors used on canvases

### DIFF
--- a/muse3/ChangeLog
+++ b/muse3/ChangeLog
@@ -1,3 +1,6 @@
+22.11.2019
+    - New solution to making bar lines more visible. Basically removed more hardcoded colors
+      and made them configurable in the appearance dialog (rj)
 21.11.2019
     - Add command line option -C "Do not re-create plugin cache." (Tim)
       Avoids (looong) repeated re-creations in some cases. Helps devs avoid after rebuilds. 

--- a/muse3/muse/appearance.cpp
+++ b/muse3/muse/appearance.cpp
@@ -186,6 +186,9 @@ Appearance::Appearance(Arranger* a, QWidget* parent)
              new IdListViewItem(0x600 + i, id, MusEGlobal::config.partColorNames[i]);
            
            new IdListViewItem(0x41c, aid, "part canvas background");
+           new IdListViewItem(0x42c, aid, "part canvas raster coarse");
+           new IdListViewItem(0x42d, aid, "part canvas raster fine");
+
            new IdListViewItem(0x41f, aid, "Ruler background");
            new IdListViewItem(0x420, aid, "Ruler text");
            new IdListViewItem(0x424, aid, "Ruler current marker space");
@@ -221,6 +224,7 @@ Appearance::Appearance(Arranger* a, QWidget* parent)
            new IdListViewItem(0x422, id, "drum list");
            new IdListViewItem(0x429, id, "raster beat");
            new IdListViewItem(0x42a, id, "raster bar");
+           new IdListViewItem(0x42e, id, "raster fine");
 
 
       id = new IdListViewItem(0, itemList, "Wave Editor");
@@ -399,7 +403,9 @@ QColor* Appearance::globalConfigColorFromId(int id) const
       case 0x42a: return &MusEGlobal::config.midiCanvasBarColor; break;
       case 0x42b: return &MusEGlobal::config.trackSectionDividerColor; break;
 
-
+      case 0x42c: return &MusEGlobal::config.partCanvasCoarseRasterColor; break;
+      case 0x42d: return &MusEGlobal::config.partCanvasFineRasterColor; break;
+      case 0x42e: return &MusEGlobal::config.midiCanvasFineColor; break;
 
       case 0x500: return &MusEGlobal::config.mixerBg;   break;
       case 0x501: return &MusEGlobal::config.midiTrackLabelBg;   break;

--- a/muse3/muse/arranger/pcanvas.cpp
+++ b/muse3/muse/arranger/pcanvas.cpp
@@ -3063,7 +3063,6 @@ void PartCanvas::drawCanvas(QPainter& p, const QRect& mr, const QRegion& mrg)
       // GRID //
       //////////
 
-      QColor baseColor(MusEGlobal::config.partCanvasBg.lighter(104));
       QPen pen;
       pen.setCosmetic(true);
 
@@ -3079,8 +3078,10 @@ void PartCanvas::drawCanvas(QPainter& p, const QRect& mr, const QRegion& mrg)
         
         drawTickRaster(p, mr, mrg, rast,
                          false, false, false,
-                         baseColor.darker(115), 
-                         baseColor);
+                       MusEGlobal::config.partCanvasFineRasterColor,
+                       Qt::red, // dummy color, initialize to a bold color so it will be evident if it is used
+                       Qt::red, // -"-
+                       MusEGlobal::config.partCanvasCoarseRasterColor);
       }
 
       //--------------------------------
@@ -3117,8 +3118,8 @@ void PartCanvas::drawCanvas(QPainter& p, const QRect& mr, const QRegion& mrg)
 // For testing...
 //                 fprintf(stderr, "... bottom edge in range. Drawing bottom edge at mx0_lim:%d myy_2:%d mx_2:%d myy_2:%d\n",
 //                         mx0_lim, myy_2, mx_2, myy_2);
-                
-                pen.setColor(baseColor.darker(130));
+
+                pen.setColor(MusEGlobal::config.partCanvasCoarseRasterColor);
                 p.setPen(pen);
                 p.drawLine(mx0_lim, myy_2, mx_2, myy_2);
               }

--- a/muse3/muse/components/mtscale.cpp
+++ b/muse3/muse/components/mtscale.cpp
@@ -475,7 +475,9 @@ void MTScale::pdraw(QPainter& p, const QRect& mr, const QRegion& mrg)
                          waveMode, false, true,
                          MusEGlobal::config.rulerFg, 
                          MusEGlobal::config.rulerFg,
-                         QColor(),
+                         Qt::red, // dummy color, initialize to a bold color so it will be evident if it is used
+                         Qt::red, // -"-
+                         MusEGlobal::config.rulerFg,
                          MusEGlobal::config.fonts[3], MusEGlobal::config.fonts[4]);
       }
 

--- a/muse3/muse/components/view.cpp
+++ b/muse3/muse/components/view.cpp
@@ -755,6 +755,8 @@ void View::drawTickRaster(
   bool drawText,
   const QColor& bar_color,
   const QColor& beat_color,
+  const QColor& fine_color,
+  const QColor& coarse_color,
   const QColor& text_color,
   const QFont& large_font,
   const QFont& small_font
@@ -944,12 +946,10 @@ void View::drawTickRaster(
                     ScaleRetStruct scale_info_text_lines = scale(true, bar, tpix);
                     if (scale_info_text_lines._drawBar) {
                       // highlight lines drawn with text
-                      pen.setColor(bar_color.darker());
+                      pen.setColor(coarse_color);
                     } else {
                       pen.setColor(bar_color);
                     }
-
-                    //>pen.setColor(bar_color);
                   }
                   p.setPen(pen);
                   
@@ -980,7 +980,7 @@ void View::drawTickRaster(
             if(!drawText && !scale_info._isSmall)
             {
               if (raster>=4) {
-                          pen.setColor(Qt::darkGray);
+                          pen.setColor(fine_color);
                           p.setPen(pen);
                           rast_xb = MusEGlobal::sigmap.bar2tick(bar, 0, 0);
                           MusEGlobal::sigmap.timesig(rast_xb, rast_z, rast_n);
@@ -1076,7 +1076,6 @@ void View::drawTickRaster(
                             pen.setColor(beat_color);
                             p.setPen(pen);
                             p.drawLine(mxx, my, mxx, mbottom);
-//                            p.drawLine(mxx+1, my, mxx+1, mbottom);
                           }
                         }
                         }

--- a/muse3/muse/components/view.h
+++ b/muse3/muse/components/view.h
@@ -167,9 +167,11 @@ class View : public QWidget {
                                       bool waveMode = false,
                                       bool useGivenColors = false,
                                       bool drawText = false,
-                                      const QColor& bar_color = QColor(),
-                                      const QColor& beat_color = QColor(),
-                                      const QColor& text_color = QColor(),
+                                      const QColor& bar_color = Qt::cyan, // default to very obvious color to visualize uninitialized drawing
+                                      const QColor& beat_color = Qt::cyan,
+                                      const QColor& fine_color = Qt::cyan,
+                                      const QColor& coarse_color = Qt::cyan,
+                                      const QColor& text_color = Qt::cyan,
                                       const QFont& large_font = QFont(),
                                       const QFont& small_font = QFont()
                                      );

--- a/muse3/muse/conf.cpp
+++ b/muse3/muse/conf.cpp
@@ -870,6 +870,10 @@ void readConfiguration(Xml& xml, bool doReadMidiPortConfig, bool doReadGlobalCon
                         
                         else if (tag == "partCanvasBg")
                               MusEGlobal::config.partCanvasBg = readColor(xml);
+                        else if (tag == "partCanvasFineRaster")
+                              MusEGlobal::config.partCanvasFineRasterColor = readColor(xml);
+                        else if (tag == "partCanvasCoarseRaster")
+                              MusEGlobal::config.partCanvasCoarseRasterColor = readColor(xml);
                         else if (tag == "trackBg")
                               MusEGlobal::config.trackBg = readColor(xml);
                         else if (tag == "selectTrackBg")
@@ -1033,10 +1037,16 @@ void readConfiguration(Xml& xml, bool doReadMidiPortConfig, bool doReadGlobalCon
 
                         else if (tag == "midiCanvasBackgroundColor")
                               MusEGlobal::config.midiCanvasBg = readColor(xml);
+
+                        else if (tag == "midiCanvasFineColor")
+                              MusEGlobal::config.midiCanvasFineColor = readColor(xml);
+
                         else if (tag == "midiCanvasBeatColor")
                               MusEGlobal::config.midiCanvasBeatColor = readColor(xml);
+
                         else if (tag == "midiCanvasBarColor")
                               MusEGlobal::config.midiCanvasBarColor = readColor(xml);
+
                         else if (tag == "midiControllerViewBackgroundColor")
                               MusEGlobal::config.midiControllerViewBg = readColor(xml);
                         else if (tag == "drumListBackgroundColor")
@@ -1552,6 +1562,9 @@ static void writeConfigurationColors(int level, MusECore::Xml& xml, bool partCol
       }
       
       xml.colorTag(level, "partCanvasBg",  MusEGlobal::config.partCanvasBg);
+      xml.colorTag(level, "partCanvasCoarseRaster",  MusEGlobal::config.partCanvasCoarseRasterColor);
+      xml.colorTag(level, "partCanvasFineRaster",  MusEGlobal::config.partCanvasFineRasterColor);
+
       xml.colorTag(level, "trackBg",       MusEGlobal::config.trackBg);
       xml.colorTag(level, "selectTrackBg", MusEGlobal::config.selectTrackBg);
       xml.colorTag(level, "selectTrackFg", MusEGlobal::config.selectTrackFg);
@@ -1615,6 +1628,7 @@ static void writeConfigurationColors(int level, MusECore::Xml& xml, bool partCol
       xml.colorTag(level, "partMidiLightEventColor", MusEGlobal::config.partMidiLightEventColor);
 
       xml.colorTag(level, "midiCanvasBackgroundColor", MusEGlobal::config.midiCanvasBg);
+      xml.colorTag(level, "midiCanvasFineColor", MusEGlobal::config.midiCanvasFineColor);
       xml.colorTag(level, "midiCanvasBeatColor", MusEGlobal::config.midiCanvasBeatColor);
       xml.colorTag(level, "midiCanvasBarColor", MusEGlobal::config.midiCanvasBarColor);
 

--- a/muse3/muse/ctrl/ctrlcanvas.cpp
+++ b/muse3/muse/ctrl/ctrlcanvas.cpp
@@ -3439,9 +3439,12 @@ QRect CtrlCanvas::overlayRect() const
 void CtrlCanvas::draw(QPainter& p, const QRect& rect, const QRegion& rg)
       {
       drawTickRaster(p, rect, rg, editor->raster(),
-                         false, false, false,
-                         MusEGlobal::config.midiCanvasBarColor, 
-                         MusEGlobal::config.midiCanvasBeatColor);
+                     false, false, false,
+                     Qt::red, // dummy color, very visual so it can be detected if it is drawn.
+                     MusEGlobal::config.midiCanvasBeatColor,
+                     MusEGlobal::config.midiCanvasFineColor,
+                     MusEGlobal::config.midiCanvasBarColor
+                     );
 
       //---------------------------------------------------
       //    draw line tool

--- a/muse3/muse/gconfig.cpp
+++ b/muse3/muse/gconfig.cpp
@@ -157,6 +157,8 @@ GlobalConfigValues config = {
       QColor(220, 211, 202),     // synthTrackBg;
       
       QColor(98, 124, 168),      // part canvas bg
+      QColor(71, 71, 71),        // partCanvasCoarseRaster;
+      QColor(130, 136, 168),     // partCanvasFineRaster;
       QColor(255, 170, 0),       // ctrlGraphFg;    Medium orange
       QColor(0, 0, 0),           // mixerBg;
 
@@ -166,7 +168,8 @@ GlobalConfigValues config = {
       QColor(255, 255, 255),        // midiControllerViewBg
       QColor(255, 255, 255),        // drumListBg
       QColor(255, 255, 255),        // rulerCurrent
-      Qt::gray,                     // midiCanvasBeatColor
+      QColor(210, 210, 210),        // midiCanvasFineColor
+      QColor(130, 130, 130),        // midiCanvasBeatColor
       Qt::black,                    // midiCanvasBarColor
       Qt::lightGray,                // waveNonselectedPart
       Qt::darkGray,                 // wavePeakColor

--- a/muse3/muse/gconfig.h
+++ b/muse3/muse/gconfig.h
@@ -199,6 +199,8 @@ struct GlobalConfigValues {
       QColor synthTrackBg;
       
       QColor partCanvasBg;
+      QColor partCanvasCoarseRasterColor;
+      QColor partCanvasFineRasterColor;
       QColor ctrlGraphFg;
       QColor mixerBg;
 
@@ -208,6 +210,7 @@ struct GlobalConfigValues {
       QColor midiControllerViewBg;
       QColor drumListBg;
       QColor rulerCurrent;
+      QColor midiCanvasFineColor;
       QColor midiCanvasBeatColor;
       QColor midiCanvasBarColor;
 

--- a/muse3/muse/midiedit/dcanvas.cpp
+++ b/muse3/muse/midiedit/dcanvas.cpp
@@ -806,9 +806,11 @@ void DrumCanvas::drawCanvas(QPainter& p, const QRect& mr, const QRegion& rg)
       //---------------------------------------------------
 
       drawTickRaster(p, mr, rg, editor->raster(), false, false, false,
-                         MusEGlobal::config.midiCanvasBarColor, 
-                         MusEGlobal::config.midiCanvasBeatColor);
-      }
+                     Qt::red, // dummy color, not used
+                     MusEGlobal::config.midiCanvasBeatColor,
+                     MusEGlobal::config.midiCanvasFineColor,
+                     MusEGlobal::config.midiCanvasBarColor);
+}
 
 //---------------------------------------------------------
 //   drawTopItem

--- a/muse3/muse/midiedit/prcanvas.cpp
+++ b/muse3/muse/midiedit/prcanvas.cpp
@@ -1502,8 +1502,10 @@ void PianoCanvas::drawCanvas(QPainter& p, const QRect& mr, const QRegion& rg)
       //---------------------------------------------------
 
       drawTickRaster(p, mr, rg, editor->raster(), false, false, false,
-                         MusEGlobal::config.midiCanvasBarColor, 
-                         MusEGlobal::config.midiCanvasBeatColor);
+                     Qt::red, // dummy color, not used
+                     MusEGlobal::config.midiCanvasBeatColor,
+                     MusEGlobal::config.midiCanvasFineColor,
+                     MusEGlobal::config.midiCanvasBarColor);
       
       }
 

--- a/muse3/muse/waveedit/wavecanvas.cpp
+++ b/muse3/muse/waveedit/wavecanvas.cpp
@@ -1513,8 +1513,11 @@ void WaveCanvas::drawCanvas(QPainter& p, const QRect& rect, const QRegion& rg)
       //---------------------------------------------------
 
       drawTickRaster(p, rect, rg, editor->raster(), true, false, false,
-                         MusEGlobal::config.midiCanvasBarColor, 
-                         MusEGlobal::config.midiCanvasBeatColor);
+                     MusEGlobal::config.midiCanvasBeatColor, // color sequence slightly done by trial and error..
+                     MusEGlobal::config.midiCanvasBeatColor,
+                     Qt::red, // dummy color
+                     MusEGlobal::config.midiCanvasBarColor
+                     );
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
![bild](https://user-images.githubusercontent.com/4476983/69450853-5dcca100-0d5e-11ea-8526-5c23a15a8b27.png)

Took another stab at fixing visibility of lines on canvases. Basically added more editable colors and removed more of the hard-coded colors, as I now think that was the main reason it was hard to get a good mix.