### PR TITLE
Appearance dlg - fixes for styles and font0

### DIFF
--- a/muse3/muse/app.cpp
+++ b/muse3/muse/app.cpp
@@ -315,39 +315,38 @@ void addProject(const QString& name)
 MusE::MusE() : QMainWindow()
       {
       setIconSize(QSize(MusEGlobal::config.iconSize, MusEGlobal::config.iconSize));
-//      setIconSize(ICON_SIZE);
       setFocusPolicy(Qt::NoFocus);
       MusEGlobal::muse      = this;    // hack
       _isRestartingApp      = false;
-      clipListEdit          = 0;
-      midiSyncConfig        = 0;
-      midiRemoteConfig      = 0;
-      midiPortConfig        = 0;
-      metronomeConfig       = 0;
-      midiFileConfig        = 0;
-      midiFilterConfig      = 0;
-      midiInputTransform    = 0;
-      midiRhythmGenerator   = 0;
-      globalSettingsConfig  = 0;
-      markerView            = 0;
-      arrangerView          = 0;
-      softSynthesizerConfig = 0;
-      midiTransformerDialog = 0;
-      shortcutConfig        = 0;
-      appearance            = 0;
-      _snooperDialog        = 0;
+      clipListEdit          = nullptr;
+      midiSyncConfig        = nullptr;
+      midiRemoteConfig      = nullptr;
+      midiPortConfig        = nullptr;
+      metronomeConfig       = nullptr;
+      midiFileConfig        = nullptr;
+      midiFilterConfig      = nullptr;
+      midiInputTransform    = nullptr;
+      midiRhythmGenerator   = nullptr;
+      globalSettingsConfig  = nullptr;
+      markerView            = nullptr;
+      arrangerView          = nullptr;
+      softSynthesizerConfig = nullptr;
+      midiTransformerDialog = nullptr;
+      shortcutConfig        = nullptr;
+      appearance            = nullptr;
+      _snooperDialog        = nullptr;
       //audioMixer            = 0;
-      mixer1                = 0;
-      mixer2                = 0;
-      routeDialog           = 0;
+      mixer1                = nullptr;
+      mixer2                = nullptr;
+      routeDialog           = nullptr;
       watchdogThread        = 0;
-      editInstrument        = 0;
+      editInstrument        = nullptr;
       //routingPopupMenu      = 0;
-      progress              = 0;
+      progress              = nullptr;
       saveIncrement         = 0;
-      activeTopWin          = NULL;
-      currentMenuSharingTopwin = NULL;
-      waitingForTopwin      = NULL;
+      activeTopWin          = nullptr;
+      currentMenuSharingTopwin = nullptr;
+      waitingForTopwin      = nullptr;
 
       appName               = PACKAGE_NAME;
       setWindowTitle(appName);
@@ -1029,7 +1028,7 @@ MusE::MusE() : QMainWindow()
       }
 
       transport = new MusEGui::Transport(this, "transport");
-      bigtime   = 0;
+      bigtime   = nullptr;
 
       MusEGlobal::song->blockSignals(false);
 

