### PR TITLE
Few more text fixes

### DIFF
--- a/muse3/README.translate
+++ b/muse3/README.translate
@@ -37,7 +37,7 @@ Step 4:
      Save the edited file "muse_fr.ts" from linguist and
      start File->Release. This generates the file "muse_fr.qm".
      Copy this file into your muse installation folder,
-     <prefix>/share/muse-2.0/locale/
+     <prefix>/share/muse-3.1/locale/
 
       or
 

--- a/muse3/awl/midivolentry.cpp
+++ b/muse3/awl/midivolentry.cpp
@@ -35,7 +35,7 @@ MidiVolEntry::MidiVolEntry(QWidget* parent, bool leftMouseButtonCanDecrease)
   	_max = 127;
       setRange(-98.0f, 0.0f);
       setSpecialText(tr("off"));
-      setSuffix(tr("db"));
+      setSuffix("dB");
       setFrame(true);
       setPrecision(0);
       }

--- a/muse3/muse/app.cpp
+++ b/muse3/muse/app.cpp
@@ -495,7 +495,7 @@ MusE::MusE() : QMainWindow()
       //----Actions
       //-------- File Actions
 
-      fileNewAction = new QAction(*MusEGui::filenewSVGIcon, tr("&New"), this);
+      fileNewAction = new QAction(*MusEGui::filenewSVGIcon, tr("&New..."), this);
       fileNewAction->setToolTip(tr("Create new song"));
       fileNewAction->setWhatsThis(tr("Create new song"));
 
@@ -526,11 +526,11 @@ MusE::MusE() : QMainWindow()
       fileImportPartAction = new QAction(tr("Import Part..."), this);
 
       fileImportWaveAction = new QAction(tr("Import Audio File..."), this);
-      fileMoveWaveFiles = new QAction(tr("Find Unused Wave Files"), this);
+      fileMoveWaveFiles = new QAction(tr("Find Unused Wave Files..."), this);
 
       quitAction = new QAction(*MusEGui::appexitSVGIcon, tr("&Quit"), this);
 
-      editSongInfoAction = new QAction(QIcon(*MusEGui::edit_listIcon), tr("Song Info"), this);
+      editSongInfoAction = new QAction(QIcon(*MusEGui::edit_listIcon), tr("Song Info..."), this);
 
       //-------- View Actions
       viewTransportAction = new QAction(QIcon(*MusEGui::view_transport_windowIcon), tr("Transport Panel..."), this);

--- a/muse3/muse/mixer/astrip.cpp
+++ b/muse3/muse/mixer/astrip.cpp
@@ -1557,8 +1557,8 @@ AudioStrip::AudioStrip(QWidget* parent, MusECore::AudioTrack* at, bool hasHandle
       sl->setSlider(slider);
       //sl->setBackgroundRole(QPalette::Mid);
       sl->setToolTip(tr("Volume/gain"));
-      sl->setSuffix(tr("dB"));
-      sl->setSpecialText(QString('-') + QChar(0x221e) + QChar(' ') + tr("dB"));
+      sl->setSuffix("dB");
+      sl->setSpecialText(QString('-') + QChar(0x221e) + QChar(' ') + "dB");
       sl->setOff(MusEGlobal::config.minSlider);
       sl->setPrecision(volSliderPrec);
       sl->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);

--- a/muse3/muse/mixer/mstrip.cpp
+++ b/muse3/muse/mixer/mstrip.cpp
@@ -2009,9 +2009,9 @@ void MidiStrip::setupMidiVolume()
       sl->setRange(MusEGlobal::config.minSlider, volSliderMaxDb);
       sl->setOff(MusEGlobal::config.minSlider);
       //sl->setSpecialText(tr("off"));
-      //sl->setSpecialText(QString('-') + QChar(0x221e) + QChar(' ') + tr("dB"));  // The infinity character.
+      //sl->setSpecialText(QString('-') + QChar(0x221e) + QChar(' ') + "dB");  // The infinity character.
       //sl->setToolTip(tr("Volume/gain"));
-      sl->setSuffix(tr("dB"));
+      sl->setSuffix("dB");
     }
     else
     {


### PR DESCRIPTION
Fixed "db" -> "dB" and removed tr() for it, I think "dB" should not be translatable (as unit of measure).
Updated obsolete reference to MusE 2.0 in README.translate (corresponding Wiki page should be updated too?).
Fixed some more menu texts.

I noticed that File->New also triggers a dialog (template selection), so changed to New... here too.
An idea: Two entries, "New" to load default template (as when freshly started), and "New from Template..." for template selection (like e.g. in Inkscape and others).