### PR TITLE
Text fixes

### DIFF
--- a/muse3/muse/app.cpp
+++ b/muse3/muse/app.cpp
@@ -2960,7 +2960,7 @@ bool MusE::checkRegionNotNull()
       if (end - start <= 0) {
             QMessageBox::critical(this,
                tr("MusE: Bounce"),
-               tr("set left/right marker for bounce range")
+               tr("Set left/right marker for bounce range")
                );
             return true;
             }

--- a/muse3/muse/arranger/pcanvas.cpp
+++ b/muse3/muse/arranger/pcanvas.cpp
@@ -759,7 +759,7 @@ QMenu* PartCanvas::genItemPopup(CItem* item)
 
       partPopup->addSeparator();
       int rc = npart->part()->nClones();
-      QString st = QString(tr("s&elect "));
+      QString st = QString(tr("S&elect "));
       if(rc > 1)
         st += (QString().setNum(rc) + QString(" "));
       st += QString(tr("clones"));
@@ -767,10 +767,10 @@ QMenu* PartCanvas::genItemPopup(CItem* item)
       act_select->setData(OP_SELECT_CLONES);
 
       partPopup->addSeparator();
-      QAction *act_rename = partPopup->addAction(tr("rename"));
+      QAction *act_rename = partPopup->addAction(tr("Rename"));
       act_rename->setData(OP_RENAME);
 
-      QMenu* colorPopup = partPopup->addMenu(tr("color"));
+      QMenu* colorPopup = partPopup->addMenu(tr("Color"));
 
       // part color selection
       for (int i = 0; i < NUM_PARTCOLORS; ++i) {
@@ -778,15 +778,15 @@ QMenu* PartCanvas::genItemPopup(CItem* item)
             act_color->setData(OP_PARTCOLORBASE+i);
             }
 
-      QAction *act_delete = partPopup->addAction(*deleteIconSVG, tr("delete"));
+      QAction *act_delete = partPopup->addAction(*deleteIconSVG, tr("Delete"));
       act_delete->setData(OP_DELETE);
-      QAction *act_split = partPopup->addAction(*cutterIconSVG, tr("split"));
+      QAction *act_split = partPopup->addAction(*cutterIconSVG, tr("Split"));
       act_split->setData(OP_SPLIT);
-      QAction *act_glue = partPopup->addAction(*glueIconSVG, tr("glue"));
+      QAction *act_glue = partPopup->addAction(*glueIconSVG, tr("Glue"));
       act_glue->setData(OP_GLUE);
-      QAction *act_superglue = partPopup->addAction(*glueIconSVG, tr("super glue (merge selection)"));
+      QAction *act_superglue = partPopup->addAction(*glueIconSVG, tr("Super glue (merge selection)"));
       act_superglue->setData(OP_GLUESELECTION);
-      QAction *act_declone = partPopup->addAction(tr("de-clone"));
+      QAction *act_declone = partPopup->addAction(tr("De-clone"));
       act_declone->setData(OP_DECLONE);
 
       partPopup->addSeparator();
@@ -796,7 +796,7 @@ QMenu* PartCanvas::genItemPopup(CItem* item)
                   partPopup->addMenu(MusEGlobal::muse->arranger()->parentWin()->scoreSubmenu);
 //                   partPopup->addAction(MusEGlobal::muse->arranger()->parentWin()->startScoreEditAction);
                   partPopup->addAction(MusEGlobal::muse->arranger()->parentWin()->startListEditAction);
-                  QAction *act_mexport = partPopup->addAction(tr("save part to disk"));
+                  QAction *act_mexport = partPopup->addAction(tr("Save part to disk..."));
                   act_mexport->setData(OP_SAVEPARTTODISK);
                   }
                   break;