--- a/muse3/muse/components/appearance.h
+++ b/muse3/muse/components/appearance.h
@@ -114,11 +114,11 @@ class Appearance : public QDialog, public Ui::AppearanceDialogBase {
       bool apply();
       // Ask to close and if so, tell the main window to close the app and return true.
       bool checkClose();
+      bool changeTheme();
 
    private slots:
       void applyClicked();
       void okClicked();
-      void changeTheme();
       void cancel();
       void addBackground();
       void removeBackground();

--- a/muse3/muse/components/appearancebase.ui
+++ b/muse3/muse/components/appearancebase.ui
@@ -1174,6 +1174,13 @@
           <item>
            <layout class="QHBoxLayout">
             <item>
+             <widget class="QLabel" name="label_5">
+              <property name="text">
+               <string>Qt system style</string>
+              </property>
+             </widget>
+            </item>
+            <item>
              <widget class="QComboBox" name="themeComboBox">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -1223,28 +1230,28 @@
               </item>
              </widget>
             </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_5">
             <item>
-             <widget class="QLabel" name="theme_label">
+             <widget class="QLabel" name="label_6">
               <property name="text">
-               <string>May require restarting MusE for best results</string>
+               <string>MusE color scheme</string>
               </property>
              </widget>
             </item>
             <item>
-             <spacer name="Spacer2">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+             <widget class="QComboBox" name="colorSchemeComboBox">
+              <property name="currentText">
+               <string>Current settings</string>
               </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Expanding</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>90</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
+              <item>
+               <property name="text">
+                <string>Current settings</string>
+               </property>
+              </item>
+             </widget>
             </item>
            </layout>
           </item>
@@ -1253,7 +1260,7 @@
             <item>
              <widget class="QLabel" name="label_41">
               <property name="text">
-               <string>Style Sheet:</string>
+               <string>Style sheet</string>
               </property>
              </widget>
             </item>
@@ -1355,39 +1362,6 @@
            </layout>
           </item>
           <item>
-           <widget class="QLabel" name="label_2">
-            <property name="text">
-             <string>MusE color scheme</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_5">
-            <item>
-             <widget class="QComboBox" name="colorSchemeComboBox">
-              <property name="currentText">
-               <string>Current settings</string>
-              </property>
-              <item>
-               <property name="text">
-                <string>Current settings</string>
-               </property>
-              </item>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="changeThemeButton">
-              <property name="text">
-               <string>Change</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
            <spacer name="spacer3">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -1412,39 +1386,7 @@
           <string>Fonts</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_6">
-          <property name="leftMargin">
-           <number>11</number>
-          </property>
-          <property name="topMargin">
-           <number>2</number>
-          </property>
-          <property name="rightMargin">
-           <number>11</number>
-          </property>
-          <property name="bottomMargin">
-           <number>6</number>
-          </property>
-          <property name="spacing">
-           <number>6</number>
-          </property>
-          <item row="6" column="2">
-           <widget class="QSpinBox" name="fontSize4">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="4">
-           <widget class="QCheckBox" name="italic1">
-            <property name="text">
-             <string>Italic</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
+          <item row="2" column="1">
            <widget class="QLineEdit" name="fontName1">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -1454,48 +1396,21 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="2">
-           <widget class="QLabel" name="TextLabel1_1">
-            <property name="text">
-             <string>Size (pt)</string>
-            </property>
-            <property name="wordWrap">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="4">
-           <widget class="QCheckBox" name="italic2">
+          <item row="2" column="4">
+           <widget class="QCheckBox" name="italic1">
             <property name="text">
              <string>Italic</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="3">
-           <widget class="QCheckBox" name="bold0">
+          <item row="6" column="3">
+           <widget class="QCheckBox" name="bold5">
             <property name="text">
              <string>Bold</string>
             </property>
            </widget>
           </item>
-          <item row="7" column="0">
-           <widget class="QLabel" name="textLabel7_2">
-            <property name="text">
-             <string>Font 5</string>
-            </property>
-            <property name="wordWrap">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="4">
-           <widget class="QCheckBox" name="italic3">
-            <property name="text">
-             <string>Italic</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="5">
+          <item row="1" column="5">
            <widget class="QToolButton" name="fontBrowse0">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
@@ -1508,77 +1423,7 @@
             </property>
            </widget>
           </item>
-          <item row="8" column="4">
-           <widget class="QCheckBox" name="italic6">
-            <property name="text">
-             <string>Italic</string>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="5">
-           <widget class="QToolButton" name="fontBrowse6">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>...</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="3">
-           <widget class="QCheckBox" name="bold2">
-            <property name="text">
-             <string>Bold</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="2">
-           <widget class="QSpinBox" name="fontSize1">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="5">
-           <widget class="QToolButton" name="fontBrowse3">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>...</string>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="5">
-           <widget class="QToolButton" name="fontBrowse5">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>...</string>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="4">
-           <widget class="QCheckBox" name="italic5">
-            <property name="text">
-             <string>Italic</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="5">
+          <item row="3" column="5">
            <widget class="QToolButton" name="fontBrowse2">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
@@ -1591,7 +1436,17 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
+          <item row="6" column="0">
+           <widget class="QLabel" name="textLabel7_2">
+            <property name="text">
+             <string>Font 5</string>
+            </property>
+            <property name="wordWrap">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
            <widget class="QLabel" name="textLabel4">
             <property name="text">
              <string>Font 1</string>
@@ -1601,193 +1456,8 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="textLabel3">
-            <property name="text">
-             <string>Font 0</string>
-            </property>
-            <property name="wordWrap">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="2">
-           <widget class="QSpinBox" name="fontSize5">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="3">
-           <widget class="QCheckBox" name="bold6">
-            <property name="text">
-             <string>Bold</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1">
-           <widget class="QLineEdit" name="fontName2">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="1">
-           <widget class="QLineEdit" name="fontName6">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="2">
-           <widget class="QSpinBox" name="fontSize3">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="1">
-           <widget class="QLineEdit" name="fontName5">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="9" column="1">
-           <widget class="QLabel" name="label_14">
-            <property name="toolTip">
-             <string/>
-            </property>
-            <property name="whatsThis">
-             <string/>
-            </property>
-            <property name="text">
-             <string>Maximum aliased size, 0 = no alias:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="2">
-           <widget class="QSpinBox" name="fontSize2">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="2">
-           <widget class="QSpinBox" name="fontSize0">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="textLabel5">
-            <property name="text">
-             <string>Font 2</string>
-            </property>
-            <property name="wordWrap">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="4">
-           <widget class="QCheckBox" name="italic4">
-            <property name="text">
-             <string>Italic</string>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="1">
-           <widget class="QLineEdit" name="fontName4">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="3">
-           <widget class="QCheckBox" name="bold4">
-            <property name="text">
-             <string>Bold</string>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="0">
-           <widget class="QLabel" name="textLabel7">
-            <property name="text">
-             <string>Font 4</string>
-            </property>
-            <property name="wordWrap">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="3">
-           <widget class="QCheckBox" name="bold5">
-            <property name="text">
-             <string>Bold</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="4">
-           <widget class="QCheckBox" name="italic0">
-            <property name="text">
-             <string>Italic</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QLineEdit" name="fontName0">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="1">
-           <widget class="QLineEdit" name="fontName3">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="3">
-           <widget class="QCheckBox" name="bold1">
-            <property name="text">
-             <string>Bold</string>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="5">
-           <widget class="QToolButton" name="fontBrowse4">
+          <item row="4" column="5">
+           <widget class="QToolButton" name="fontBrowse3">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
               <horstretch>0</horstretch>
@@ -1799,7 +1469,71 @@
             </property>
            </widget>
           </item>
-          <item row="9" column="2">
+          <item row="4" column="0">
+           <widget class="QLabel" name="textLabel6">
+            <property name="text">
+             <string>Font 3</string>
+            </property>
+            <property name="wordWrap">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="2">
+           <widget class="QSpinBox" name="fontSize2">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QLineEdit" name="fontName3">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="1">
+           <widget class="QLineEdit" name="fontName5">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="fontName0">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="4">
+           <widget class="QCheckBox" name="italic3">
+            <property name="text">
+             <string>Italic</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="4">
+           <widget class="QCheckBox" name="italic6">
+            <property name="text">
+             <string>Italic</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="2">
            <widget class="QSpinBox" name="maxAliasedPointSize">
             <property name="toolTip">
              <string>At what point size to switch from aliased text
@@ -1835,24 +1569,112 @@ The font family is forced to 'Sans', which should
             </property>
            </widget>
           </item>
-          <item row="5" column="3">
-           <widget class="QCheckBox" name="bold3">
+          <item row="3" column="3">
+           <widget class="QCheckBox" name="bold2">
             <property name="text">
              <string>Bold</string>
             </property>
            </widget>
           </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="textLabel6">
+          <item row="7" column="1">
+           <widget class="QLineEdit" name="fontName6">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="2">
+           <widget class="QSpinBox" name="fontSize4">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="textLabel7_3">
             <property name="text">
-             <string>Font 3</string>
+             <string>Font 6</string>
             </property>
             <property name="wordWrap">
              <bool>false</bool>
             </property>
            </widget>
           </item>
-          <item row="8" column="2">
+          <item row="5" column="3">
+           <widget class="QCheckBox" name="bold4">
+            <property name="text">
+             <string>Bold</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QLineEdit" name="fontName4">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="4">
+           <widget class="QCheckBox" name="italic5">
+            <property name="text">
+             <string>Italic</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="textLabel3">
+            <property name="text">
+             <string>Font 0</string>
+            </property>
+            <property name="wordWrap">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3">
+           <widget class="QCheckBox" name="bold0">
+            <property name="text">
+             <string>Bold</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="textLabel2">
+            <property name="text">
+             <string>Family</string>
+            </property>
+            <property name="wordWrap">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="textLabel7">
+            <property name="text">
+             <string>Font 4</string>
+            </property>
+            <property name="wordWrap">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="4">
+           <widget class="QCheckBox" name="italic0">
+            <property name="text">
+             <string>Italic</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="2">
            <widget class="QSpinBox" name="fontSize6">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -1862,7 +1684,41 @@ The font family is forced to 'Sans', which should
             </property>
            </widget>
           </item>
-          <item row="3" column="5">
+          <item row="6" column="5">
+           <widget class="QToolButton" name="fontBrowse5">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="4">
+           <widget class="QCheckBox" name="italic4">
+            <property name="text">
+             <string>Italic</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="3">
+           <widget class="QCheckBox" name="bold3">
+            <property name="text">
+             <string>Bold</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="3">
+           <widget class="QCheckBox" name="bold1">
+            <property name="text">
+             <string>Bold</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="5">
            <widget class="QToolButton" name="fontBrowse1">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
@@ -1875,23 +1731,126 @@ The font family is forced to 'Sans', which should
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
-           <widget class="QLabel" name="textLabel2">
+          <item row="8" column="1">
+           <widget class="QLabel" name="label_14">
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="whatsThis">
+             <string/>
+            </property>
             <property name="text">
-             <string>Family</string>
+             <string>Maximum aliased size, 0 = no alias:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="2">
+           <widget class="QSpinBox" name="fontSize3">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QSpinBox" name="fontSize0">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="2">
+           <widget class="QSpinBox" name="fontSize1">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="textLabel5">
+            <property name="text">
+             <string>Font 2</string>
             </property>
             <property name="wordWrap">
              <bool>false</bool>
             </property>
            </widget>
           </item>
-          <item row="8" column="0">
-           <widget class="QLabel" name="textLabel7_3">
+          <item row="7" column="5">
+           <widget class="QToolButton" name="fontBrowse6">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <property name="text">
-             <string>Font 6</string>
+             <string>...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="2">
+           <widget class="QSpinBox" name="fontSize5">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="4">
+           <widget class="QCheckBox" name="italic2">
+            <property name="text">
+             <string>Italic</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="3">
+           <widget class="QCheckBox" name="bold6">
+            <property name="text">
+             <string>Bold</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QLineEdit" name="fontName2">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QLabel" name="TextLabel1_1">
+            <property name="text">
+             <string>Size (pt)</string>
             </property>
             <property name="wordWrap">
              <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="5">
+           <widget class="QToolButton" name="fontBrowse4">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>...</string>
             </property>
            </widget>
           </item>

--- a/muse3/muse/components/editevent.cpp
+++ b/muse3/muse/components/editevent.cpp
@@ -370,7 +370,7 @@ EditMetaDialog::EditMetaDialog(int tick, const MusECore::Event& ev,
       connect(hexButton, SIGNAL(toggled(bool)), SLOT(toggled(bool)));
 
       edit = new QTextEdit;
-      edit->setFont(MusEGlobal::config.fonts[0]);
+      edit->setFont(qApp->font());
 
       if (!ev.empty()) {
             epos->setValue(tick);

--- a/muse3/muse/components/plugindialog.cpp
+++ b/muse3/muse/components/plugindialog.cpp
@@ -29,7 +29,7 @@ PluginDialog::PluginDialog(QWidget* parent)
   : QDialog(parent)
 {
     ui.setupUi(this);
-    this->setStyleSheet("font-size:" + QString::number(MusEGlobal::config.fonts[0].pointSize()) + "pt");
+    this->setStyleSheet("font-size:" + QString::number(qApp->font().pointSize()) + "pt");
 
       group_info=NULL;
       setWindowTitle(tr("MusE: select plugin"));

--- a/muse3/muse/components/utils.cpp
+++ b/muse3/muse/components/utils.cpp
@@ -978,7 +978,7 @@ bool getUniqueFileName(const QString& origFilepath, QString& newAbsFilePath)
 QString font2StyleSheetFull(const QFont& fnt)
 {
     QString ss("* {" + MusECore::font2StyleSheet(fnt) + "}");
-    ss += "QToolTip {font-size:" + QString::number(MusEGlobal::config.fonts[0].pointSize()) + "pt}";
+    ss += "QToolTip {font-size:" + QString::number(qApp->font().pointSize()) + "pt}";
     return ss;
 }
 

--- a/muse3/muse/instruments/editinstrument.cpp
+++ b/muse3/muse/instruments/editinstrument.cpp
@@ -3865,7 +3865,7 @@ QMenu* EditInstrument::createPopupPatchList(bool drum)
                           if(!pm) {
                             pm = new QMenu(pgp->name, patchpopup);
                             patchpopup->addMenu(pm);
-                            pm->setFont(MusEGlobal::config.fonts[0]);
+                            pm->setFont(qApp->font());
                           }
                           int id = ((mp->hbank & 0xff) << 16)
                                       + ((mp->lbank & 0xff) << 8) + (mp->program & 0xff);

--- a/muse3/muse/instruments/minstrument.cpp
+++ b/muse3/muse/instruments/minstrument.cpp
@@ -1248,7 +1248,7 @@ void MidiInstrument::populatePatchPopup(MusEGui::PopupMenu* menu, int /*chan*/, 
                               if(!pm) {
                                 pm = new MusEGui::PopupMenu(pgp->name, menu, menu->stayOpen());  // Use the parent stayOpen here.
                                 menu->addMenu(pm);
-                                pm->setFont(MusEGlobal::config.fonts[0]);
+                                pm->setFont(qApp->font());
                               }
                               int id = ((mp->hbank & 0xff) << 16)
                                          + ((mp->lbank & 0xff) << 8) + (mp->program & 0xff);

--- a/muse3/muse/mixer/strip.cpp
+++ b/muse3/muse/mixer/strip.cpp
@@ -902,7 +902,7 @@ void Strip::changeTrackName()
   dlg.setWindowTitle(tr("Name"));
   dlg.setLabelText(tr("Enter track name:"));
   dlg.setTextValue(oldname);
-  dlg.setStyleSheet("font-size:" + QString::number(MusEGlobal::config.fonts[0].pointSize()) + "pt");
+  dlg.setStyleSheet("font-size:" + QString::number(qApp->font().pointSize()) + "pt");
 
   const int res = dlg.exec();
   if(res == QDialog::Rejected)
@@ -992,7 +992,7 @@ void Strip::updateStyleSheet()
       .arg(c2.red()).arg(c2.green()).arg(c2.blue()).arg(c2.alpha()).arg(c.red()).arg(c.green()).arg(c.blue()).arg(c.alpha());
   //stxt += QString("color: rgb(0, 0, 0);");
   stxt += MusECore::font2StyleSheet(fnt) + "}";
-  stxt += "QToolTip {font-size:" + QString::number(MusEGlobal::config.fonts[0].pointSize()) + "pt}";
+  stxt += "QToolTip {font-size:" + QString::number(qApp->font().pointSize()) + "pt}";
 
   label->setStyleSheet(stxt);
 }


### PR DESCRIPTION
Some modifications from last year that I did not want to merge before my vacation, in case there were issues...

Appearance dialog:
1. Removed the inconsistent handling (special button) for changing the MusE color scheme. Now the scheme is switched by Apply/OK like all the other settings.
2. Implemented user override for the internal colour settings. Now if there is a file with the same name as the scheme + .cfc (like Ardour.cfc) in the user theme directory, then it will be applied at scheme change.
3. Looking into the font handling in more depth, I think Font 0 can't be consistently applied and is more or less redundant. It's always replaced by the system font (Qt theme font) and/or style sheet font at MusE start. 
Implicitly changing it when appearance settings are applied only adds to the confusion, because the behaviour is different depending on the desktop used (and probably never intended by the user), and is lost at the next MusE start anyway.
So I changed all the usages of font0 (mostly my early fixes of too small fonts) to the current application font instead. Font 0 is still used in main.cpp as base setting before style/stylesheet is applied - just to be sure, in case there is a scenario where it's necessary. Even so it could be replaced by a constant there and removed from the appearance settings IMO to avoid confusion.