### PR TITLE
Native plugin UI - HiDPI scaling (fixes #697)

### DIFF
--- a/muse3/ChangeLog
+++ b/muse3/ChangeLog
@@ -1,3 +1,9 @@
+30.11.2019
+	- Fix #697: On HiDPI displays, plugin native UI windows are automatically
+	  scaled by Qt, but most of the native plugin UIs are not scalable 
+	  or apply their own scaling. There is now a global setting for reverting 
+	  the Qt window scaling. It can be overridden for each soft synth track
+	  by a local setting in the Quirks toolbar. (kybos)
 28.11.2019
     - Fixed the DidYouKnow menu alternative so it shows the dialog even if the
       checkbox for not displaying it is checked. (rj)

--- a/muse3/muse/components/genset.cpp
+++ b/muse3/muse/components/genset.cpp
@@ -223,6 +223,7 @@ void GlobalSettingsConfig::updateSettings()
       denormalCheckBox->setChecked(MusEGlobal::config.useDenormalBias);
       outputLimiterCheckBox->setChecked(MusEGlobal::config.useOutputLimiter);
       vstInPlaceCheckBox->setChecked(MusEGlobal::config.vstInPlace);
+      revertPluginNativeGUIScalingCheckBox->setChecked(MusEGlobal::config.noPluginScaling);
 
       deviceAudioBackendComboBox->setCurrentIndex(MusEGlobal::config.deviceAudioBackend);
 
@@ -448,6 +449,7 @@ void GlobalSettingsConfig::apply()
       MusEGlobal::config.smartFocus = smartFocusCheckBox->isChecked();
       MusEGlobal::config.borderlessMouse = borderlessMouseCheckBox->isChecked();
       MusEGlobal::config.velocityPerNote = velocityPerNoteCheckBox->isChecked();
+      MusEGlobal::config.noPluginScaling = revertPluginNativeGUIScalingCheckBox->isChecked();
 
       MusEGlobal::config.addHiddenTracks = addHiddenCheckBox->isChecked();
       MusEGlobal::config.unhideTracks = unhideTracksCheckBox->isChecked();

--- a/muse3/muse/components/gensetbase.ui
+++ b/muse3/muse/components/gensetbase.ui
@@ -13,8 +13,8 @@
   <property name="windowTitle">
    <string>MusE: Global Settings</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_4">
-   <item>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
     <widget class="QTabWidget" name="TabWidget2">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -23,7 +23,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="TabPage">
       <attribute name="title">
@@ -1321,7 +1321,7 @@ Adjusts responsiveness of audio controls and
             <x>0</x>
             <y>0</y>
             <width>556</width>
-            <height>508</height>
+            <height>479</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_16">
@@ -1890,22 +1890,12 @@ Certain operations will also force them to be resent,
              <property name="geometry">
               <rect>
                <x>0</x>
-               <y>0</y>
-               <width>530</width>
-               <height>640</height>
+               <y>-244</y>
+               <width>534</width>
+               <height>566</height>
               </rect>
              </property>
              <layout class="QGridLayout" name="gridLayout_6">
-              <item row="4" column="0" colspan="2">
-               <widget class="QLabel" name="textLabel1_4_2">
-                <property name="text">
-                 <string>Move single armed track with selection</string>
-                </property>
-                <property name="wordWrap">
-                 <bool>false</bool>
-                </property>
-               </widget>
-              </item>
               <item row="4" column="2">
                <widget class="QCheckBox" name="moveArmedCheckBox">
                 <property name="sizePolicy">
@@ -1919,13 +1909,24 @@ Certain operations will also force them to be resent,
                 </property>
                </widget>
               </item>
-              <item row="6" column="0" colspan="2">
-               <widget class="QLabel" name="TextLabel1_3">
-                <property name="toolTip">
-                 <string/>
-                </property>
+              <item row="23" column="0">
+               <widget class="QLabel" name="label_19">
                 <property name="text">
-                 <string>Some popup menus stay open (else hold Ctrl)</string>
+                 <string>Show note names on notes in pianoroll</string>
+                </property>
+               </widget>
+              </item>
+              <item row="19" column="0">
+               <widget class="QLabel" name="label_16">
+                <property name="text">
+                 <string>Monitor on record-arm automatically</string>
+                </property>
+               </widget>
+              </item>
+              <item row="22" column="0">
+               <widget class="QLabel" name="label_17">
+                <property name="text">
+                 <string>Style hack: Force line edit widgets to draw a frame</string>
                 </property>
                </widget>
               </item>
@@ -1939,125 +1940,13 @@ Certain operations will also force them to be resent,
                 </property>
                </widget>
               </item>
-              <item row="5" column="2">
-               <widget class="QCheckBox" name="projectSaveCheckBox">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="TextLabel1">
-                <property name="text">
-                 <string>GUI Refresh Rate</string>
-                </property>
-                <property name="wordWrap">
-                 <bool>false</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="2">
-               <widget class="QSpinBox" name="guiRefreshSelect">
-                <property name="suffix">
-                 <string>/sec</string>
-                </property>
-                <property name="minimum">
-                 <number>2</number>
-                </property>
-                <property name="maximum">
-                 <number>100</number>
-                </property>
-                <property name="value">
-                 <number>20</number>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="0">
-               <widget class="QLabel" name="textLabel1_4">
-                <property name="text">
-                 <string>Use old-style stop shortcut:</string>
-                </property>
-                <property name="wordWrap">
-                 <bool>false</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="2">
-               <widget class="QCheckBox" name="oldStyleStopCheckBox">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-               </widget>
-              </item>
-              <item row="6" column="2">
-               <widget class="QCheckBox" name="popsDefStayOpenCheckBox">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
+              <item row="22" column="2">
+               <widget class="QCheckBox" name="lineEditStyleHackCheckBox">
                 <property name="toolTip">
-                 <string>Allows some popup menus to stay open.
-Otherwise, hold Ctrl to keep them open.</string>
-                </property>
-                <property name="text">
-                 <string notr="true"/>
-                </property>
-               </widget>
-              </item>
-              <item row="7" column="0" colspan="2">
-               <widget class="QLabel" name="label_2">
-                <property name="toolTip">
-                 <string>In some areas, the middle mouse button decreases
-values, while the right button increases. Users without a
-middle mouse button can select this option to make the
-left button behave like the middle button in such areas.</string>
-                </property>
-                <property name="text">
-                 <string>Use left mouse button for decreasing values</string>
-                </property>
-               </widget>
-              </item>
-              <item row="7" column="2">
-               <widget class="QCheckBox" name="lmbDecreasesCheckBox">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string notr="true"/>
-                </property>
-               </widget>
-              </item>
-              <item row="8" column="0" colspan="2">
-               <widget class="QLabel" name="label_3">
-                <property name="text">
-                 <string>Ctrl + Right click sets left range marker</string>
-                </property>
-               </widget>
-              </item>
-              <item row="8" column="2">
-               <widget class="QCheckBox" name="rangeMarkerWithoutMMBCheckBox">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
+                 <string>Force line edit widgets to draw a frame at 
+ small sizes. Some styles refuse to draw 
+ the frame. This hack forces a frame to be 
+ drawn, but may interfere with other styles.</string>
                 </property>
                 <property name="text">
                  <string/>
@@ -2071,34 +1960,51 @@ left button behave like the middle button in such areas.</string>
                 </property>
                </widget>
               </item>
-              <item row="9" column="2">
-               <widget class="QCheckBox" name="addHiddenCheckBox">
+              <item row="12" column="2">
+               <widget class="QCheckBox" name="velocityPerNoteCheckBox">
                 <property name="text">
                  <string/>
                 </property>
                </widget>
               </item>
-              <item row="10" column="0" colspan="2">
-               <widget class="QLabel" name="label_5">
-                <property name="text">
-                 <string>Unhide tracks when adding hidden tracks</string>
+              <item row="17" column="2">
+               <widget class="QCheckBox" name="preferKnobsVsSlidersCheckBox">
+                <property name="toolTip">
+                 <string>Whether to show knobs or sliders in certain places, for example mixer strips</string>
                 </property>
-               </widget>
-              </item>
-              <item row="10" column="2">
-               <widget class="QCheckBox" name="unhideTracksCheckBox">
                 <property name="text">
                  <string/>
                 </property>
                </widget>
               </item>
-              <item row="11" column="0" colspan="2">
-               <widget class="QLabel" name="label5">
-                <property name="text">
-                 <string>Smart focus</string>
+              <item row="19" column="2">
+               <widget class="QCheckBox" name="monitorOnRecordCheckBox">
+                <property name="toolTip">
+                 <string>Whether record-arming a track 
+ automatically activates monitoring.</string>
                 </property>
-                <property name="wordWrap">
-                 <bool>false</bool>
+                <property name="text">
+                 <string/>
+                </property>
+               </widget>
+              </item>
+              <item row="12" column="0" colspan="2">
+               <widget class="QLabel" name="label_6">
+                <property name="text">
+                 <string>Show newly created midi velocity graphs per-note</string>
+                </property>
+               </widget>
+              </item>
+              <item row="13" column="0" colspan="2">
+               <widget class="QLabel" name="label_8">
+                <property name="toolTip">
+                 <string/>
+                </property>
+                <property name="whatsThis">
+                 <string/>
+                </property>
+                <property name="text">
+                 <string>Borderless zoom/pan mouse (else use alternate method)</string>
                 </property>
                </widget>
               </item>
@@ -2122,80 +2028,27 @@ left button behave like the middle button in such areas.</string>
                 </property>
                </widget>
               </item>
-              <item row="12" column="0" colspan="2">
-               <widget class="QLabel" name="label_6">
+              <item row="17" column="0">
+               <widget class="QLabel" name="label_14">
                 <property name="text">
-                 <string>Show newly created midi velocity graphs per-note</string>
+                 <string>Prefer knobs instead of sliders</string>
                 </property>
                </widget>
               </item>
-              <item row="12" column="2">
-               <widget class="QCheckBox" name="velocityPerNoteCheckBox">
-                <property name="text">
-                 <string/>
+              <item row="6" column="2">
+               <widget class="QCheckBox" name="popsDefStayOpenCheckBox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
                 </property>
-               </widget>
-              </item>
-              <item row="13" column="0" colspan="2">
-               <widget class="QLabel" name="label_8">
                 <property name="toolTip">
-                 <string/>
-                </property>
-                <property name="whatsThis">
-                 <string/>
+                 <string>Allows some popup menus to stay open.
+Otherwise, hold Ctrl to keep them open.</string>
                 </property>
                 <property name="text">
-                 <string>Borderless zoom/pan mouse (else use alternate method)</string>
-                </property>
-               </widget>
-              </item>
-              <item row="13" column="2">
-               <widget class="QCheckBox" name="borderlessMouseCheckBox">
-                <property name="toolTip">
-                 <string>Enable borderless mouse.
-For certain functions like zoom/pan.
-Disable to use an alternate standard 
- method.
-</string>
-                </property>
-                <property name="whatsThis">
-                 <string>Enable borderless mouse.
-For certain functions like zoom.
-Disable to use an alternate standard
- method.</string>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-               </widget>
-              </item>
-              <item row="14" column="0">
-               <widget class="QLabel" name="label_7">
-                <property name="text">
-                 <string>Track height</string>
-                </property>
-               </widget>
-              </item>
-              <item row="14" column="2">
-               <widget class="QSpinBox" name="trackHeight">
-                <property name="suffix">
-                 <string> px</string>
-                </property>
-                <property name="minimum">
-                 <number>20</number>
-                </property>
-                <property name="maximum">
-                 <number>2000</number>
-                </property>
-                <property name="value">
-                 <number>20</number>
-                </property>
-               </widget>
-              </item>
-              <item row="15" column="0">
-               <widget class="QLabel" name="label_9">
-                <property name="text">
-                 <string>Scrollable submenus</string>
+                 <string notr="true"/>
                 </property>
                </widget>
               </item>
@@ -2213,17 +2066,24 @@ Disable to use an alternate standard
                 </property>
                </widget>
               </item>
-              <item row="16" column="2">
-               <widget class="QCheckBox" name="liveWaveUpdateCheckBox">
+              <item row="15" column="0">
+               <widget class="QLabel" name="label_9">
                 <property name="text">
-                 <string/>
+                 <string>Scrollable submenus</string>
                 </property>
                </widget>
               </item>
-              <item row="25" column="0">
-               <widget class="QLabel" name="label_11">
+              <item row="8" column="0" colspan="2">
+               <widget class="QLabel" name="label_3">
                 <property name="text">
-                 <string>LV2 UI Open behavior</string>
+                 <string>Ctrl + Right click sets left range marker</string>
+                </property>
+               </widget>
+              </item>
+              <item row="23" column="2">
+               <widget class="QCheckBox" name="showNoteNamesCheckBox">
+                <property name="text">
+                 <string/>
                 </property>
                </widget>
               </item>
@@ -2246,76 +2106,46 @@ Disable to use an alternate standard
                 </item>
                </widget>
               </item>
-              <item row="17" column="0">
-               <widget class="QLabel" name="label_14">
-                <property name="text">
-                 <string>Prefer knobs instead of sliders</string>
+              <item row="0" column="2">
+               <widget class="QSpinBox" name="guiRefreshSelect">
+                <property name="suffix">
+                 <string>/sec</string>
+                </property>
+                <property name="minimum">
+                 <number>2</number>
+                </property>
+                <property name="maximum">
+                 <number>100</number>
+                </property>
+                <property name="value">
+                 <number>20</number>
                 </property>
                </widget>
               </item>
-              <item row="17" column="2">
-               <widget class="QCheckBox" name="preferKnobsVsSlidersCheckBox">
-                <property name="toolTip">
-                 <string>Whether to show knobs or sliders in certain places, for example mixer strips</string>
+              <item row="1" column="0">
+               <widget class="QLabel" name="textLabel1_4_4">
+                <property name="text">
+                 <string>Bug fix: Fix frozen MDI windows</string>
                 </property>
+                <property name="wordWrap">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="16" column="2">
+               <widget class="QCheckBox" name="liveWaveUpdateCheckBox">
                 <property name="text">
                  <string/>
                 </property>
                </widget>
               </item>
-              <item row="18" column="0">
-               <widget class="QLabel" name="label_15">
+              <item row="3" column="0">
+               <widget class="QLabel" name="textLabel1_4">
                 <property name="text">
-                 <string>Show knob and slider values</string>
+                 <string>Use old-style stop shortcut:</string>
                 </property>
-               </widget>
-              </item>
-              <item row="18" column="2">
-               <widget class="QCheckBox" name="showControlValuesCheckBox">
-                <property name="toolTip">
-                 <string>Whether to show knob and slider values in certain places, for example mixer strips.
-Turn off to reduce clutter.</string>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-               </widget>
-              </item>
-              <item row="19" column="0">
-               <widget class="QLabel" name="label_16">
-                <property name="text">
-                 <string>Monitor on record-arm automatically</string>
-                </property>
-               </widget>
-              </item>
-              <item row="19" column="2">
-               <widget class="QCheckBox" name="monitorOnRecordCheckBox">
-                <property name="toolTip">
-                 <string>Whether record-arming a track 
- automatically activates monitoring.</string>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-               </widget>
-              </item>
-              <item row="22" column="0">
-               <widget class="QLabel" name="label_17">
-                <property name="text">
-                 <string>Style hack: Force line edit widgets to draw a frame</string>
-                </property>
-               </widget>
-              </item>
-              <item row="22" column="2">
-               <widget class="QCheckBox" name="lineEditStyleHackCheckBox">
-                <property name="toolTip">
-                 <string>Force line edit widgets to draw a frame at 
- small sizes. Some styles refuse to draw 
- the frame. This hack forces a frame to be 
- drawn, but may interfere with other styles.</string>
-                </property>
-                <property name="text">
-                 <string/>
+                <property name="wordWrap">
+                 <bool>false</bool>
                 </property>
                </widget>
               </item>
@@ -2337,13 +2167,197 @@ Turn off to reduce clutter.</string>
                 </property>
                </widget>
               </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="textLabel1_4_4">
+              <item row="14" column="0">
+               <widget class="QLabel" name="label_7">
                 <property name="text">
-                 <string>Bug fix: Fix frozen MDI windows</string>
+                 <string>Track height</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="TextLabel1">
+                <property name="text">
+                 <string>GUI Refresh Rate</string>
                 </property>
                 <property name="wordWrap">
                  <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="18" column="0">
+               <widget class="QLabel" name="label_15">
+                <property name="text">
+                 <string>Show knob and slider values</string>
+                </property>
+               </widget>
+              </item>
+              <item row="11" column="0" colspan="2">
+               <widget class="QLabel" name="label5">
+                <property name="text">
+                 <string>Smart focus</string>
+                </property>
+                <property name="wordWrap">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="2">
+               <widget class="QCheckBox" name="projectSaveCheckBox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+               </widget>
+              </item>
+              <item row="8" column="2">
+               <widget class="QCheckBox" name="rangeMarkerWithoutMMBCheckBox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+               </widget>
+              </item>
+              <item row="18" column="2">
+               <widget class="QCheckBox" name="showControlValuesCheckBox">
+                <property name="toolTip">
+                 <string>Whether to show knob and slider values in certain places, for example mixer strips.
+Turn off to reduce clutter.</string>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+               </widget>
+              </item>
+              <item row="7" column="2">
+               <widget class="QCheckBox" name="lmbDecreasesCheckBox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string notr="true"/>
+                </property>
+               </widget>
+              </item>
+              <item row="25" column="0">
+               <widget class="QLabel" name="label_11">
+                <property name="text">
+                 <string>LV2 UI Open behavior</string>
+                </property>
+               </widget>
+              </item>
+              <item row="7" column="0" colspan="2">
+               <widget class="QLabel" name="label_2">
+                <property name="toolTip">
+                 <string>In some areas, the middle mouse button decreases
+values, while the right button increases. Users without a
+middle mouse button can select this option to make the
+left button behave like the middle button in such areas.</string>
+                </property>
+                <property name="text">
+                 <string>Use left mouse button for decreasing values</string>
+                </property>
+               </widget>
+              </item>
+              <item row="9" column="2">
+               <widget class="QCheckBox" name="addHiddenCheckBox">
+                <property name="text">
+                 <string/>
+                </property>
+               </widget>
+              </item>
+              <item row="10" column="0" colspan="2">
+               <widget class="QLabel" name="label_5">
+                <property name="text">
+                 <string>Unhide tracks when adding hidden tracks</string>
+                </property>
+               </widget>
+              </item>
+              <item row="6" column="0" colspan="2">
+               <widget class="QLabel" name="TextLabel1_3">
+                <property name="toolTip">
+                 <string/>
+                </property>
+                <property name="text">
+                 <string>Some popup menus stay open (else hold Ctrl)</string>
+                </property>
+               </widget>
+              </item>
+              <item row="10" column="2">
+               <widget class="QCheckBox" name="unhideTracksCheckBox">
+                <property name="text">
+                 <string/>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="0" colspan="2">
+               <widget class="QLabel" name="textLabel1_4_2">
+                <property name="text">
+                 <string>Move single armed track with selection</string>
+                </property>
+                <property name="wordWrap">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="14" column="2">
+               <widget class="QSpinBox" name="trackHeight">
+                <property name="suffix">
+                 <string> px</string>
+                </property>
+                <property name="minimum">
+                 <number>20</number>
+                </property>
+                <property name="maximum">
+                 <number>2000</number>
+                </property>
+                <property name="value">
+                 <number>20</number>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="2">
+               <widget class="QCheckBox" name="oldStyleStopCheckBox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+               </widget>
+              </item>
+              <item row="13" column="2">
+               <widget class="QCheckBox" name="borderlessMouseCheckBox">
+                <property name="toolTip">
+                 <string>Enable borderless mouse.
+For certain functions like zoom/pan.
+Disable to use an alternate standard 
+ method.
+</string>
+                </property>
+                <property name="whatsThis">
+                 <string>Enable borderless mouse.
+For certain functions like zoom.
+Disable to use an alternate standard
+ method.</string>
+                </property>
+                <property name="text">
+                 <string/>
                 </property>
                </widget>
               </item>
@@ -2371,15 +2385,18 @@ Benign XCB connection errors may still
                 </property>
                </widget>
               </item>
-              <item row="23" column="0">
-               <widget class="QLabel" name="label_19">
+              <item row="26" column="0">
+               <widget class="QLabel" name="label_23">
                 <property name="text">
-                 <string>Show note names on notes in pianoroll</string>
+                 <string>Revert native GUI scaling for plugins in HiDPI</string>
                 </property>
                </widget>
               </item>
-              <item row="23" column="2">
-               <widget class="QCheckBox" name="showNoteNamesCheckBox">
+              <item row="26" column="2">
+               <widget class="QCheckBox" name="revertPluginNativeGUIScalingCheckBox">
+                <property name="toolTip">
+                 <string>Revert native UI window HiDPI scaling (some plugins ignore this setting)</string>
+                </property>
                 <property name="text">
                  <string/>
                 </property>
@@ -2487,8 +2504,8 @@ Benign XCB connection errors may still
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>560</width>
-               <height>373</height>
+               <width>546</width>
+               <height>387</height>
               </rect>
              </property>
              <layout class="QHBoxLayout" name="horizontalLayout_3">
@@ -2506,7 +2523,7 @@ Benign XCB connection errors may still
      </widget>
     </widget>
    </item>
-   <item>
+   <item row="1" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <property name="spacing">
       <number>6</number>

--- a/muse3/muse/components/vst_native_editor.cpp
+++ b/muse3/muse/components/vst_native_editor.cpp
@@ -154,7 +154,6 @@ void VstNativeEditor::open(MusECore::VstNativeSynthIF* sif, MusECore::VstNativeP
   }
 
 
-
   //int rv = _sif->dispatch(effEditOpen, 0, value, ptr, 0.0f);
   //fprintf(stderr, "VstNativeEditor::open effEditOpen returned:%d effEditGetRect rect l:%d r:%d t:%d b:%d\n", rv, pRect->left, pRect->right, pRect->top, pRect->bottom); // REMOVE Tim.
   

--- a/muse3/muse/components/vst_native_editor.cpp
+++ b/muse3/muse/components/vst_native_editor.cpp
@@ -27,11 +27,14 @@
 
 #include "vst_native_editor.h"
 #include "vst_native.h"
+#include "gconfig.h"
 
 #include <QtGlobal>
 #if defined(Q_WS_X11)
 #include <QX11Info>
 #endif
+#include <QApplication>
+
 
 namespace MusEGui {
 
@@ -135,6 +138,13 @@ void VstNativeEditor::open(MusECore::VstNativeSynthIF* sif, MusECore::VstNativeP
           int h = pRect->bottom - pRect->top;
           if (w > 0 && h > 0)
           {
+              if ((_sif->cquirks()._fixNativeUIScaling == MusECore::PluginQuirks::NatUISCaling::GLOBAL && MusEGlobal::config.noPluginScaling)
+                   || _sif->cquirks()._fixNativeUIScaling == MusECore::PluginQuirks::NatUISCaling::ON) {
+
+                  w = qRound((qreal)w / qApp->devicePixelRatio());
+                  h = qRound((qreal)h / qApp->devicePixelRatio());
+              }
+
                   QWidget::setMinimumSize(w, h);
                   if((w != width()) || (h != height()))
                   {
@@ -142,6 +152,7 @@ void VstNativeEditor::open(MusECore::VstNativeSynthIF* sif, MusECore::VstNativeP
                   }
           }
   }
+
 
 
   //int rv = _sif->dispatch(effEditOpen, 0, value, ptr, 0.0f);

--- a/muse3/muse/conf.cpp
+++ b/muse3/muse/conf.cpp
@@ -1202,6 +1202,8 @@ void readConfiguration(Xml& xml, bool doReadMidiPortConfig, bool doReadGlobalCon
                               MusEGlobal::config.mixdownPath = xml.parse1();
                         else if (tag == "showNoteNamesInPianoRoll")
                               MusEGlobal::config.showNoteNamesInPianoRoll = xml.parseInt();
+                        else if (tag == "noPluginScaling")
+                              MusEGlobal::config.noPluginScaling = xml.parseInt();
 
 
                         // ---- the following only skips obsolete entries ----
@@ -1851,6 +1853,7 @@ void MusE::writeGlobalConfiguration(int level, MusECore::Xml& xml) const
       xml.intTag(level, "lv2UiBehavior", static_cast<int>(MusEGlobal::config.lv2UiBehavior));
       xml.strTag(level, "mixdownPath", MusEGlobal::config.mixdownPath);
       xml.intTag(level, "showNoteNamesInPianoRoll", MusEGlobal::config.showNoteNamesInPianoRoll);
+      xml.intTag(level, "noPluginScaling", MusEGlobal::config.noPluginScaling);
 
       for (int i = 0; i < NUM_FONTS; ++i) {
             xml.strTag(level, QString("font") + QString::number(i), MusEGlobal::config.fonts[i].toString());

--- a/muse3/muse/gconfig.cpp
+++ b/muse3/muse/gconfig.cpp
@@ -333,6 +333,7 @@ GlobalConfigValues config = {
       false,                        // commonProjectLatency
       "",                           // mixdownPath
       true,                         // showNoteNamesInPianoRoll
+      true,                         // noPluginScaling
       false                         // selectionsUndoable Whether selecting parts or events is undoable.
     };
 

--- a/muse3/muse/gconfig.h
+++ b/muse3/muse/gconfig.h
@@ -377,6 +377,8 @@ struct GlobalConfigValues {
       // Whether selecting parts or events is undoable.
       // If set, it can be somewhat tedious for the user to step through all the undo/redo items.
       bool selectionsUndoable;
+      // Revert native GUI scaling on HiDPI
+      bool noPluginScaling;
       };
 
 

--- a/muse3/muse/icons.cpp
+++ b/muse3/muse/icons.cpp
@@ -504,6 +504,8 @@ QIcon* closedHandIconSVG;
 QIcon* cursorIconSVG;
 QIcon* magnetIconSVG;
 
+QIcon* noscaleSVGIcon[3];
+
 //----------------------------------
 // Cursors
 //----------------------------------
@@ -852,6 +854,10 @@ void initIcons(bool useThemeIconsIfPossible)
       cursorIconSVG     = new QIcon(":/svg/cursor.svg");
       magnetIconSVG     = new QIcon(":/svg/magnet.svg");
 
+      noscaleSVGIcon[0] = new QIcon(":/svg/noscale1.svg");
+      noscaleSVGIcon[1] = new QIcon(":/svg/noscale2.svg");
+      noscaleSVGIcon[2] = new QIcon(":/svg/noscale3.svg");
+
       //----------------------------------
       // Cursors
       //----------------------------------
@@ -1159,7 +1165,12 @@ void deleteIcons()
       delete cursorIconSVG;
       delete magnetIconSVG;
 
-      //----------------------------------
+      delete noscaleSVGIcon[0];
+      delete noscaleSVGIcon[1];
+      delete noscaleSVGIcon[2];
+
+
+    //----------------------------------
       // Cursors
       //----------------------------------
 

--- a/muse3/muse/icons.h
+++ b/muse3/muse/icons.h
@@ -330,6 +330,8 @@ extern QIcon* closedHandIconSVG;
 extern QIcon* cursorIconSVG;
 extern QIcon* magnetIconSVG;
 
+extern QIcon* noscaleSVGIcon[3];
+
 //----------------------------------
 // Cursors
 //----------------------------------

--- a/muse3/muse/lv2host.cpp
+++ b/muse3/muse/lv2host.cpp
@@ -1602,7 +1602,7 @@ void LV2Synth::lv2ui_ShowNativeGui(LV2PluginWrapper_State *state, bool bShow, Pl
                         win->setCentralWidget(ewWin);
 #endif
 
-                        if (state->uiX11Size.width() == 0 || state->uiX11Size.height() == 0)
+                        if(state->uiX11Size.width() == 0 || state->uiX11Size.height() == 0)
                         {
                             int w = 0;
                             int h = 0;

--- a/muse3/muse/lv2host.cpp
+++ b/muse3/muse/lv2host.cpp
@@ -1333,7 +1333,7 @@ void LV2Synth::lv2ui_Gtk2ResizeCb(int width, int height, void *arg)
     }
 }
 
-void LV2Synth::lv2ui_ShowNativeGui(LV2PluginWrapper_State *state, bool bShow)
+void LV2Synth::lv2ui_ShowNativeGui(LV2PluginWrapper_State *state, bool bShow, PluginQuirks::NatUISCaling fixScaling)
 {
     LV2Synth* synth = state->synth;
     LV2PluginWrapper_Window *win = NULL;
@@ -1602,11 +1602,19 @@ void LV2Synth::lv2ui_ShowNativeGui(LV2PluginWrapper_State *state, bool bShow)
                         win->setCentralWidget(ewWin);
 #endif
 
-                        if(state->uiX11Size.width() == 0 || state->uiX11Size.height() == 0)
+                        if (state->uiX11Size.width() == 0 || state->uiX11Size.height() == 0)
                         {
                             int w = 0;
                             int h = 0;
                             MusEGui::lv2Gtk2Helper_gtk_widget_get_allocation(uiW, &w, &h);
+
+                            if ((fixScaling == MusECore::PluginQuirks::NatUISCaling::GLOBAL && MusEGlobal::config.noPluginScaling)
+                                 || fixScaling == MusECore::PluginQuirks::NatUISCaling::ON) {
+
+                                w = qRound((qreal)w / qApp->devicePixelRatio());
+                                h = qRound((qreal)h / qApp->devicePixelRatio());
+                            }
+
                             win->setMinimumSize(w, h);
                             win->resize(w, h);
                         }
@@ -1615,7 +1623,14 @@ void LV2Synth::lv2ui_ShowNativeGui(LV2PluginWrapper_State *state, bool bShow)
                     else
                     {
                         // Set the minimum size to the supplied uiX11Size.
-                        win->setMinimumSize(state->uiX11Size.width(), state->uiX11Size.height());
+                         if ((fixScaling == MusECore::PluginQuirks::NatUISCaling::GLOBAL && MusEGlobal::config.noPluginScaling)
+                              || fixScaling == MusECore::PluginQuirks::NatUISCaling::ON) {
+
+                             state->uiX11Size.setWidth(qRound((qreal)state->uiX11Size.width() / qApp->devicePixelRatio()));
+                             state->uiX11Size.setHeight(qRound((qreal)state->uiX11Size.height() / qApp->devicePixelRatio()));
+                         }
+
+                         win->setMinimumSize(state->uiX11Size.width(), state->uiX11Size.height());
 
                         if(state->uiX11Size.width() == 0 || state->uiX11Size.height() == 0)
                             win->resize(ewWin->size());
@@ -4886,7 +4901,7 @@ void LV2SynthIF::showNativeGui(bool bShow)
         _state->extHost.plugin_human_id = _state->human_id = strdup((track()->name() + QString(": ") + name()).toUtf8().constData());
     }
 
-    LV2Synth::lv2ui_ShowNativeGui(_state, bShow);
+    LV2Synth::lv2ui_ShowNativeGui(_state, bShow, cquirks()._fixNativeUIScaling);
 }
 
 void LV2SynthIF::write(int level, Xml &xml) const
@@ -5694,7 +5709,7 @@ void LV2PluginWrapper::showNativeGui(PluginI *p, bool bShow)
         state->extHost.plugin_human_id = state->human_id = strdup((p->track()->name() + QString(": ") + label()).toUtf8().constData());
     }
 
-    LV2Synth::lv2ui_ShowNativeGui(state, bShow);
+    LV2Synth::lv2ui_ShowNativeGui(state, bShow, p->cquirks()._fixNativeUIScaling);
 }
 
 bool LV2PluginWrapper::nativeGuiVisible(const PluginI *p) const

--- a/muse3/muse/lv2host.h
+++ b/muse3/muse/lv2host.h
@@ -433,7 +433,7 @@ public:
     static int lv2ui_Resize ( LV2UI_Feature_Handle handle, int width, int height );
     static void lv2ui_Gtk2AllocateCb(int width, int height, void *arg);
     static void lv2ui_Gtk2ResizeCb(int width, int height, void *arg);
-    static void lv2ui_ShowNativeGui ( LV2PluginWrapper_State *state, bool bShow );
+    static void lv2ui_ShowNativeGui (LV2PluginWrapper_State *state, bool bShow , PluginQuirks::NatUISCaling fixScaling);
     static void lv2ui_PortWrite ( LV2UI_Controller controller, uint32_t port_index, uint32_t buffer_size, uint32_t protocol, void const *buffer );
     static void lv2ui_Touch (LV2UI_Controller controller, uint32_t port_index, bool grabbed);
     static void lv2ui_ExtUi_Closed ( LV2UI_Controller contr );

--- a/muse3/muse/plugin.cpp
+++ b/muse3/muse/plugin.cpp
@@ -3574,10 +3574,13 @@ PluginGui::PluginGui(MusECore::PluginIBase* p)
         QOverload<int>::of(&QSpinBox::valueChanged), [=](int v) { latencyOverrideValueChanged(v); } );
       tools->addWidget(latencyOverrideEntry);
 
+      fixScalingTooltip[0] = tr("Revert native UI HiDPI scaling: Follow global setting");
+      fixScalingTooltip[1] = tr("Revert native UI HiDPI scaling: On");
+      fixScalingTooltip[2] = tr("Revert native UI HiDPI scaling: Off");
       fixNativeUIScalingTB = new QToolButton(this);
-      fixNativeUIScalingTB->setIcon(*noscaleSVGIcon[0]);
-      fixNativeUIScalingTB->setProperty("state", 0);
-      fixNativeUIScalingTB->setToolTip(tr("Revert native UI HiDPI scaling: Follow global setting"));
+      fixNativeUIScalingTB->setIcon(*noscaleSVGIcon[plugin->cquirks()._fixNativeUIScaling]);
+      fixNativeUIScalingTB->setProperty("state", plugin->cquirks()._fixNativeUIScaling);
+      fixNativeUIScalingTB->setToolTip(fixScalingTooltip[plugin->cquirks()._fixNativeUIScaling]);
       connect(fixNativeUIScalingTB, &QToolButton::clicked, [this]() { fixNativeUIScalingTBClicked(); } );
       tools->addWidget(fixNativeUIScalingTB);
 
@@ -4370,16 +4373,15 @@ void PluginGui::latencyOverrideValueChanged(int v)
 void PluginGui::fixNativeUIScalingTBClicked()
 {
     int state = fixNativeUIScalingTB->property("state").toInt();
-    if (state == 0) {
-        state++;
-        fixNativeUIScalingTB->setToolTip(tr("Revert native UI HiDPI scaling"));
-    } else if (state == 1) {
-        state++;
-        fixNativeUIScalingTB->setToolTip(tr("Don't revert native UI HiDPI scaling"));
-    } else {
-        state = 0;
-        fixNativeUIScalingTB->setToolTip(tr("Native UI HiDPI scaling: Follow global setting"));
-    }
+    state = (state == 2) ? 0 : ++state;
+//    if (state == 0) {
+//        state++;
+//    } else if (state == 1) {
+//        state++;
+//    } else {
+//        state = 0;
+//    }
+    fixNativeUIScalingTB->setToolTip(fixScalingTooltip[state]);
     fixNativeUIScalingTB->setIcon(*noscaleSVGIcon[state]);
     fixNativeUIScalingTB->setProperty("state", state);
     plugin->quirks()._fixNativeUIScaling = (MusECore::PluginQuirks::NatUISCaling)state;

--- a/muse3/muse/plugin.h
+++ b/muse3/muse/plugin.h
@@ -665,10 +665,11 @@ class PluginGui : public QMainWindow {
       QAction* transpGovLatencyAct;
       QAction* fixedSpeedAct;
       QAction* overrideLatencyAct;
-      QToolButton* fixNativeUIScalingTB;
       QSpinBox* latencyOverrideEntry;
       QWidget* mw;            // main widget
       QScrollArea* view;
+      QToolButton* fixNativeUIScalingTB;
+      QString fixScalingTooltip[3];
 
       void updateControls();
       void getPluginConvertedValues(LADSPA_PortRangeHint range,

--- a/muse3/muse/plugin.h
+++ b/muse3/muse/plugin.h
@@ -42,6 +42,7 @@
 #include <QHideEvent>
 #include <QAction>
 #include <QSpinBox>
+//#include <QToolButton>
 
 #include <ladspa.h>
 
@@ -299,12 +300,16 @@ class PluginQuirks
     bool _overrideReportedLatency;
     // Value to override the reported latency.
     int _latencyOverrideValue;
+    // Reverse scaling of native UI windows on HiDPI
+    enum NatUISCaling {GLOBAL, ON, OFF};
+    NatUISCaling _fixNativeUIScaling;
 
   PluginQuirks() :
     _fixedSpeed(false),
     _transportAffectsAudioLatency(false),
     _overrideReportedLatency(false),
-    _latencyOverrideValue(0)
+    _latencyOverrideValue(0),
+    _fixNativeUIScaling(NatUISCaling::GLOBAL)
     { }
 
   void write(int level, Xml& xml) const;
@@ -660,6 +665,7 @@ class PluginGui : public QMainWindow {
       QAction* transpGovLatencyAct;
       QAction* fixedSpeedAct;
       QAction* overrideLatencyAct;
+      QToolButton* fixNativeUIScalingTB;
       QSpinBox* latencyOverrideEntry;
       QWidget* mw;            // main widget
       QScrollArea* view;
@@ -677,6 +683,7 @@ class PluginGui : public QMainWindow {
       void save();
       void bypassToggled(bool);
       void transportGovernsLatencyToggled(bool);
+      void fixNativeUIScalingTBClicked();
       void fixedSpeedToggled(bool);
       void overrideReportedLatencyToggled(bool);
       void latencyOverrideValueChanged(int);

--- a/muse3/resources.qrc
+++ b/muse3/resources.qrc
@@ -72,5 +72,8 @@
         <file>svg/punchout.svg</file>
         <file>svg/redo.svg</file>
         <file>svg/undo.svg</file>
+        <file>svg/noscale1.svg</file>
+        <file>svg/noscale2.svg</file>
+        <file>svg/noscale3.svg</file>
     </qresource>
 </RCC>

--- a/muse3/svg/noscale1.svg
+++ b/muse3/svg/noscale1.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg id="SVGRoot" width="64px" height="64px" version="1.1" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata>
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <g transform="matrix(1 0 0 .9 0 .3)" stroke-width="1.0541">
+  <path transform="translate(-3 -6)" d="m6 9h49v50h-49z" fill="#ccc" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.0541"/>
+  <path d="m3.0192 8.007v-4.5754h48.955v9.1508h-48.955z" style="paint-order:stroke fill markers"/>
+  <g fill="#fff">
+   <circle cx="8.1161" cy="7.4255" r="2" style="paint-order:stroke fill markers"/>
+   <circle cx="41.748" cy="7.2929" r="2" style="paint-order:stroke fill markers"/>
+   <circle cx="47.537" cy="7.3371" r="2" style="paint-order:stroke fill markers"/>
+  </g>
+ </g>
+ <g transform="matrix(.61224 0 0 .55102 28.151 30.588)" stroke-width="1.7217">
+  <path transform="translate(-3 -6)" d="m6 9h49v50h-49z" fill="#ccc" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.7217"/>
+  <path d="m3.0192 8.007v-4.5754h48.955v9.1508h-48.955z" style="paint-order:stroke fill markers"/>
+  <g fill="#fff">
+   <circle cx="8.1161" cy="7.4255" r="2" style="paint-order:stroke fill markers"/>
+   <circle cx="41.748" cy="7.2929" r="2" style="paint-order:stroke fill markers"/>
+   <circle cx="47.537" cy="7.3371" r="2" style="paint-order:stroke fill markers"/>
+  </g>
+ </g>
+</svg>

--- a/muse3/svg/noscale2.svg
+++ b/muse3/svg/noscale2.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg id="SVGRoot" width="64px" height="64px" version="1.1" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata>
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <path d="m3 3h49v45h-49z" fill="#008000" stroke="#000" stroke-linecap="round" stroke-linejoin="round"/>
+ <path d="m3.0192 7.5063v-4.1179h48.955v8.2358h-48.955z" style="paint-order:stroke fill markers"/>
+ <g fill="#fff">
+  <ellipse cx="8.1161" cy="6.9829" rx="2" ry="1.8" style="paint-order:stroke fill markers"/>
+  <ellipse cx="41.748" cy="6.8636" rx="2" ry="1.8" style="paint-order:stroke fill markers"/>
+  <ellipse cx="47.537" cy="6.9034" rx="2" ry="1.8" style="paint-order:stroke fill markers"/>
+ </g>
+ <path d="m29.988 32.241h30v27.551h-30z" fill="#008000" stroke="#000" stroke-linecap="round" stroke-linejoin="round"/>
+ <path d="m30 35v-2.5212h29.972v5.0423h-29.972z" style="paint-order:stroke fill markers"/>
+ <g fill="#fff">
+  <ellipse cx="33.121" cy="34.68" rx="1.2245" ry="1.102" style="paint-order:stroke fill markers"/>
+  <ellipse cx="53.711" cy="34.607" rx="1.2245" ry="1.102" style="paint-order:stroke fill markers"/>
+  <ellipse cx="57.256" cy="34.631" rx="1.2245" ry="1.102" style="paint-order:stroke fill markers"/>
+ </g>
+</svg>

--- a/muse3/svg/noscale3.svg
+++ b/muse3/svg/noscale3.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg id="SVGRoot" width="64px" height="64px" version="1.1" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata>
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <path d="m3 3h49v45h-49z" fill="#a02c2c" stroke="#000" stroke-linecap="round" stroke-linejoin="round"/>
+ <path d="m3.0192 7.5063v-4.1179h48.955v8.2358h-48.955z" style="paint-order:stroke fill markers"/>
+ <g fill="#fff">
+  <ellipse cx="8.1161" cy="6.9829" rx="2" ry="1.8" style="paint-order:stroke fill markers"/>
+  <ellipse cx="41.748" cy="6.8636" rx="2" ry="1.8" style="paint-order:stroke fill markers"/>
+  <ellipse cx="47.537" cy="6.9034" rx="2" ry="1.8" style="paint-order:stroke fill markers"/>
+ </g>
+ <path d="m29.988 32.241h30v27.551h-30z" fill="#a02c2c" stroke="#000" stroke-linecap="round" stroke-linejoin="round"/>
+ <path d="m30 35v-2.5212h29.972v5.0423h-29.972z" style="paint-order:stroke fill markers"/>
+ <g fill="#fff">
+  <ellipse cx="33.121" cy="34.68" rx="1.2245" ry="1.102" style="paint-order:stroke fill markers"/>
+  <ellipse cx="53.711" cy="34.607" rx="1.2245" ry="1.102" style="paint-order:stroke fill markers"/>
+  <ellipse cx="57.256" cy="34.631" rx="1.2245" ry="1.102" style="paint-order:stroke fill markers"/>
+ </g>
+</svg>


### PR DESCRIPTION
New global setting created for reverting the HiDPI scaling of incompatible plugins.
Can be overridden per soft synth track in the quirks.