### PR TITLE
Cleanup obsolete version checks, minor text/icon changes

### DIFF
--- a/muse3/muse/arranger/arrangerview.cpp
+++ b/muse3/muse/arranger/arrangerview.cpp
@@ -774,12 +774,12 @@ void ArrangerView::updateScoreMenus()
   scoreAllInOneSubsubmenu->clear();
 
   
-  action=new QAction(tr("New"), this);
+  action=new QAction(tr("New..."), this);
   connect(action, &QAction::triggered, []() { MusEGlobal::muse->openInScoreEdit_oneStaffPerTrack(nullptr); } );
   scoreOneStaffPerTrackSubsubmenu->addAction(action);
   
   
-  action=new QAction(tr("New"), this); //the above action may NOT be reused!
+  action=new QAction(tr("New..."), this); //the above action may NOT be reused!
   connect(action, &QAction::triggered, []() { MusEGlobal::muse->openInScoreEdit_allInOne(nullptr); } );
   scoreAllInOneSubsubmenu->addAction(action);
 

--- a/muse3/muse/components/canvas.cpp
+++ b/muse3/muse/components/canvas.cpp
@@ -36,10 +36,7 @@
 #include <QMouseEvent>
 #include <QWheelEvent>
 #include <QRect>
-// screenGeometry() is obsolete. Qt >= 5.6 ? use primaryScreen().
-#if QT_VERSION >= 0x050600
 #include <QScreen>
-#endif
 
 #include <vector>
 
@@ -958,12 +955,7 @@ void Canvas::viewMousePressEvent(QMouseEvent* event)
                             //  button while the mouse has been dragged outside causes it to bypass us !
                             setMouseGrab(true); // CAUTION
                             
-// screenGeometry() is obsolete. Qt >= 5.6 ? use primaryScreen().
-#if QT_VERSION >= 0x050600
                             QRect r = QApplication::primaryScreen()->geometry();
-#else
-                            QRect r = QApplication::desktop()->screenGeometry();
-#endif
                             ignore_mouse_move = true;      // Avoid recursion.
                             QCursor::setPos( QPoint(r.width()/2, r.height()/2) );
                             //ignore_mouse_move = false;
@@ -980,11 +972,7 @@ void Canvas::viewMousePressEvent(QMouseEvent* event)
                             setMouseGrab(true); // CAUTION
                             
 // screenGeometry() is obsolete. Qt >= 5.6 ? use primaryScreen().
-#if QT_VERSION >= 0x050600
                             QRect r = QApplication::primaryScreen()->geometry();
-#else
-                            QRect r = QApplication::desktop()->screenGeometry();
-#endif
                             ignore_mouse_move = true;      // Avoid recursion.
                             QCursor::setPos( QPoint(r.width()/2, r.height()/2) );
                             //ignore_mouse_move = false;
@@ -1247,12 +1235,7 @@ void Canvas::viewMouseMoveEvent(QMouseEvent* event)
         cancelMouseOps();
       }
       
-// screenGeometry() is obsolete. Qt >= 5.6 ? use primaryScreen().
-#if QT_VERSION >= 0x050600
       QRect  screen_rect    = QApplication::primaryScreen()->geometry();
-#else
-      QRect  screen_rect    = QApplication::desktop()->screenGeometry();
-#endif
       QPoint screen_center  = QPoint(screen_rect.width()/2, screen_rect.height()/2);
       QPoint glob_dist      = event->globalPos() - ev_global_pos;
       QPoint glob_zoom_dist = MusEGlobal::config.borderlessMouse ? (event->globalPos() - screen_center) : glob_dist;

