### PR TITLE
Custom file dlg for style / user style override

### DIFF
--- a/muse3/muse/components/appearance.cpp
+++ b/muse3/muse/components/appearance.cpp
@@ -704,32 +704,34 @@ void Appearance::changeTheme()
         return;
     }
 
+    backgroundTree->reset();
 
     QString currentTheme = colorSchemeComboBox->currentText();
     printf("Changing to theme %s\n", currentTheme.toLatin1().constData() );
 
-    QString themeDir = MusEGlobal::museGlobalShare + "/themes/";
-    backgroundTree->reset();
+    QString styleFile = QFileInfo(currentTheme).baseName() + ".qss";
+    QString stylePath = MusEGlobal::configPath + "/themes/" + styleFile;
 
-    QString configPath = themeDir + currentTheme;
-    if (QFile::exists(themeDir + QFileInfo(currentTheme).baseName()+ ".qss"))
+    if (!QFile::exists(stylePath)) {
+        stylePath = MusEGlobal::museGlobalShare + "/themes/" + styleFile;
+    }
+
+    if (QFile::exists(stylePath))
     {
-      styleSheetPath->setText(themeDir + QFileInfo(currentTheme).baseName()+ ".qss");
-      MusEGlobal::config.styleSheetFile = styleSheetPath->text();
+      styleSheetPath->setText(stylePath);
+      MusEGlobal::config.styleSheetFile = stylePath;
       if (MusEGlobal::debugMsg)
           printf("Setting config.styleSheetFile to %s\n", config->styleSheetFile.toLatin1().data());
-
-      MusECore::readConfiguration(configPath.toLatin1().constData());
-      // We want the simple version, don't set the style or stylesheet yet.
-      MusEGlobal::muse->changeConfig(true);
     }
     else
     {
       MusEGlobal::config.styleSheetFile = "";
-      // We want the simple version, don't set the style or stylesheet yet.
-      MusEGlobal::muse->changeConfig(true);
-      MusECore::readConfiguration(configPath.toLatin1().constData());
     }
+
+    QString configPath = MusEGlobal::museGlobalShare + "/themes/" + currentTheme;
+    // We want the simple version, don't set the style or stylesheet yet.
+    MusEGlobal::muse->changeConfig(true);
+    MusECore::readConfiguration(configPath.toLatin1().constData());
 
     hide();
 
@@ -1642,7 +1644,8 @@ void Appearance::browseStyleSheet()
         path = info.absolutePath();
       }
       
-      QString file = QFileDialog::getOpenFileName(this, tr("Select style sheet"), path, tr("Qt style sheets (*.qss)"));
+      QString file = MusEGui::getOpenFileName(QString("themes"), MusEGlobal::stylesheet_file_pattern, this,
+                                              tr("Select style sheet"), nullptr, MusEGui::MFileDialog::GLOBAL_VIEW);
       styleSheetPath->setText(file);
 }
 

--- a/muse3/muse/globals.cpp
+++ b/muse3/muse/globals.cpp
@@ -251,6 +251,12 @@ const char* colors_config_file_pattern[] = {
       0
 };
 
+const char* stylesheet_file_pattern[] = {
+    QT_TRANSLATE_NOOP("file_patterns", "Qt style sheets (*.qss)"),
+    QT_TRANSLATE_NOOP("file_patterns", "All Files (*)"),
+    0
+};
+
 Qt::KeyboardModifiers globalKeyState;
 
 // Midi Filter Parameter

--- a/muse3/muse/globals.h
+++ b/muse3/muse/globals.h
@@ -132,6 +132,7 @@ extern const char* drum_map_file_pattern[];
 extern const char* drum_map_file_save_pattern[];
 extern const char* audio_file_pattern[];
 extern const char* colors_config_file_pattern[];
+extern const char* stylesheet_file_pattern[];
 
 extern Qt::KeyboardModifiers globalKeyState;
 


### PR DESCRIPTION
Replaced the standard file open dialog in appearance->style sheet selection with the custom one (with Global/User/Project buttons), to make selection of custom style sheet faster.
Added user override for theme stylesheet - if there is e.g. Ardour.qss in user config folder, then it's chosen instead of the default one on theme change.