### PR TITLE
Remove font 0 from UI

### DIFF
--- a/muse3/muse/app.cpp
+++ b/muse3/muse/app.cpp
@@ -1037,6 +1037,12 @@ MusE::MusE() : QMainWindow()
 
       MusEGlobal::song->update();
       updateWindowMenu();
+
+      ensurePolished();
+      MusEGlobal::config.fonts[0].setFamily(font().family());
+      MusEGlobal::config.fonts[0].setPointSize(font().pointSize());
+      MusEGlobal::config.fonts[0].setBold(font().bold());
+      MusEGlobal::config.fonts[0].setItalic(font().italic());
       }
 
 //---------------------------------------------------------

--- a/muse3/muse/components/appearance.cpp
+++ b/muse3/muse/components/appearance.cpp
@@ -644,10 +644,10 @@ void Appearance::bgSelectionChanged(QTreeWidgetItem* item)
 
 void Appearance::updateFonts()
       {
-      fontSize0->setValue(qApp->font().pointSize());
-      fontName0->setText(qApp->font().family());
-      italic0->setChecked(qApp->font().italic());
-      bold0->setChecked(qApp->font().bold());
+      fontSize0->setValue(MusEGlobal::config.fonts[0].pointSize());
+      fontName0->setText(MusEGlobal::config.fonts[0].family());
+      italic0->setChecked(MusEGlobal::config.fonts[0].italic());
+      bold0->setChecked(MusEGlobal::config.fonts[0].bold());
 
       fontSize1->setValue(config->fonts[1].pointSize());
       fontName1->setText(config->fonts[1].family());

--- a/muse3/muse/components/appearance.cpp
+++ b/muse3/muse/components/appearance.cpp
@@ -318,14 +318,12 @@ Appearance::Appearance(Arranger* a, QWidget* parent)
       //    Fonts
       //---------------------------------------------------
 
-      fontBrowse0->setIcon(*fileopenSVGIcon);
       fontBrowse1->setIcon(*fileopenSVGIcon);
       fontBrowse2->setIcon(*fileopenSVGIcon);
       fontBrowse3->setIcon(*fileopenSVGIcon);
       fontBrowse4->setIcon(*fileopenSVGIcon);
       fontBrowse5->setIcon(*fileopenSVGIcon);
       fontBrowse6->setIcon(*fileopenSVGIcon);
-      connect(fontBrowse0, SIGNAL(clicked()), SLOT(browseFont0()));
       connect(fontBrowse1, SIGNAL(clicked()), SLOT(browseFont1()));
       connect(fontBrowse2, SIGNAL(clicked()), SLOT(browseFont2()));
       connect(fontBrowse3, SIGNAL(clicked()), SLOT(browseFont3()));
@@ -646,10 +644,10 @@ void Appearance::bgSelectionChanged(QTreeWidgetItem* item)
 
 void Appearance::updateFonts()
       {
-      fontSize0->setValue(config->fonts[0].pointSize());
-      fontName0->setText(config->fonts[0].family());
-      italic0->setChecked(config->fonts[0].italic());
-      bold0->setChecked(config->fonts[0].bold());
+      fontSize0->setValue(qApp->font().pointSize());
+      fontName0->setText(qApp->font().family());
+      italic0->setChecked(qApp->font().italic());
+      bold0->setChecked(qApp->font().bold());
 
       fontSize1->setValue(config->fonts[1].pointSize());
       fontName1->setText(config->fonts[1].family());
@@ -792,10 +790,10 @@ bool Appearance::apply()
       for (int i = 0; i < user_bg->childCount(); ++i)
             config->canvasCustomBgList << user_bg->child(i)->data(0, Qt::UserRole).toString();
 
-      config->fonts[0].setFamily(fontName0->text());
-      config->fonts[0].setPointSize(fontSize0->value());
-      config->fonts[0].setItalic(italic0->isChecked());
-      config->fonts[0].setBold(bold0->isChecked());
+//      config->fonts[0].setFamily(fontName0->text());
+//      config->fonts[0].setPointSize(fontSize0->value());
+//      config->fonts[0].setItalic(italic0->isChecked());
+//      config->fonts[0].setBold(bold0->isChecked());
 
       config->fonts[1].setFamily(fontName1->text());
       config->fonts[1].setPointSize(fontSize1->value());
@@ -1654,7 +1652,6 @@ void Appearance::setDefaultStyleSheet()
 //   browseFont
 //---------------------------------------------------------
 
-void Appearance::browseFont0() { browseFont(0); }
 void Appearance::browseFont1() { browseFont(1); }
 void Appearance::browseFont2() { browseFont(2); }
 void Appearance::browseFont3() { browseFont(3); }

--- a/muse3/muse/components/appearance.h
+++ b/muse3/muse/components/appearance.h
@@ -127,7 +127,6 @@ class Appearance : public QDialog, public Ui::AppearanceDialogBase {
       void browseStyleSheet();
       void setDefaultStyleSheet();
       void browseFont(int);
-      void browseFont0();
       void browseFont1();
       void browseFont2();
       void browseFont3();

--- a/muse3/muse/components/appearancebase.ui
+++ b/muse3/muse/components/appearancebase.ui
@@ -1410,19 +1410,6 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="5">
-           <widget class="QToolButton" name="fontBrowse0">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>...</string>
-            </property>
-           </widget>
-          </item>
           <item row="3" column="5">
            <widget class="QToolButton" name="fontBrowse2">
             <property name="sizePolicy">
@@ -1511,6 +1498,9 @@
           </item>
           <item row="1" column="1">
            <widget class="QLineEdit" name="fontName0">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -1633,7 +1623,7 @@ The font family is forced to 'Sans', which should
           <item row="1" column="0">
            <widget class="QLabel" name="textLabel3">
             <property name="text">
-             <string>Font 0</string>
+             <string>System</string>
             </property>
             <property name="wordWrap">
              <bool>false</bool>
@@ -1642,6 +1632,9 @@ The font family is forced to 'Sans', which should
           </item>
           <item row="1" column="3">
            <widget class="QCheckBox" name="bold0">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
             <property name="text">
              <string>Bold</string>
             </property>
@@ -1669,6 +1662,9 @@ The font family is forced to 'Sans', which should
           </item>
           <item row="1" column="4">
            <widget class="QCheckBox" name="italic0">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
             <property name="text">
              <string>Italic</string>
             </property>
@@ -1756,6 +1752,9 @@ The font family is forced to 'Sans', which should
           </item>
           <item row="1" column="2">
            <widget class="QSpinBox" name="fontSize0">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
             <property name="sizePolicy">
              <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
               <horstretch>0</horstretch>

--- a/muse3/muse/conf.cpp
+++ b/muse3/muse/conf.cpp
@@ -758,8 +758,8 @@ void readConfiguration(Xml& xml, bool doReadMidiPortConfig, bool doReadGlobalCon
                               MusEGlobal::config.moveArmedCheckBox = xml.parseInt();
                         else if (tag == "externalWavEditor")
                               MusEGlobal::config.externalWavEditor = xml.parse1();
-                        else if (tag == "font0")
-                              MusEGlobal::config.fonts[0].fromString(xml.parse1());
+//                        else if (tag == "font0")
+//                              MusEGlobal::config.fonts[0].fromString(xml.parse1());
                         else if (tag == "font1")
                               MusEGlobal::config.fonts[1].fromString(xml.parse1());
                         else if (tag == "font2")
@@ -1889,7 +1889,8 @@ void MusE::writeGlobalConfiguration(int level, MusECore::Xml& xml) const
       xml.intTag(level, "noPluginScaling", MusEGlobal::config.noPluginScaling);
       xml.intTag(level, "openMDIWinMaximized", MusEGlobal::config.openMDIWinMaximized);
 
-      for (int i = 0; i < NUM_FONTS; ++i) {
+      for (int i = 1; i < NUM_FONTS; ++i) {
+//          for (int i = 0; i < NUM_FONTS; ++i) {
             xml.strTag(level, QString("font") + QString::number(i), MusEGlobal::config.fonts[i].toString());
             }
             

--- a/muse3/muse/helper.cpp
+++ b/muse3/muse/helper.cpp
@@ -1956,7 +1956,7 @@ void loadStyleSheetFile(const QString& s)
 void updateThemeAndStyle(bool forceStyle)
 {
   // Note that setting a stylesheet completely takes over the font until blanked again.
-  qApp->setFont(MusEGlobal::config.fonts[0]);
+//  qApp->setFont(MusEGlobal::config.fonts[0]); // has no effect
   loadStyleSheetFile(MusEGlobal::config.styleSheetFile);
   loadTheme(MusEGlobal::config.style, forceStyle || !MusEGlobal::config.styleSheetFile.isEmpty());
 }


### PR DESCRIPTION
This removes font 0 from the settings and replaces it by the actual application font set by Qt style or in a stylesheet, as discussed in #750.