--- a/muse3/muse/components/filedialog.cpp
+++ b/muse3/muse/components/filedialog.cpp
@@ -248,17 +248,10 @@ MFileDialog::MFileDialog(const QString& dir,
             spl->insertWidget(0,&buttons);
 
         // Qt >= 4.6 allows us to select icons from the theme
-#if QT_VERSION >= 0x040600
             buttons.globalButton->setIcon(*globalIcon);
             buttons.userButton->setIcon(*userIcon);
             buttons.homeButton->setIcon(*userIcon);
             buttons.projectButton->setIcon(*projectIcon);
-#else
-            buttons.globalButton->setIcon(style()->standardIcon(QStyle::SP_DirIcon));
-            buttons.userButton->setIcon(style()->standardIcon(QStyle::SP_DesktopIcon));
-            buttons.homeButton->setIcon(style()->standardIcon(QStyle::SP_DirHomeIcon));
-            buttons.projectButton->setIcon(style()->standardIcon(QStyle::SP_DirOpenIcon));
-#endif
 
             buttons.globalButton->setAutoExclusive(true);
             buttons.userButton->setAutoExclusive(true);

--- a/muse3/muse/components/projectcreateimpl.cpp
+++ b/muse3/muse/components/projectcreateimpl.cpp
@@ -86,12 +86,10 @@ ProjectCreateImpl::ProjectCreateImpl(QWidget *parent) :
   connect(createFolderCheckbox,SIGNAL(clicked()), this, SLOT(createProjFolderChanged()));
   connect(projectFileTypeCB,SIGNAL(currentIndexChanged(int)), this, SLOT(updateDirectoryPath()));
   connect(buttonBox, SIGNAL(accepted()), this, SLOT(ok()));
-#if QT_VERSION >= 0x040700
   projectNameEdit->setPlaceholderText("<Project Name>");
   // Orcan: Commented out since there is no QPlainTextEdit::setPlaceholderText()
   //        as of Qt-4.7.1
   //commentEdit->setPlaceholderText("<Add information about project here>");
-#endif
   updateDirectoryPath();
   projectNameEdit->setFocus();
   show();

--- a/muse3/muse/ctrl.cpp
+++ b/muse3/muse/ctrl.cpp
@@ -833,13 +833,11 @@ void CtrlList::read(Xml& xml)
                         }
                         else if (tag == "color")
                         {
-#if QT_VERSION >= 0x040700
                               ok = _displayColor.isValidColor(xml.s2());
                               if (!ok) {
                                 printf("CtrlList::read failed reading color string: %s\n", xml.s2().toLatin1().constData());
                                 break;
                               }
-#endif
                               _displayColor.setNamedColor(xml.s2());
                         }
                         else

--- a/muse3/muse/ctrl/ctrlcanvas.cpp
+++ b/muse3/muse/ctrl/ctrlcanvas.cpp
@@ -1531,10 +1531,7 @@ void CtrlCanvas::viewMousePressEvent(QMouseEvent* event)
         //       the 'options' items but not the 'actions' items ?
         PopupMenu* itemPopupMenu = new PopupMenu(this, false);
         populateMergeOptions(itemPopupMenu);
-#if QT_VERSION >= 0x050100
-        // This is required after Qt 5.1
         itemPopupMenu->setToolTipsVisible(true);
-#endif
         QAction *act = itemPopupMenu->exec(event->globalPos());
         int idx = -1;
         bool is_checked = false;

