### PR TITLE
Fix icon size on plugin toolbar (fixes #703)

### DIFF
--- a/muse3/muse/plugin.cpp
+++ b/muse3/muse/plugin.cpp
@@ -53,6 +53,7 @@
 #include "meter.h"
 #include "utils.h"
 #include "pluglist.h"
+#include "gui.h"
 
 #ifdef LV2_SUPPORT
 #include "lv2host.h"
@@ -3507,6 +3508,7 @@ PluginGui::PluginGui(MusECore::PluginIBase* p)
       setWindowTitle(plugin->titlePrefix() + plugin->name());
       
       QToolBar* tools = addToolBar(tr("File Buttons"));
+      tools->setIconSize(ICON_SIZE);
 
       QAction* fileOpen = new QAction(QIcon(*openIconS), tr("Load Preset"), this);
 //       connect(fileOpen, SIGNAL(triggered()), this, SLOT(load()));


### PR DESCRIPTION
See #703 

Fix:
![image](https://user-images.githubusercontent.com/10009541/69525535-96d86180-0f68-11ea-9b7b-e394cfb09c93.png)
