### PR TITLE
Tiny font in mixer strip tooltips

### DIFF
--- a/muse3/muse/mixer/astrip.cpp
+++ b/muse3/muse/mixer/astrip.cpp
@@ -1351,8 +1351,9 @@ AudioStrip::AudioStrip(QWidget* parent, MusECore::AudioTrack* at, bool hasHandle
       
       // Set the whole strip's font, except for the label.
       // May be good to keep this. In the midi strip without it the upper rack is too tall at first. So avoid trouble.
-      setFont(MusEGlobal::config.fonts[1]);  
-      setStyleSheet(MusECore::font2StyleSheet(MusEGlobal::config.fonts[1]));
+//      setFont(MusEGlobal::config.fonts[1]); // should be redundant, overridden by style sheet
+      setStyleSheet("QWidget {" + MusECore::font2StyleSheet(MusEGlobal::config.fonts[1]) + "}" +
+                    "QToolTip {font-size:" + QString::number(MusEGlobal::config.fonts[0].pointSize()) + "pt}");
 
       channel       = at->channels();
 


### PR DESCRIPTION
I found out at last how to fix the tiny font problem in mixer tooltips, it did not seem possible...

This code line created an invalid style sheet (acc. to Qt docu and CSS specs), without any selector specified:
`setStyleSheet(MusECore::font2StyleSheet(MusEGlobal::config.fonts[1]));`

Funnily it still worked but it was not possible to change the style for anything else after that.
With the fix the tooltips will have the standard size.