--- a/muse3/muse/gconfig.cpp
+++ b/muse3/muse/gconfig.cpp
@@ -122,13 +122,13 @@ GlobalConfigValues config = {
       QColor(0, 0, 0),        // bigTimeBackgroundColor;
       QColor(200, 192, 171),  // waveEditBackgroundColor;
       {
-        QFont(QString("arial"), 10, QFont::Normal),
-        QFont(QString("arial"), 7,  QFont::Normal),    // Mixer strips and midi track info panel
-        QFont(QString("arial"), 10, QFont::Normal),
-        QFont(QString("arial"), 10, QFont::Bold),
-        QFont(QString("arial"), 8,  QFont::Normal),    // Small numbers: Timescale and markers, part name overlay
-        QFont(QString("arial"), 8,  QFont::Bold),      // Small bold numbers such as marker text
-        QFont(QString("arial"), 8,  QFont::Bold, true)  // Mixer strip labels. Looks and fits better with bold + italic than bold alone, 
+        QFont(QString("helvetica"), 10, QFont::Normal),
+        QFont(QString("helvetica"), 7,  QFont::Normal),    // Mixer strips and midi track info panel
+        QFont(QString("helvetica"), 10, QFont::Normal),
+        QFont(QString("helvetica"), 10, QFont::Bold),
+        QFont(QString("helvetica"), 8,  QFont::Normal),    // Small numbers: Timescale and markers, part name overlay
+        QFont(QString("helvetica"), 8,  QFont::Bold),      // Small bold numbers such as marker text
+        QFont(QString("helvetica"), 8,  QFont::Bold, true)  // Mixer strip labels. Looks and fits better with bold + italic than bold alone,
                                                         //  at the price of only few more pixels than Normal mode.
         },
       QColor(84, 97, 114),          // trackBg;

--- a/muse3/muse/main.cpp
+++ b/muse3/muse/main.cpp
@@ -160,13 +160,11 @@ class MuseApplication : public QApplication {
          const bool flag = QApplication::notify(receiver, event);
          const QEvent::Type type = event->type();
          if (type == QEvent::KeyPress) {
-#if QT_VERSION >= 0x050000
             const QMetaObject * mo = receiver->metaObject();
             if (mo){
                if (strcmp(mo->className(), "QWidgetWindow") == 0)
                  return false;
             }
-#endif
             QKeyEvent* ke = (QKeyEvent*)event;
             MusEGlobal::globalKeyState = ke->modifiers();
 
@@ -550,17 +548,7 @@ CommandLineParseResult parseCommandLine(
 int main(int argc, char* argv[])
       {
       // Get the separator used for file paths.
-      #if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
-          const QChar list_separator = QDir::listSeparator();
-      #else
-          // Ugly solution. No c/c++ solution except in c++17, which is a bit too new ATM.
-          // Hopefully everyone's got Qt 5.6 or higher.
-          #if defined(WIN32) || defined(_WIN32)
-              const QChar list_separator = QChar(';');
-          #else
-              const QChar list_separator = QChar(':');
-          #endif
-      #endif
+      const QChar list_separator = QDir::listSeparator();
 
       // Get environment variables for various paths.
       // "The Qt environment manipulation functions are thread-safe, but this requires that
@@ -625,10 +613,8 @@ int main(int argc, char* argv[])
   #endif
 
         // Now create the application, and let Qt remove recognized arguments.
-#if QT_VERSION >= 0x050600
         QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
         QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
-#endif
 
         //========================
         //  Application instance:
@@ -652,25 +638,10 @@ int main(int argc, char* argv[])
         //        (ie. ~./config/MusE/MusE-qt).
         //       Beware, setting application name and organization name influence these locations.
 
-        #if (QT_VERSION >= QT_VERSION_CHECK(5, 5, 0))
           // "Returns a directory location where user-specific configuration files should be written.
           //  This is an application-specific directory, and the returned path is never empty.
           //  This enum value was added in Qt 5.5."
-          MusEGlobal::configPath = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
-        #else
-          // "Returns a directory location where user-specific configuration files should be written.
-          //  This may be either a generic value or application-specific, and the returned path is never empty."
-          //MusEGlobal::configPath = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation)
-          //    + QString("/") + QString(ORGANIZATION_NAME) + QString("/") + QString(PACKAGE_NAME);
-          // "Returns a directory location where user-specific configuration files shared between multiple
-          //   applications should be written. This is a generic value and the returned path is never empty."
-          // According to the chart in the docs, here we should be able to rely on this  since
-          //  'ConfigLocation' acts a bit different on some OS (it might already include the app name).
-          // Also, according to the docs and observation this should equal (resemble?) what is returned by
-          //  the newer 'AppConfigLocation' in Qt 5.5.
-          MusEGlobal::configPath = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation)
-              + "/" + ORGANIZATION_NAME + "/" + PACKAGE_NAME;
-        #endif
+        MusEGlobal::configPath = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
 
         // "Returns a directory location where user-specific non-essential (cached) data should be written.
         //  This is an application-specific directory. The returned path is never empty."

--- a/muse3/muse/widgets/scldiv.cpp
+++ b/muse3/muse/widgets/scldiv.cpp
@@ -22,10 +22,7 @@
 //
 //=========================================================
 
-// As of Qt 5.13 or so, qCopy() is obsolete. use std::copy().
-#if QT_VERSION >= 0x050000
 #include <algorithm>
-#endif
 
 #include "muse_math.h"
 #include "scldiv.h"
@@ -378,12 +375,7 @@ bool ScaleDiv::buildLinDiv(int maxMajSteps, int maxMinSteps, double step)
       }
       //d_minMarks.duplicate(buffer.data(), minSize);
       d_minMarks.resize(minSize);
-// As of Qt 5.13 or so, qCopy() is obsolete. use std::copy().
-#if QT_VERSION >= 0x050000
       std::copy(buffer.data(), buffer.data() + minSize, d_minMarks.begin());
-#else
-      qCopy(buffer.data(), buffer.data() + minSize, d_minMarks.begin());
-#endif
    }
 
    return rv;
@@ -540,12 +532,7 @@ bool ScaleDiv::buildLogDiv(int maxMajSteps, int maxMinSteps, double majStep)
       // copy values into the minMarks array
       //d_minMarks.duplicate(buffer.data(), minSize);
       d_minMarks.resize(minSize);
-// As of Qt 5.13 or so, qCopy() is obsolete. use std::copy().
-#if QT_VERSION >= 0x050000
       std::copy(buffer.data(), buffer.data() + minSize, d_minMarks.begin());
-#else
-      qCopy(buffer.data(), buffer.data() + minSize, d_minMarks.begin());
-#endif
 
    }
    else				// major step > one decade
@@ -597,12 +584,7 @@ bool ScaleDiv::buildLogDiv(int maxMajSteps, int maxMinSteps, double majStep)
       }
       //d_minMarks.duplicate(buffer.data(), minSize);
       d_minMarks.resize(minSize);