@@ -804,16 +804,16 @@ QMenu* PartCanvas::genItemPopup(CItem* item)
             case MusECore::Track::DRUM: {
                   partPopup->addAction(MusEGlobal::muse->arranger()->parentWin()->startDrumEditAction);
                   partPopup->addAction(MusEGlobal::muse->arranger()->parentWin()->startListEditAction);
-                  QAction *act_dexport = partPopup->addAction(tr("save part to disk"));
+                  QAction *act_dexport = partPopup->addAction(tr("Save part to disk..."));
                   act_dexport->setData(OP_SAVEPARTTODISK);
                   }
                   break;
             case MusECore::Track::WAVE: {
-                  QAction *act_wedit = partPopup->addAction(QIcon(*edit_waveIcon), tr("wave edit"));
+                  QAction *act_wedit = partPopup->addAction(QIcon(*edit_waveIcon), tr("Wave edit"));
                   act_wedit->setData(OP_WAVEEDIT);
-                  QAction *act_wexport = partPopup->addAction(tr("save part to disk"));
+                  QAction *act_wexport = partPopup->addAction(tr("Save part to disk"));
                   act_wexport->setData(OP_SAVEPARTTODISK);
-                  QAction *act_wfinfo = partPopup->addAction(tr("file info"));
+                  QAction *act_wfinfo = partPopup->addAction(tr("File info"));
                   act_wfinfo->setData(OP_FILEINFO);
                   QAction *act_wfnorm = partPopup->addAction(tr("Normalize"));
                   act_wfnorm->setData(OP_NORMALIZE);

--- a/muse3/muse/arranger/tlist.cpp
+++ b/muse3/muse/arranger/tlist.cpp
@@ -614,7 +614,7 @@ void TList::returnPressed()
                             editor->blockSignals(false); 
                             QMessageBox::critical(this,
                               tr("MusE: bad trackname"),
-                              tr("please choose a unique track name"),
+                              tr("Please choose a unique track name"),
                               QMessageBox::Ok,
                               Qt::NoButton,
                               Qt::NoButton);
@@ -1066,12 +1066,12 @@ void TList::oportPropertyPopupMenu(MusECore::Track* t, int x, int y)
         if(!synth->synth())
           p->addAction(tr("SYNTH IS UNAVAILABLE!"));
 
-        QAction* gact = p->addAction(tr("show gui"));
+        QAction* gact = p->addAction(tr("Show gui"));
         gact->setCheckable(true);
         gact->setEnabled(synth->hasGui());
         gact->setChecked(synth->guiVisible());
   
-        QAction* nact = p->addAction(tr("show native gui"));
+        QAction* nact = p->addAction(tr("Show native gui"));
         nact->setCheckable(true);
         nact->setEnabled(synth->hasNativeGui());
         nact->setChecked(synth->nativeGuiVisible());
@@ -1131,12 +1131,12 @@ void TList::oportPropertyPopupMenu(MusECore::Track* t, int x, int y)
           p->addAction(tr("SYNTH IS UNAVAILABLE!"));
       }
 
-      QAction* gact = p->addAction(tr("show gui"));
+      QAction* gact = p->addAction(tr("Show gui"));
       gact->setCheckable(true);
       gact->setEnabled(port->hasGui());
       gact->setChecked(port->guiVisible());
 
-      QAction* nact = p->addAction(tr("show native gui"));
+      QAction* nact = p->addAction(tr("Show native gui"));
       nact->setCheckable(true);
       nact->setEnabled(port->hasNativeGui());
       nact->setChecked(port->nativeGuiVisible());
@@ -1555,7 +1555,7 @@ PopupMenu* TList::colorMenu(QColor c, int id, QWidget* parent)
     }
   }
   m->addAction(new MenuTitleItem(tr("Other"), m));
-  QAction *act = m->addAction(tr("clear automation"));
+  QAction *act = m->addAction(tr("Clear automation"));
   act->setCheckable(false);
   act->setData((id<<8) + 253); // Shift 8 bits. Make clear menu item 253 (should enum this)
   

--- a/muse3/muse/components/filedialog.cpp
+++ b/muse3/muse/components/filedialog.cpp
@@ -94,7 +94,7 @@ static bool testDirCreate(QWidget* parent, const QString& path)
           {
             QMessageBox::critical(parent,
                 QWidget::tr("MusE: create directory"),
-                QWidget::tr("creating dir failed"));
+                QWidget::tr("Creating dir failed"));
             return true;
           }
       }

--- a/muse3/muse/components/plugindialog.cpp
+++ b/muse3/muse/components/plugindialog.cpp
@@ -101,9 +101,9 @@ PluginDialog::PluginDialog(QWidget* parent)
 
       ui.tabBar->setCurrentIndex(selectedGroup);
       ui.tabBar->setContextMenuPolicy(Qt::ActionsContextMenu);
-      newGroupAction= new QAction(tr("&create new group"),ui.tabBar);
-      delGroupAction= new QAction(tr("&delete currently selected group"),ui.tabBar);
-      renGroupAction= new QAction(tr("re&name currently selected group"),ui.tabBar);
+      newGroupAction= new QAction(tr("&Create new group"),ui.tabBar);
+      delGroupAction= new QAction(tr("&Delete currently selected group"),ui.tabBar);
+      renGroupAction= new QAction(tr("Re&name currently selected group"),ui.tabBar);
       ui.tabBar->addAction(newGroupAction);
       ui.tabBar->addAction(delGroupAction);
       ui.tabBar->addAction(renGroupAction);
