### PR TITLE
Tooltip size fix

### DIFF
--- a/muse3/muse/components/utils.cpp
+++ b/muse3/muse/components/utils.cpp
@@ -43,6 +43,7 @@
 #include "part.h"
 #include "utils.h"
 #include "xml.h"
+#include "gconfig.h"
 
 namespace MusECore {
 
@@ -973,6 +974,13 @@ bool getUniqueFileName(const QString& origFilepath, QString& newAbsFilePath)
       printf("Could not find a suitable filename (more than 100000 files based on %s - clean up!\n", origFilepath.toLatin1().constData());
       return false;
        }
+
+QString font2StyleSheetFull(const QFont& fnt)
+{
+    QString ss("* {" + MusECore::font2StyleSheet(fnt) + "}");
+    ss += "QToolTip {font-size:" + QString::number(MusEGlobal::config.fonts[0].pointSize()) + "pt}";
+    return ss;
+}
 
 QString font2StyleSheet(const QFont& fnt)
 {

--- a/muse3/muse/components/utils.h
+++ b/muse3/muse/components/utils.h
@@ -67,6 +67,7 @@ extern int get_paste_len();
 extern bool getUniqueFileName(const QString& filename, QString& newAbsFilePath);
 
 extern QString font2StyleSheet(const QFont& fnt);
+extern QString font2StyleSheetFull(const QFont& fnt);
 
 } // namespace MusECore
 

--- a/muse3/muse/ctrl/ctrlpanel.cpp
+++ b/muse3/muse/ctrl/ctrlpanel.cpp
@@ -186,7 +186,7 @@ void CtrlPanel::buildPanel()
   if(_patchEdit->font() != MusEGlobal::config.fonts[1])
   {
     _patchEdit->setFont(MusEGlobal::config.fonts[1]);
-    _patchEdit->setStyleSheet(MusECore::font2StyleSheet(MusEGlobal::config.fonts[1]));
+    _patchEdit->setStyleSheet(MusECore::font2StyleSheetFull(MusEGlobal::config.fonts[1]));
   }
 
   connect(_patchEdit, SIGNAL(valueChanged(int,int)), SLOT(patchCtrlChanged(int)));
@@ -217,7 +217,7 @@ void CtrlPanel::buildPanel()
     if(_knob->font() != MusEGlobal::config.fonts[1])
     {
       _knob->setFont(MusEGlobal::config.fonts[1]);
-      _knob->setStyleSheet(MusECore::font2StyleSheet(MusEGlobal::config.fonts[1]));
+      _knob->setStyleSheet(MusECore::font2StyleSheetFull(MusEGlobal::config.fonts[1]));
     }
 
     connect(_knob, SIGNAL(valueStateChanged(double,bool,int,int)), SLOT(ctrlChanged(double,bool,int,int)));
@@ -247,7 +247,7 @@ void CtrlPanel::buildPanel()
     if(_slider->font() != MusEGlobal::config.fonts[1])
     {
       _slider->setFont(MusEGlobal::config.fonts[1]);
-      _slider->setStyleSheet(MusECore::font2StyleSheet(MusEGlobal::config.fonts[1]));
+      _slider->setStyleSheet(MusECore::font2StyleSheetFull(MusEGlobal::config.fonts[1]));
     }
 
     connect(_slider, SIGNAL(valueStateChanged(double,bool,int,int)), SLOT(ctrlChanged(double,bool,int,int)));
@@ -511,7 +511,7 @@ void CtrlPanel::configChanged()
     if(_patchEdit->font() != MusEGlobal::config.fonts[1])
     {
       _patchEdit->setFont(MusEGlobal::config.fonts[1]);
-      _patchEdit->setStyleSheet(MusECore::font2StyleSheet(MusEGlobal::config.fonts[1]));
+      _patchEdit->setStyleSheet(MusECore::font2StyleSheetFull(MusEGlobal::config.fonts[1]));
     }
     _patchEdit->setMaxAliasedPointSize(MusEGlobal::config.maxAliasedPointSize);
   }
@@ -521,7 +521,7 @@ void CtrlPanel::configChanged()
     if(_knob->font() != MusEGlobal::config.fonts[1])
     {
       _knob->setFont(MusEGlobal::config.fonts[1]);
-      _knob->setStyleSheet(MusECore::font2StyleSheet(MusEGlobal::config.fonts[1]));
+      _knob->setStyleSheet(MusECore::font2StyleSheetFull(MusEGlobal::config.fonts[1]));
     }
 
     // Whether to show values along with labels for certain controls.
@@ -533,7 +533,7 @@ void CtrlPanel::configChanged()
     if(_slider->font() != MusEGlobal::config.fonts[1])
     {
       _slider->setFont(MusEGlobal::config.fonts[1]);
-      _slider->setStyleSheet(MusECore::font2StyleSheet(MusEGlobal::config.fonts[1]));
+      _slider->setStyleSheet(MusECore::font2StyleSheetFull(MusEGlobal::config.fonts[1]));
     }
 
     _slider->setMaxAliasedPointSize(MusEGlobal::config.maxAliasedPointSize);

--- a/muse3/muse/mixer/astrip.cpp
+++ b/muse3/muse/mixer/astrip.cpp
@@ -877,7 +877,7 @@ void AudioStrip::configChanged()
   {
     setFont(MusEGlobal::config.fonts[1]);
     DEBUG_AUDIO_STRIP(stderr, "AudioStrip::configChanged changing font: current size:%d\n", font().pointSize());
-    setStyleSheet(MusECore::font2StyleSheet(MusEGlobal::config.fonts[1]));
+    setStyleSheet(MusECore::font2StyleSheetFull(MusEGlobal::config.fonts[1]));
   }
   
   // Set the strip label's font.
