### PR TITLE
Fix theming of toolbutton with submenu

### DIFF
--- a/muse3/share/themes/Ardour.qss
+++ b/muse3/share/themes/Ardour.qss
@@ -52,6 +52,14 @@ QToolBar QToolButton:checked {
 
 }
 
+QToolBar QToolButton[popupMode="1"] {
+      padding-right: 12px;
+}
+
 QTreeView, QListView {
 	alternate-background-color: rgb(127,127,137);
+}
+
+MusEGui--RouteTreeWidget {
+	qproperty-categoryColor: DarkCyan;
 }

--- a/muse3/share/themes/Dark Theme.qss
+++ b/muse3/share/themes/Dark Theme.qss
@@ -52,7 +52,15 @@ QToolBar QToolButton:checked {
 
 }
 
+QToolBar QToolButton[popupMode="1"] {
+      padding-right: 12px;
+}
+
 QTreeView, QListView {
      alternate-background-color: rgb(60,60,60);
      background: rgb(30,30,30);
  }
+
+MusEGui--RouteTreeWidget {
+	qproperty-categoryColor: DarkSlateGray;
+}


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/10009541/69499023-68b63b80-0eee-11ea-8e74-7ab1226101c2.png)

Fix:
![image](https://user-images.githubusercontent.com/10009541/69498936-acf50c00-0eed-11ea-989c-e3ae3288dc3a.png)

Also added fixes for "category colour", see #669.