-// As of Qt 5.13 or so, qCopy() is obsolete. use std::copy().
-#if QT_VERSION >= 0x050000
       std::copy(buffer.data(), buffer.data() + minSize, d_minMarks.begin());
-#else
-      qCopy(buffer.data(), buffer.data() + minSize, d_minMarks.begin());
-#endif
 
    }
 

--- a/muse3/muse/widgets/sliderbase.cpp
+++ b/muse3/muse/widgets/sliderbase.cpp
@@ -34,10 +34,7 @@
 #include <QDesktopWidget>
 #include <QCursor>
 #include <QToolTip>
-// screenGeometry() is obsolete. Qt >= 5.6 ? use primaryScreen().
-#if QT_VERSION >= 0x050600
 #include <QScreen>
-#endif
 // For debugging output: Uncomment the fprintf section.
 #define DEBUG_SLIDER_BASE(dev, format, args...)  //fprintf(dev, format, ##args);
 
@@ -665,12 +662,7 @@ void SliderBase::mouseMoveEvent(QMouseEvent *e)
     d_trackingTempDisable = meta; // Generate automation graph recording straight lines if modifier held.
     if(borderlessMouse())
     {
-// screenGeometry() is obsolete. Qt >= 5.6 ? use primaryScreen().
-#if QT_VERSION >= 0x050600
       const QRect r = QApplication::primaryScreen()->geometry();
-#else
-      const QRect r = QApplication::desktop()->screenGeometry();
-#endif
       const QPoint scrn_cntr(r.width()/2, r.height()/2);
       QPoint delta;
       if(_firstMouseMoveAfterPress)

--- a/muse3/svg/mixerstrip.svg
+++ b/muse3/svg/mixerstrip.svg
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg id="SVGRoot" width="64px" height="64px" version="1.1" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg id="SVGRoot" width="64px" height="64px" version="1.1" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
  <defs>
   <linearGradient id="linearGradient1637" x1="31" x2="31" y1="4" y2="61" gradientTransform="matrix(.25 0 0 .80702 -2.75 5.7719)" gradientUnits="userSpaceOnUse">
    <stop stop-color="#f00" offset="0"/>
@@ -36,22 +35,10 @@
    </cc:Work>
   </rdf:RDF>
  </metadata>
- <g>
-  <g fill="none" stroke="#fff">
-   <path d="m10 3v57" stroke-width="3"/>
-   <g stroke-width="2">
-    <path d="m5 12h10"/>
-    <path d="m5 22h10"/>
-    <path d="m5 32h10"/>
-    <path d="m5 42h10"/>
-    <path d="m5 52h10"/>
-   </g>
-  </g>
-  <g fill-rule="evenodd" stroke="#000" stroke-dashoffset="37.795" stroke-linejoin="round">
-   <rect x="1" y="9" width="8" height="46" fill="url(#linearGradient1637)" style="paint-order:fill markers stroke"/>
-   <rect x="55" y="9" width="8" height="46" fill="url(#linearGradient1659)" style="paint-order:fill markers stroke"/>
-   <rect x="37" y="9" width="8" height="46" fill="url(#linearGradient1657)" style="paint-order:fill markers stroke"/>
-   <rect x="19" y="9" width="8" height="46" fill="url(#linearGradient1655)" style="paint-order:fill markers stroke"/>
-  </g>
+ <g fill-rule="evenodd" stroke="#000" stroke-dashoffset="37.795" stroke-linejoin="round">
+  <rect x="1" y="9" width="8" height="46" fill="url(#linearGradient1637)" style="paint-order:fill markers stroke"/>
+  <rect x="55" y="9" width="8" height="46" fill="url(#linearGradient1659)" style="paint-order:fill markers stroke"/>
+  <rect x="37" y="9" width="8" height="46" fill="url(#linearGradient1657)" style="paint-order:fill markers stroke"/>
+  <rect x="19" y="9" width="8" height="46" fill="url(#linearGradient1655)" style="paint-order:fill markers stroke"/>
  </g>
 </svg>


### PR DESCRIPTION
MusE requires Qt 5.7 as a prerequisite, so removing the obsolete version checks.