@@ -1351,9 +1351,8 @@ AudioStrip::AudioStrip(QWidget* parent, MusECore::AudioTrack* at, bool hasHandle
       
       // Set the whole strip's font, except for the label.
       // May be good to keep this. In the midi strip without it the upper rack is too tall at first. So avoid trouble.
-//      setFont(MusEGlobal::config.fonts[1]); // should be redundant, overridden by style sheet
-      setStyleSheet("QWidget {" + MusECore::font2StyleSheet(MusEGlobal::config.fonts[1]) + "}" +
-                    "QToolTip {font-size:" + QString::number(MusEGlobal::config.fonts[0].pointSize()) + "pt}");
+      setFont(MusEGlobal::config.fonts[1]);
+      setStyleSheet(MusECore::font2StyleSheetFull(MusEGlobal::config.fonts[1]));
 
       channel       = at->channels();
 

--- a/muse3/muse/mixer/mstrip.cpp
+++ b/muse3/muse/mixer/mstrip.cpp
@@ -1388,7 +1388,7 @@ MidiStrip::MidiStrip(QWidget* parent, MusECore::MidiTrack* t, bool hasHandle, bo
       
       // Set the whole strip's font, except for the label.
       setFont(MusEGlobal::config.fonts[1]); // For some reason must keep this, the upper rack is too tall at first.
-      setStyleSheet(MusECore::font2StyleSheet(MusEGlobal::config.fonts[1]));
+      setStyleSheet(MusECore::font2StyleSheetFull(MusEGlobal::config.fonts[1]));
       
       // Clear so the meters don't start off by showing stale values.
       t->setActivity(0);
@@ -2188,7 +2188,7 @@ void MidiStrip::configChanged()
   {
     //DEBUG_MIDI_STRIP(stderr, "MidiStrip::configChanged changing font: current size:%d\n", font().pointSize());
     setFont(MusEGlobal::config.fonts[1]);
-    setStyleSheet(MusECore::font2StyleSheet(MusEGlobal::config.fonts[1]));
+    setStyleSheet(MusECore::font2StyleSheetFull(MusEGlobal::config.fonts[1]));
     // Update in case font changed.
     updateRackSizes(true, true);
   }

--- a/muse3/muse/mixer/strip.cpp
+++ b/muse3/muse/mixer/strip.cpp
@@ -978,11 +978,12 @@ void Strip::updateStyleSheet()
   c.setAlpha(190);
   c2.setAlpha(190);
 
-  QString stxt = QString("background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:1, y2:1,"
+  QString stxt = QString("* { background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:1, y2:1,"
       "stop:0.263158 rgba(%1, %2, %3, %4), stop:0.7547368 rgba(%5, %6, %7, %8));")
       .arg(c2.red()).arg(c2.green()).arg(c2.blue()).arg(c2.alpha()).arg(c.red()).arg(c.green()).arg(c.blue()).arg(c.alpha());
   //stxt += QString("color: rgb(0, 0, 0);");
-  stxt += MusECore::font2StyleSheet(fnt);
+  stxt += MusECore::font2StyleSheet(fnt) + "}";
+  stxt += "QToolTip {font-size:" + QString::number(MusEGlobal::config.fonts[0].pointSize()) + "pt}";
 
   label->setStyleSheet(stxt);
 }

--- a/muse3/muse/plugin.cpp
+++ b/muse3/muse/plugin.cpp
@@ -3687,7 +3687,7 @@ PluginGui::PluginGui(MusECore::PluginIBase* p)
                         fnt.setStyleStrategy(QFont::NoAntialias);
                         fnt.setHintingPreference(QFont::PreferVerticalHinting);
                         s->setFont(fnt);
-                        s->setStyleSheet(MusECore::font2StyleSheet(fnt));
+                        s->setStyleSheet(MusECore::font2StyleSheetFull(fnt));
                         s->setSizeHint(200, 8);
 
                         for(unsigned long i = 0; i < nobj; i++)
@@ -3819,7 +3819,7 @@ PluginGui::PluginGui(MusECore::PluginIBase* p)
                         fnt.setStyleStrategy(QFont::NoAntialias);
                         fnt.setHintingPreference(QFont::PreferVerticalHinting);
                         s->setFont(fnt);
-                        s->setStyleSheet(MusECore::font2StyleSheet(fnt));
+                        s->setStyleSheet(MusECore::font2StyleSheetFull(fnt));
 
                         s->setCursorHoming(true);
                         s->setId(i);
@@ -3907,7 +3907,7 @@ PluginGui::PluginGui(MusECore::PluginIBase* p)
                       fnt.setStyleStrategy(QFont::NoAntialias);
                       fnt.setHintingPreference(QFont::PreferVerticalHinting);
                       m->setFont(fnt);
-                      m->setStyleSheet(MusECore::font2StyleSheet(fnt));
+                      m->setStyleSheet(MusECore::font2StyleSheetFull(fnt));
 
                       paramsOut[i].actuator = m;
                       label->setSizePolicy(QSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed));


### PR DESCRIPTION
Refers to #714.
I created a central wrapper function to ensure the tooltips always keep the same size, I think it's cleaner than to change each usage manually.
IMO changing tooltip font size looks like a mistake to the user, and there even is a bug in Qt related to that:  The tooltip frame is not always drawn correctly when the tooltip font size changes.