@@ -243,8 +243,8 @@ void PluginDialog::enableOkB()
 void PluginDialog::newGroup()
 {
   MusEGlobal::plugin_groups.shift_right(selectedGroup+1, ui.tabBar->count());
-  ui.tabBar->insertTab(selectedGroup+1, tr("new group"));
-  MusEGlobal::plugin_group_names.insert(selectedGroup, tr("new group"));
+  ui.tabBar->insertTab(selectedGroup+1, tr("New group"));
+  MusEGlobal::plugin_group_names.insert(selectedGroup, tr("New group"));
 }
 
 void PluginDialog::delGroup()

--- a/muse3/muse/confmport.cpp
+++ b/muse3/muse/confmport.cpp
@@ -431,7 +431,7 @@ void MPConfig::DeviceItemRenamed(QTableWidgetItem* item)
       {
         QMessageBox::critical(this,
             tr("MusE: bad device name"),
-            tr("please choose a unique device name"),
+            tr("Please choose a unique device name"),
             QMessageBox::Ok,
             Qt::NoButton,
             Qt::NoButton);

--- a/muse3/muse/ctrl/ctrlpanel.cpp
+++ b/muse3/muse/ctrl/ctrlpanel.cpp
@@ -259,7 +259,7 @@ void CtrlPanel::buildPanel()
   _veloPerNoteButton = new PixmapButton(veloPerNote_OnIcon, veloPerNote_OffIcon, 2, this);  // Margin = 2
   _veloPerNoteButton->setFocusPolicy(Qt::NoFocus);
   _veloPerNoteButton->setCheckable(true);
-  _veloPerNoteButton->setToolTip(tr("all/per-note velocity mode"));
+  _veloPerNoteButton->setToolTip(tr("All/Per-note velocity mode"));
   _veloPerNoteButton->setEnabled(false);
   _veloPerNoteButton->hide();
   connect(_veloPerNoteButton, SIGNAL(clicked()), SLOT(velPerNoteClicked()));

--- a/muse3/muse/help.cpp
+++ b/muse3/muse/help.cpp
@@ -77,7 +77,7 @@ void MusE::startHelpBrowser()
         if (access(museHelp.toLatin1(), R_OK) != 0) {
               museHelp = DOCDIR + QString("/muse_html/single/documentation/index.html");
               if (access(museHelp.toLatin1(), R_OK) != 0) {
-                    QString info(tr("no help found at: "));
+                    QString info(tr("No help found at: "));
                     info += museHelp;
                     QMessageBox::critical(this, tr("MusE: Open Help"), info);
                     return;

--- a/muse3/muse/importmidi.cpp
+++ b/muse3/muse/importmidi.cpp
@@ -112,7 +112,7 @@ bool MusE::importMidi(const QString name, bool merge)
       bool rv = mf.read();
       popenFlag ? pclose(fp) : fclose(fp);
       if (rv) {
-            QString s(tr("reading midifile\n  "));
+            QString s(tr("Reading midifile\n  "));
             s += name;
             s += tr("\nfailed: ");
             s += mf.error();

--- a/muse3/muse/instruments/editinstrument.cpp
+++ b/muse3/muse/instruments/editinstrument.cpp
@@ -387,20 +387,20 @@ EditInstrument::~EditInstrument()
 
 void EditInstrument::setHeaderWhatsThis()
       {
-      dlist_header->setWhatsThis(COL_HIDE, tr("hide instrument"));
-      dlist_header->setWhatsThis(COL_MUTE, tr("mute instrument"));
-      dlist_header->setWhatsThis(COL_NAME, tr("sound name"));
-      dlist_header->setWhatsThis(COL_VOLUME, tr("volume percent"));
-      dlist_header->setWhatsThis(COL_QUANT, tr("quantisation"));
-      dlist_header->setWhatsThis(COL_INPUTTRIGGER, tr("this input note triggers the sound"));
-      dlist_header->setWhatsThis(COL_NOTELENGTH, tr("note length"));
-      dlist_header->setWhatsThis(COL_NOTE, tr("this is the note which is played"));
-      dlist_header->setWhatsThis(COL_OUTCHANNEL, tr("override track output channel (hold ctl to affect all rows)"));
-      dlist_header->setWhatsThis(COL_OUTPORT, tr("override track output port (hold ctl to affect all rows)"));
-      dlist_header->setWhatsThis(COL_LEVEL1, tr("control + meta keys: draw velocity level 1"));
-      dlist_header->setWhatsThis(COL_LEVEL2, tr("meta key: draw velocity level 2"));
-      dlist_header->setWhatsThis(COL_LEVEL3, tr("draw default velocity level 3"));
-      dlist_header->setWhatsThis(COL_LEVEL4, tr("meta + alt keys: draw velocity level 4"));
+      dlist_header->setWhatsThis(COL_HIDE, tr("Hide instrument"));
+      dlist_header->setWhatsThis(COL_MUTE, tr("Mute instrument"));
+      dlist_header->setWhatsThis(COL_NAME, tr("Sound name"));
+      dlist_header->setWhatsThis(COL_VOLUME, tr("Volume percent"));
+      dlist_header->setWhatsThis(COL_QUANT, tr("Quantisation"));
+      dlist_header->setWhatsThis(COL_INPUTTRIGGER, tr("This input note triggers the sound"));
+      dlist_header->setWhatsThis(COL_NOTELENGTH, tr("Note length"));
+      dlist_header->setWhatsThis(COL_NOTE, tr("This is the note which is played"));
+      dlist_header->setWhatsThis(COL_OUTCHANNEL, tr("Override track output channel (hold ctl to affect all rows)"));
+      dlist_header->setWhatsThis(COL_OUTPORT, tr("Override track output port (hold ctl to affect all rows)"));
+      dlist_header->setWhatsThis(COL_LEVEL1, tr("Control + meta keys: Draw velocity level 1"));
+      dlist_header->setWhatsThis(COL_LEVEL2, tr("Meta key: Draw velocity level 2"));
+      dlist_header->setWhatsThis(COL_LEVEL3, tr("Draw default velocity level 3"));
+      dlist_header->setWhatsThis(COL_LEVEL4, tr("Meta + alt keys: Draw velocity level 4"));
       }
 
 //---------------------------------------------------------
@@ -409,20 +409,20 @@ void EditInstrument::setHeaderWhatsThis()
 
 void EditInstrument::setHeaderToolTips()
       {
-      dlist_header->setToolTip(COL_HIDE, tr("hide instrument"));
-      dlist_header->setToolTip(COL_MUTE, tr("mute instrument"));
-      dlist_header->setToolTip(COL_NAME, tr("sound name"));
-      dlist_header->setToolTip(COL_VOLUME, tr("volume percent"));
-      dlist_header->setToolTip(COL_QUANT, tr("quantisation"));
-      dlist_header->setToolTip(COL_INPUTTRIGGER, tr("this input note triggers the sound"));
-      dlist_header->setToolTip(COL_NOTELENGTH, tr("note length"));
-      dlist_header->setToolTip(COL_NOTE, tr("this is the note which is played"));
-      dlist_header->setToolTip(COL_OUTCHANNEL, tr("override track output channel (ctl: affect all rows)"));
-      dlist_header->setToolTip(COL_OUTPORT, tr("override track output port (ctl: affect all rows)"));
-      dlist_header->setToolTip(COL_LEVEL1, tr("control + meta keys: draw velocity level 1"));
-      dlist_header->setToolTip(COL_LEVEL2, tr("meta key: draw velocity level 2"));
-      dlist_header->setToolTip(COL_LEVEL3, tr("draw default velocity level 3"));
-      dlist_header->setToolTip(COL_LEVEL4, tr("meta + alt keys: draw velocity level 4"));
+      dlist_header->setToolTip(COL_HIDE, tr("Hide instrument"));
+      dlist_header->setToolTip(COL_MUTE, tr("Mute instrument"));
+      dlist_header->setToolTip(COL_NAME, tr("Sound name"));
+      dlist_header->setToolTip(COL_VOLUME, tr("Volume percent"));
+      dlist_header->setToolTip(COL_QUANT, tr("Quantisation"));
+      dlist_header->setToolTip(COL_INPUTTRIGGER, tr("This input note triggers the sound"));
+      dlist_header->setToolTip(COL_NOTELENGTH, tr("Note length"));
+      dlist_header->setToolTip(COL_NOTE, tr("This is the note which is played"));
+      dlist_header->setToolTip(COL_OUTCHANNEL, tr("Override track output channel (ctl: affect all rows)"));
+      dlist_header->setToolTip(COL_OUTPORT, tr("Override track output port (ctl: affect all rows)"));
+      dlist_header->setToolTip(COL_LEVEL1, tr("Control + meta keys: Draw velocity level 1"));
+      dlist_header->setToolTip(COL_LEVEL2, tr("Meta key: Draw velocity level 2"));
+      dlist_header->setToolTip(COL_LEVEL3, tr("Draw default velocity level 3"));
+      dlist_header->setToolTip(COL_LEVEL4, tr("Meta + alt keys: Draw velocity level 4"));
       }
 
 void EditInstrument::findInstrument(const QString& find_instrument)

--- a/muse3/muse/instruments/minstrument.cpp
+++ b/muse3/muse/instruments/minstrument.cpp
@@ -263,7 +263,7 @@ loadIDF_end:
 
 void initMidiInstruments()
       {
-      genericMidiInstrument = new MidiInstrument(QWidget::tr("generic midi"));
+      genericMidiInstrument = new MidiInstrument(QWidget::tr("Generic midi"));
       midiInstruments.push_back(genericMidiInstrument);
 
       // Initialize with a default drum map on default channel. Patch is default 0xffffff. GM-1 does not specify a drum patch number.

--- a/muse3/muse/liste/listedit.cpp
+++ b/muse3/muse/liste/listedit.cpp
@@ -470,10 +470,10 @@ ListEdit::ListEdit(MusECore::PartList* pl, QWidget* parent, const char* name)
       
       insertItems = new QActionGroup(this);
       insertItems->setExclusive(false);
-      insertNote = new QAction(QIcon(*note1Icon), tr("insert Note"), insertItems);
-      insertSysEx = new QAction(QIcon(*sysexIcon), tr("insert SysEx"), insertItems);
-      insertCtrl = new QAction(QIcon(*ctrlIcon), tr("insert Ctrl"), insertItems);
-      insertMeta = new QAction(QIcon(*metaIcon), tr("insert Meta"), insertItems);
+      insertNote = new QAction(QIcon(*note1Icon), tr("Insert Note"), insertItems);
+      insertSysEx = new QAction(QIcon(*sysexIcon), tr("Insert SysEx"), insertItems);
+      insertCtrl = new QAction(QIcon(*ctrlIcon), tr("Insert Ctrl"), insertItems);
+      insertMeta = new QAction(QIcon(*metaIcon), tr("Insert Meta"), insertItems);
 
       connect(insertNote,    SIGNAL(triggered()), SLOT(editInsertNote()));
       connect(insertSysEx,   SIGNAL(triggered()), SLOT(editInsertSysEx()));

--- a/muse3/muse/marker/markerview.cpp
+++ b/muse3/muse/marker/markerview.cpp
@@ -177,10 +177,10 @@ MarkerView::MarkerView(QWidget* parent)
       {
       setWindowTitle(tr("MusE: Marker"));
 
-      QAction* markerAdd = new QAction(QIcon(*flagIcon), tr("add marker"), this);
+      QAction* markerAdd = new QAction(QIcon(*flagIcon), tr("Add marker"), this);
       connect(markerAdd, SIGNAL(triggered()), SLOT(addMarker()));
 
-      QAction* markerDelete = new QAction(QIcon(*deleteIcon), tr("delete marker"), this);
+      QAction* markerDelete = new QAction(QIcon(*deleteIcon), tr("Delete marker"), this);
       connect(markerDelete, SIGNAL(triggered()), SLOT(deleteMarker()));
 
       //---------Pulldown Menu----------------------------
@@ -205,7 +205,7 @@ MarkerView::MarkerView(QWidget* parent)
       //          toolbar with the same object name, it /replaces/ it using insertToolBar(),
       //          instead of /appending/ with addToolBar().
 
-      QToolBar* edit = addToolBar(tr("edit tools"));
+      QToolBar* edit = addToolBar(tr("Edit tools"));
       edit->setObjectName("marker edit tools");
       edit->addAction(markerAdd);
       edit->addAction(markerDelete);

--- a/muse3/muse/midiedit/drumedit.cpp
+++ b/muse3/muse/midiedit/drumedit.cpp
@@ -93,20 +93,20 @@ static const int drumeditTools = MusEGui::PointerTool | MusEGui::PencilTool | Mu
 
 void DrumEdit::setHeaderWhatsThis()
       {
-      header->setWhatsThis(COL_HIDE, tr("hide instrument"));
-      header->setWhatsThis(COL_MUTE, tr("mute instrument"));
-      header->setWhatsThis(COL_NAME, tr("sound name"));
-      header->setWhatsThis(COL_VOLUME, tr("volume percent"));
-      header->setWhatsThis(COL_QUANT, tr("quantisation"));
-      header->setWhatsThis(COL_INPUTTRIGGER, tr("this input note triggers the sound"));
-      header->setWhatsThis(COL_NOTELENGTH, tr("note length"));
-      header->setWhatsThis(COL_NOTE, tr("this is the note which is played"));
-      header->setWhatsThis(COL_OUTCHANNEL, tr("override track output channel (hold ctl to affect all rows)"));
-      header->setWhatsThis(COL_OUTPORT, tr("override track output port (hold ctl to affect all rows)"));
-      header->setWhatsThis(COL_LEVEL1, tr("control + meta keys: draw velocity level 1"));
-      header->setWhatsThis(COL_LEVEL2, tr("meta key: draw velocity level 2"));
-      header->setWhatsThis(COL_LEVEL3, tr("draw default velocity level 3"));
-      header->setWhatsThis(COL_LEVEL4, tr("meta + alt keys: draw velocity level 4"));
+      header->setWhatsThis(COL_HIDE, tr("Hide instrument"));
+      header->setWhatsThis(COL_MUTE, tr("Mute instrument"));
+      header->setWhatsThis(COL_NAME, tr("Sound name"));
+      header->setWhatsThis(COL_VOLUME, tr("Volume percent"));
+      header->setWhatsThis(COL_QUANT, tr("Quantisation"));
+      header->setWhatsThis(COL_INPUTTRIGGER, tr("This input note triggers the sound"));
+      header->setWhatsThis(COL_NOTELENGTH, tr("Note length"));
+      header->setWhatsThis(COL_NOTE, tr("This is the note which is played"));
+      header->setWhatsThis(COL_OUTCHANNEL, tr("Override track output channel (hold ctl to affect all rows)"));
+      header->setWhatsThis(COL_OUTPORT, tr("Override track output port (hold ctl to affect all rows)"));
+      header->setWhatsThis(COL_LEVEL1, tr("Control + meta keys: Draw velocity level 1"));
+      header->setWhatsThis(COL_LEVEL2, tr("Meta key: Draw velocity level 2"));
+      header->setWhatsThis(COL_LEVEL3, tr("Draw default velocity level 3"));
+      header->setWhatsThis(COL_LEVEL4, tr("Meta + alt keys: Draw velocity level 4"));
       }
 
 //---------------------------------------------------------
@@ -115,20 +115,20 @@ void DrumEdit::setHeaderWhatsThis()
 
 void DrumEdit::setHeaderToolTips()
       {
-      header->setToolTip(COL_HIDE, tr("hide instrument"));
-      header->setToolTip(COL_MUTE, tr("mute instrument"));
-      header->setToolTip(COL_NAME, tr("sound name"));
-      header->setToolTip(COL_VOLUME, tr("volume percent"));
-      header->setToolTip(COL_QUANT, tr("quantisation"));
-      header->setToolTip(COL_INPUTTRIGGER, tr("this input note triggers the sound"));
-      header->setToolTip(COL_NOTELENGTH, tr("note length"));
-      header->setToolTip(COL_NOTE, tr("this is the note which is played"));
-      header->setToolTip(COL_OUTCHANNEL, tr("override track output channel (ctl: affect all rows)"));
-      header->setToolTip(COL_OUTPORT, tr("override track output port (ctl: affect all rows)"));
-      header->setToolTip(COL_LEVEL1, tr("control + meta keys: draw velocity level 1"));
-      header->setToolTip(COL_LEVEL2, tr("meta key: draw velocity level 2"));
-      header->setToolTip(COL_LEVEL3, tr("draw default velocity level 3"));
-      header->setToolTip(COL_LEVEL4, tr("meta + alt keys: draw velocity level 4"));
+      header->setToolTip(COL_HIDE, tr("Hide instrument"));
+      header->setToolTip(COL_MUTE, tr("Mute instrument"));
+      header->setToolTip(COL_NAME, tr("Sound name"));
+      header->setToolTip(COL_VOLUME, tr("Volume percent"));
+      header->setToolTip(COL_QUANT, tr("Quantisation"));
+      header->setToolTip(COL_INPUTTRIGGER, tr("This input note triggers the sound"));
+      header->setToolTip(COL_NOTELENGTH, tr("Note length"));
+      header->setToolTip(COL_NOTE, tr("This is the note which is played"));
+      header->setToolTip(COL_OUTCHANNEL, tr("Override track output channel (ctl: affect all rows)"));
+      header->setToolTip(COL_OUTPORT, tr("Override track output port (ctl: affect all rows)"));
+      header->setToolTip(COL_LEVEL1, tr("Control + meta keys: Draw velocity level 1"));
+      header->setToolTip(COL_LEVEL2, tr("Meta key: Draw velocity level 2"));
+      header->setToolTip(COL_LEVEL3, tr("Draw default velocity level 3"));
+      header->setToolTip(COL_LEVEL4, tr("Meta + alt keys: Draw velocity level 4"));
       }
 
 //---------------------------------------------------------
@@ -475,7 +475,7 @@ DrumEdit::DrumEdit(MusECore::PartList* pl, QWidget* parent, const char* name, un
       info->setObjectName("Drum note info");
       addToolBar(info);
 
-      QToolBar* cursorToolbar = addToolBar(tr("cursor tools"));
+      QToolBar* cursorToolbar = addToolBar(tr("Cursor tools"));
       cursorToolbar->setObjectName("Cursor step tools");
       QLabel *stepStr = new QLabel(tr("Cursor step:"));
       cursorToolbar->addWidget(stepStr);

--- a/muse3/muse/miditransform.cpp
+++ b/muse3/muse/miditransform.cpp
@@ -234,7 +234,7 @@ void MidiTransformation::write(int level, Xml& xml)
 
 void readMidiTransform(Xml& xml)
       {
-      MidiTransformation trans(QWidget::tr("new"));
+      MidiTransformation trans(QWidget::tr("New"));
 
       for (;;) {
             Xml::Token token = xml.parse();

--- a/muse3/muse/mixer/rack.cpp
+++ b/muse3/muse/mixer/rack.cpp
@@ -214,7 +214,7 @@ void EffectRack::updateContents()
       for (int i = 0; i < MusECore::PipelineDepth; ++i) {
             QString name = track->efxPipe()->name(i);
             item(i)->setText(name);
-            item(i)->setToolTip(name == QString("empty") ? tr("effect rack") : name );
+            item(i)->setToolTip(name == QString(tr("Empty")) ? tr("Effect rack") : name );
             //item(i)->setBackground(track->efxPipe()->isOn(i) ? activeColor : palette().dark());
             if(viewport())
             {
@@ -307,15 +307,15 @@ void EffectRack::menuRequested(QListWidgetItem* it)
       //enum { NEW, CHANGE, UP, DOWN, REMOVE, BYPASS, SHOW, SAVE };
       enum { NEW, CHANGE, UP, DOWN, REMOVE, BYPASS, SHOW, SHOW_NATIVE, SAVE };
       QMenu* menu = new QMenu;
-      QAction* newAction = menu->addAction(tr("new"));
-      QAction* changeAction = menu->addAction(tr("change"));
-      QAction* upAction = menu->addAction(QIcon(*upIcon), tr("move up"));//,   UP, UP);
-      QAction* downAction = menu->addAction(QIcon(*downIcon), tr("move down"));//, DOWN, DOWN);
-      QAction* removeAction = menu->addAction(tr("remove"));//,    REMOVE, REMOVE);
-      QAction* bypassAction = menu->addAction(tr("bypass"));//,    BYPASS, BYPASS);
-      QAction* showGuiAction = menu->addAction(tr("show gui"));//,  SHOW, SHOW);
-      QAction* showNativeGuiAction = menu->addAction(tr("show native gui"));//,  SHOW_NATIVE, SHOW_NATIVE);
-      QAction* saveAction = menu->addAction(tr("save preset"));
+      QAction* newAction = menu->addAction(tr("New"));
+      QAction* changeAction = menu->addAction(tr("Change"));
+      QAction* upAction = menu->addAction(QIcon(*upIcon), tr("Move up"));//,   UP, UP);
+      QAction* downAction = menu->addAction(QIcon(*downIcon), tr("Move down"));//, DOWN, DOWN);
+      QAction* removeAction = menu->addAction(tr("Remove"));//,    REMOVE, REMOVE);
+      QAction* bypassAction = menu->addAction(tr("Bypass"));//,    BYPASS, BYPASS);
+      QAction* showGuiAction = menu->addAction(tr("Show gui"));//,  SHOW, SHOW);
+      QAction* showNativeGuiAction = menu->addAction(tr("Show native gui"));//,  SHOW_NATIVE, SHOW_NATIVE);
+      QAction* saveAction = menu->addAction(tr("Save preset"));
 
       newAction->setData(NEW);
       changeAction->setData(CHANGE);
@@ -472,7 +472,7 @@ void EffectRack::doubleClicked(QListWidgetItem* it)
       int idx        = row(item);
       MusECore::Pipeline* pipe = track->efxPipe();
 
-      if (pipe->name(idx) == QString("empty")) {
+      if (pipe->name(idx) == QString(tr("Empty"))) {
             choosePlugin(it);
             return;
             }

--- a/muse3/muse/mixer/rack.cpp
+++ b/muse3/muse/mixer/rack.cpp
@@ -472,7 +472,7 @@ void EffectRack::doubleClicked(QListWidgetItem* it)
       int idx        = row(item);
       MusECore::Pipeline* pipe = track->efxPipe();
 
-      if (pipe->name(idx) == QString(tr("Empty"))) {
+      if (pipe->name(idx) == QString("Empty")) {
             choosePlugin(it);
             return;
             }

--- a/muse3/muse/mixer/strip.cpp
+++ b/muse3/muse/mixer/strip.cpp
@@ -911,7 +911,7 @@ void Strip::changeTrackName()
     {
       QMessageBox::critical(this,
         tr("MusE: bad trackname"),
-        tr("please choose a unique track name"),
+        tr("Please choose a unique track name"),
         QMessageBox::Ok,
         Qt::NoButton,
         Qt::NoButton);

--- a/muse3/muse/plugin.cpp
+++ b/muse3/muse/plugin.cpp
@@ -1460,7 +1460,7 @@ QString Pipeline::name(int idx) const
       PluginI* p = (*this)[idx];
       if (p)
             return p->name();
-      return QString("empty");
+      return QString("Empty");
       }
 
 //---------------------------------------------------------

--- a/muse3/muse/song.cpp
+++ b/muse3/muse/song.cpp
@@ -2465,11 +2465,11 @@ int Song::execAutomationCtlPopup(AudioTrack* track, const QPoint& menupos, int a
 
   menu->addAction(new MusEGui::MenuTitleItem(tr("Automation:"), menu));
   
-  QAction* prevEvent = menu->addAction(tr("previous event"));
+  QAction* prevEvent = menu->addAction(tr("Previous event"));
   prevEvent->setData(PREV_EVENT);
   prevEvent->setEnabled(canSeekPrev);
 
-  QAction* nextEvent = menu->addAction(tr("next event"));
+  QAction* nextEvent = menu->addAction(tr("Next event"));
   nextEvent->setData(NEXT_EVENT);
   nextEvent->setEnabled(canSeekNext);
 
@@ -2478,21 +2478,21 @@ int Song::execAutomationCtlPopup(AudioTrack* track, const QPoint& menupos, int a
   QAction* addEvent = new QAction(menu);
   menu->addAction(addEvent);
   if(isEvent)
-    addEvent->setText(tr("set event"));
+    addEvent->setText(tr("Set event"));
   else  
-    addEvent->setText(tr("add event"));
+    addEvent->setText(tr("Add event"));
   addEvent->setData(ADD_EVENT);
   addEvent->setEnabled(canAdd);
 
-  QAction* eraseEventAction = menu->addAction(tr("erase event"));
+  QAction* eraseEventAction = menu->addAction(tr("Erase event"));
   eraseEventAction->setData(CLEAR_EVENT);
   eraseEventAction->setEnabled(isEvent);
 
-  QAction* eraseRangeAction = menu->addAction(tr("erase range"));
+  QAction* eraseRangeAction = menu->addAction(tr("Erase range"));
   eraseRangeAction->setData(CLEAR_RANGE);
   eraseRangeAction->setEnabled(canEraseRange);
 
-  QAction* clearAction = menu->addAction(tr("clear automation"));
+  QAction* clearAction = menu->addAction(tr("Clear automation"));
   clearAction->setData(CLEAR_ALL_EVENTS);
   clearAction->setEnabled((bool)count);
 
@@ -2733,7 +2733,7 @@ int Song::execMidiAutomationCtlPopup(MidiTrack* track, MidiPart* part, const QPo
   menu->addAction(new MusEGui::MenuTitleItem(tr("Controller:"), menu));
   QAction* bypassEvent = new QAction(menu);
   menu->addAction(bypassEvent);
-  bypassEvent->setText(tr("bypass"));
+  bypassEvent->setText(tr("Bypass"));
   bypassEvent->setData(BYPASS_CONTROLLER);
   bypassEvent->setEnabled(true);
   bypassEvent->setCheckable(true);
@@ -2744,13 +2744,13 @@ int Song::execMidiAutomationCtlPopup(MidiTrack* track, MidiPart* part, const QPo
   QAction* addEvent = new QAction(menu);
   menu->addAction(addEvent);
   if(isEvent)
-    addEvent->setText(tr("set event"));
+    addEvent->setText(tr("Set event"));
   else
-    addEvent->setText(tr("add event"));
+    addEvent->setText(tr("Add event"));
   addEvent->setData(ADD_EVENT);
   addEvent->setEnabled(true);
 
-  QAction* eraseEventAction = menu->addAction(tr("erase event"));
+  QAction* eraseEventAction = menu->addAction(tr("Erase event"));
   eraseEventAction->setData(CLEAR_EVENT);
   eraseEventAction->setEnabled(isEvent);
 

--- a/muse3/muse/wave.cpp
+++ b/muse3/muse/wave.cpp
@@ -162,7 +162,7 @@ void SndFile::createCache(const QString& path, bool showProgress, bool bWrite, s
       return;
    QProgressDialog* progress = 0;
    if (showProgress) {
-      QString label(QWidget::tr("create peakfile for "));
+      QString label(QWidget::tr("Create peakfile for "));
       label += basename();
       progress = new QProgressDialog(label,
                                      QString(), 0, csize, 0);
@@ -1379,8 +1379,7 @@ void MusE::importWave()
       if(track == 0)
       {
          QMessageBox::critical(this, QString("MusE"),
-                 tr("to import an audio file you have first to select"
-                 "a wave track"));
+                 tr("To import an audio file you have first to select a wave track"));
                return;
 
       }


### PR DESCRIPTION
Refer to #711.
Got a little more than intended, I used regex to search for them... But this should be it now.

There is a problem with the "Empty" text in the rack. It is not marked with tr() so it's not translatable, which is not good, as it's quite visible.
However, it can't be translated as it is now, because it would break the functionality - the text is used for direct string comparison:

`if (pipe->name(idx) == QString("Empty")) `
(rack.cpp, line 475)

It's being compared with:

```
QString Pipeline::name(int idx) const
      {
      PluginI* p = (*this)[idx];
      if (p)
            return p->name();
      return QString("Empty");
      }
```
(plugin.cpp, line 1463)