### PR TITLE
New options for font settings

### DIFF
--- a/muse3/muse/app.cpp
+++ b/muse3/muse/app.cpp
@@ -1043,6 +1043,14 @@ MusE::MusE() : QMainWindow()
       MusEGlobal::config.fonts[0].setPointSize(font().pointSize());
       MusEGlobal::config.fonts[0].setBold(font().bold());
       MusEGlobal::config.fonts[0].setItalic(font().italic());
+
+      int fs = font().pointSize();
+      MusEGlobal::config.fonts[1].setPointSize(qRound(fs * MusEGlobal::FntFac::F1));
+      MusEGlobal::config.fonts[2].setPointSize(qRound(fs * MusEGlobal::FntFac::F2));
+      MusEGlobal::config.fonts[3].setPointSize(qRound(fs * MusEGlobal::FntFac::F3));
+      MusEGlobal::config.fonts[4].setPointSize(qRound(fs * MusEGlobal::FntFac::F4));
+      MusEGlobal::config.fonts[5].setPointSize(qRound(fs * MusEGlobal::FntFac::F5));
+      MusEGlobal::config.fonts[6].setPointSize(qRound(fs * MusEGlobal::FntFac::F6));
       }
 
 //---------------------------------------------------------

--- a/muse3/muse/components/appearance.cpp
+++ b/muse3/muse/components/appearance.cpp
@@ -504,6 +504,7 @@ void Appearance::resetValues()
       *backupConfig = MusEGlobal::config;  // init with global config values
       styleSheetPath->setText(config->styleSheetFile);
       updateFonts();
+      cbAutoAdjustFontSize->setChecked(config->autoAdjustFontSize);
 
       setConfigurationColors();
       
@@ -834,6 +835,7 @@ bool Appearance::apply()
       config->canvasShowGrid = arrGrid->isChecked();
       config->globalAlphaBlend = globalAlphaVal->value();
       config->maxAliasedPointSize = maxAliasedPointSize->value();
+      config->autoAdjustFontSize = cbAutoAdjustFontSize->isChecked();
 
       if (config->iconSize != iconSizeSpin->value()) {
           restart_required = true;
@@ -1670,3 +1672,24 @@ void Appearance::browseFont(int n)
       }
 
 } // namespace MusEGui
+
+void MusEGui::Appearance::on_pbAdjustFontSizes_clicked()
+{
+    int fs = fontSize0->value();
+    fontSize1->setValue(qRound(fs * MusEGlobal::FntFac::F1));
+    fontSize2->setValue(qRound(fs * MusEGlobal::FntFac::F2));
+    fontSize3->setValue(qRound(fs * MusEGlobal::FntFac::F3));
+    fontSize4->setValue(qRound(fs * MusEGlobal::FntFac::F4));
+    fontSize5->setValue(qRound(fs * MusEGlobal::FntFac::F5));
+    fontSize6->setValue(qRound(fs * MusEGlobal::FntFac::F6));
+}
+
+void MusEGui::Appearance::on_pbSetFontFamily_clicked()
+{
+    fontName1->setText(fontName0->text());
+    fontName2->setText(fontName0->text());
+    fontName3->setText(fontName0->text());
+    fontName4->setText(fontName0->text());
+    fontName5->setText(fontName0->text());
+    fontName6->setText(fontName0->text());
+}

--- a/muse3/muse/components/appearance.h
+++ b/muse3/muse/components/appearance.h
@@ -158,7 +158,12 @@ class Appearance : public QDialog, public Ui::AppearanceDialogBase {
       ~Appearance();
       void resetValues();
       static QString& getSetDefaultStyle(const QString *newStyle = NULL);
-      };
+private slots:
+      void on_pbSetFontFamily_clicked();
+
+private slots:
+      void on_pbAdjustFontSizes_clicked();
+};
 
 } // namespace MusEGui
 

--- a/muse3/muse/components/appearancebase.ui
+++ b/muse3/muse/components/appearancebase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>568</width>
-    <height>707</height>
+    <height>702</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -1361,22 +1361,6 @@
             </item>
            </layout>
           </item>
-          <item>
-           <spacer name="spacer3">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::Expanding</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>23</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
          </layout>
         </widget>
        </item>
@@ -1386,7 +1370,54 @@
           <string>Fonts</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_6">
-          <item row="2" column="1">
+          <item row="7" column="4">
+           <widget class="QCheckBox" name="italic0">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="text">
+             <string>Italic</string>
+            </property>
+           </widget>
+          </item>
+          <item row="11" column="2">
+           <widget class="QSpinBox" name="fontSize4">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="1">
+           <widget class="QLineEdit" name="fontName2">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="10" column="2">
+           <widget class="QSpinBox" name="fontSize3">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0" colspan="4">
+           <widget class="QLabel" name="label_7">
+            <property name="text">
+             <string>Distribute current system font family to all other fonts</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="1">
            <widget class="QLineEdit" name="fontName1">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -1396,87 +1427,51 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="4">
-           <widget class="QCheckBox" name="italic1">
+          <item row="13" column="4">
+           <widget class="QCheckBox" name="italic6">
             <property name="text">
              <string>Italic</string>
             </property>
            </widget>
           </item>
-          <item row="6" column="3">
-           <widget class="QCheckBox" name="bold5">
+          <item row="7" column="0">
+           <widget class="QLabel" name="textLabel3">
+            <property name="text">
+             <string>System</string>
+            </property>
+            <property name="wordWrap">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="11" column="4">
+           <widget class="QCheckBox" name="italic4">
+            <property name="text">
+             <string>Italic</string>
+            </property>
+           </widget>
+          </item>
+          <item row="13" column="5">
+           <widget class="QToolButton" name="fontBrowse6">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="11" column="3">
+           <widget class="QCheckBox" name="bold4">
             <property name="text">
              <string>Bold</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="5">
-           <widget class="QToolButton" name="fontBrowse2">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>...</string>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="0">
-           <widget class="QLabel" name="textLabel7_2">
-            <property name="text">
-             <string>Font 5</string>
-            </property>
-            <property name="wordWrap">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="textLabel4">
-            <property name="text">
-             <string>Font 1</string>
-            </property>
-            <property name="wordWrap">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="5">
-           <widget class="QToolButton" name="fontBrowse3">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>...</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="textLabel6">
-            <property name="text">
-             <string>Font 3</string>
-            </property>
-            <property name="wordWrap">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="2">
-           <widget class="QSpinBox" name="fontSize2">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1">
+          <item row="10" column="1">
            <widget class="QLineEdit" name="fontName3">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -1486,44 +1481,96 @@
             </property>
            </widget>
           </item>
-          <item row="6" column="1">
-           <widget class="QLineEdit" name="fontName5">
+          <item row="0" column="0" colspan="5">
+           <widget class="QCheckBox" name="cbAutoAdjustFontSize">
+            <property name="toolTip">
+             <string>Font sizes for fonts 1-6 are determined at every program start, to optimally match the currently used system font.
+Disable if you want to set fixed sizes in the font settings below.
+
+Default scaling factors:
+Font 1: 70%
+Font 2: 100%
+Font 3: 100%
+Font 4: 80%
+Font 5: 80%
+Font 6: 80%</string>
+            </property>
+            <property name="text">
+             <string>Calculate and apply relative font sizes dynamically at program start</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="3">
+           <widget class="QCheckBox" name="bold2">
+            <property name="text">
+             <string>Bold</string>
+            </property>
+           </widget>
+          </item>
+          <item row="13" column="0">
+           <widget class="QLabel" name="textLabel7_3">
+            <property name="text">
+             <string>Font 6</string>
+            </property>
+            <property name="wordWrap">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="11" column="5">
+           <widget class="QToolButton" name="fontBrowse4">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
+            <property name="text">
+             <string>...</string>
+            </property>
            </widget>
           </item>
-          <item row="1" column="1">
-           <widget class="QLineEdit" name="fontName0">
+          <item row="8" column="4">
+           <widget class="QCheckBox" name="italic1">
+            <property name="text">
+             <string>Italic</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="0">
+           <widget class="QLabel" name="textLabel4">
+            <property name="text">
+             <string>Font 1</string>
+            </property>
+            <property name="wordWrap">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="10" column="0">
+           <widget class="QLabel" name="textLabel6">
+            <property name="text">
+             <string>Font 3</string>
+            </property>
+            <property name="wordWrap">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="3">
+           <widget class="QCheckBox" name="bold0">
             <property name="enabled">
              <bool>false</bool>
             </property>
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="4">
-           <widget class="QCheckBox" name="italic3">
             <property name="text">
-             <string>Italic</string>
+             <string>Bold</string>
             </property>
            </widget>
           </item>
-          <item row="7" column="4">
-           <widget class="QCheckBox" name="italic6">
-            <property name="text">
-             <string>Italic</string>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="2">
+          <item row="14" column="2">
            <widget class="QSpinBox" name="maxAliasedPointSize">
             <property name="toolTip">
              <string>At what point size to switch from aliased text
@@ -1559,25 +1606,15 @@ The font family is forced to 'Sans', which should
             </property>
            </widget>
           </item>
-          <item row="3" column="3">
-           <widget class="QCheckBox" name="bold2">
+          <item row="9" column="4">
+           <widget class="QCheckBox" name="italic2">
             <property name="text">
-             <string>Bold</string>
+             <string>Italic</string>
             </property>
            </widget>
           </item>
-          <item row="7" column="1">
-           <widget class="QLineEdit" name="fontName6">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="2">
-           <widget class="QSpinBox" name="fontSize4">
+          <item row="12" column="2">
+           <widget class="QSpinBox" name="fontSize5">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -1586,135 +1623,7 @@ The font family is forced to 'Sans', which should
             </property>
            </widget>
           </item>
-          <item row="7" column="0">
-           <widget class="QLabel" name="textLabel7_3">
-            <property name="text">
-             <string>Font 6</string>
-            </property>
-            <property name="wordWrap">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="3">
-           <widget class="QCheckBox" name="bold4">
-            <property name="text">
-             <string>Bold</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="1">
-           <widget class="QLineEdit" name="fontName4">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="4">
-           <widget class="QCheckBox" name="italic5">
-            <property name="text">
-             <string>Italic</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="textLabel3">
-            <property name="text">
-             <string>System</string>
-            </property>
-            <property name="wordWrap">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="3">
-           <widget class="QCheckBox" name="bold0">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="text">
-             <string>Bold</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QLabel" name="textLabel2">
-            <property name="text">
-             <string>Family</string>
-            </property>
-            <property name="wordWrap">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="textLabel7">
-            <property name="text">
-             <string>Font 4</string>
-            </property>
-            <property name="wordWrap">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="4">
-           <widget class="QCheckBox" name="italic0">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="text">
-             <string>Italic</string>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="2">
-           <widget class="QSpinBox" name="fontSize6">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="5">
-           <widget class="QToolButton" name="fontBrowse5">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>...</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="4">
-           <widget class="QCheckBox" name="italic4">
-            <property name="text">
-             <string>Italic</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="3">
-           <widget class="QCheckBox" name="bold3">
-            <property name="text">
-             <string>Bold</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="3">
-           <widget class="QCheckBox" name="bold1">
-            <property name="text">
-             <string>Bold</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="5">
+          <item row="8" column="5">
            <widget class="QToolButton" name="fontBrowse1">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
@@ -1727,7 +1636,87 @@ The font family is forced to 'Sans', which should
             </property>
            </widget>
           </item>
-          <item row="8" column="1">
+          <item row="13" column="2">
+           <widget class="QSpinBox" name="fontSize6">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="5">
+           <widget class="QToolButton" name="fontBrowse2">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="2">
+           <widget class="QSpinBox" name="fontSize1">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="12" column="0">
+           <widget class="QLabel" name="textLabel7_2">
+            <property name="text">
+             <string>Font 5</string>
+            </property>
+            <property name="wordWrap">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="1">
+           <widget class="QLabel" name="textLabel2">
+            <property name="text">
+             <string>Family</string>
+            </property>
+            <property name="wordWrap">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="2">
+           <widget class="QSpinBox" name="fontSize2">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="12" column="3">
+           <widget class="QCheckBox" name="bold5">
+            <property name="text">
+             <string>Bold</string>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="0">
+           <widget class="QLabel" name="textLabel5">
+            <property name="text">
+             <string>Font 2</string>
+            </property>
+            <property name="wordWrap">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="14" column="1">
            <widget class="QLabel" name="label_14">
             <property name="toolTip">
              <string/>
@@ -1740,17 +1729,67 @@ The font family is forced to 'Sans', which should
             </property>
            </widget>
           </item>
-          <item row="4" column="2">
-           <widget class="QSpinBox" name="fontSize3">
+          <item row="13" column="1">
+           <widget class="QLineEdit" name="fontName6">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
            </widget>
           </item>
-          <item row="1" column="2">
+          <item row="12" column="5">
+           <widget class="QToolButton" name="fontBrowse5">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="13" column="3">
+           <widget class="QCheckBox" name="bold6">
+            <property name="text">
+             <string>Bold</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="1">
+           <widget class="QLineEdit" name="fontName0">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="3">
+           <widget class="QCheckBox" name="bold1">
+            <property name="text">
+             <string>Bold</string>
+            </property>
+           </widget>
+          </item>
+          <item row="11" column="1">
+           <widget class="QLineEdit" name="fontName4">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="2">
            <widget class="QSpinBox" name="fontSize0">
             <property name="enabled">
              <bool>false</bool>
@@ -1763,28 +1802,42 @@ The font family is forced to 'Sans', which should
             </property>
            </widget>
           </item>
-          <item row="2" column="2">
-           <widget class="QSpinBox" name="fontSize1">
+          <item row="2" column="4">
+           <widget class="QPushButton" name="pbSetFontFamily">
+            <property name="text">
+             <string>Insert</string>
+            </property>
+           </widget>
+          </item>
+          <item row="10" column="4">
+           <widget class="QCheckBox" name="italic3">
+            <property name="text">
+             <string>Italic</string>
+            </property>
+           </widget>
+          </item>
+          <item row="12" column="1">
+           <widget class="QLineEdit" name="fontName5">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="textLabel5">
+          <item row="11" column="0">
+           <widget class="QLabel" name="textLabel7">
             <property name="text">
-             <string>Font 2</string>
+             <string>Font 4</string>
             </property>
             <property name="wordWrap">
              <bool>false</bool>
             </property>
            </widget>
           </item>
-          <item row="7" column="5">
-           <widget class="QToolButton" name="fontBrowse6">
+          <item row="10" column="5">
+           <widget class="QToolButton" name="fontBrowse3">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
               <horstretch>0</horstretch>
@@ -1797,40 +1850,6 @@ The font family is forced to 'Sans', which should
            </widget>
           </item>
           <item row="6" column="2">
-           <widget class="QSpinBox" name="fontSize5">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="4">
-           <widget class="QCheckBox" name="italic2">
-            <property name="text">
-             <string>Italic</string>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="3">
-           <widget class="QCheckBox" name="bold6">
-            <property name="text">
-             <string>Bold</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QLineEdit" name="fontName2">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
            <widget class="QLabel" name="TextLabel1_1">
             <property name="text">
              <string>Size (pt)</string>
@@ -1840,16 +1859,31 @@ The font family is forced to 'Sans', which should
             </property>
            </widget>
           </item>
-          <item row="5" column="5">
-           <widget class="QToolButton" name="fontBrowse4">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
+          <item row="12" column="4">
+           <widget class="QCheckBox" name="italic5">
             <property name="text">
-             <string>...</string>
+             <string>Italic</string>
+            </property>
+           </widget>
+          </item>
+          <item row="10" column="3">
+           <widget class="QCheckBox" name="bold3">
+            <property name="text">
+             <string>Bold</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="4">
+           <widget class="QPushButton" name="pbAdjustFontSizes">
+            <property name="text">
+             <string>Insert</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0" colspan="4">
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>Fill in optimal font sizes in relation to the system font</string>
             </property>
            </widget>
           </item>
@@ -1859,6 +1893,22 @@ The font family is forced to 'Sans', which should
       </layout>
      </widget>
     </widget>
+   </item>
+   <item>
+    <spacer name="spacer3">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Expanding</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item>
     <layout class="QHBoxLayout">

--- a/muse3/muse/conf.cpp
+++ b/muse3/muse/conf.cpp
@@ -772,8 +772,10 @@ void readConfiguration(Xml& xml, bool doReadMidiPortConfig, bool doReadGlobalCon
                               MusEGlobal::config.fonts[5].fromString(xml.parse1());
                         else if (tag == "font6")
                               MusEGlobal::config.fonts[6].fromString(xml.parse1());
+                        else if (tag == "autoAdjustFontSize")
+                              MusEGlobal::config.autoAdjustFontSize = xml.parseInt();
                         else if (tag == "globalAlphaBlend")
-                              MusEGlobal::config.globalAlphaBlend = xml.parseInt();
+                            MusEGlobal::config.globalAlphaBlend = xml.parseInt();
                         else if (tag == "palette0")
                               MusEGlobal::config.palette[0] = readColor(xml);
                         else if (tag == "palette1")
@@ -1893,6 +1895,7 @@ void MusE::writeGlobalConfiguration(int level, MusECore::Xml& xml) const
 //          for (int i = 0; i < NUM_FONTS; ++i) {
             xml.strTag(level, QString("font") + QString::number(i), MusEGlobal::config.fonts[i].toString());
             }
+      xml.intTag(level, "autoAdjustFontSize", MusEGlobal::config.autoAdjustFontSize);
             
       xml.intTag(level, "globalAlphaBlend", MusEGlobal::config.globalAlphaBlend);
       

--- a/muse3/muse/gconfig.cpp
+++ b/muse3/muse/gconfig.cpp
@@ -122,15 +122,16 @@ GlobalConfigValues config = {
       QColor(0, 0, 0),        // bigTimeBackgroundColor;
       QColor(200, 192, 171),  // waveEditBackgroundColor;
       {
-        QFont(QString("helvetica"), 10, QFont::Normal),
-        QFont(QString("helvetica"), 7,  QFont::Normal),    // Mixer strips and midi track info panel
-        QFont(QString("helvetica"), 10, QFont::Normal),
-        QFont(QString("helvetica"), 10, QFont::Bold),
-        QFont(QString("helvetica"), 8,  QFont::Normal),    // Small numbers: Timescale and markers, part name overlay
-        QFont(QString("helvetica"), 8,  QFont::Bold),      // Small bold numbers such as marker text
-        QFont(QString("helvetica"), 8,  QFont::Bold, true)  // Mixer strip labels. Looks and fits better with bold + italic than bold alone,
+        QFont(QString("sans-serif"), 10, QFont::Normal),
+        QFont(QString("sans-serif"), 7,  QFont::Normal),    // Mixer strips and midi track info panel
+        QFont(QString("sans-serif"), 10, QFont::Normal),
+        QFont(QString("sans-serif"), 10, QFont::Bold),
+        QFont(QString("sans-serif"), 8,  QFont::Normal),    // Small numbers: Timescale and markers, part name overlay
+        QFont(QString("sans-serif"), 8,  QFont::Bold),      // Small bold numbers such as marker text
+        QFont(QString("sans-serif"), 8,  QFont::Bold, true)  // Mixer strip labels. Looks and fits better with bold + italic than bold alone,
                                                         //  at the price of only few more pixels than Normal mode.
         },
+      true,                         // autoAdjustFontSize;
       QColor(84, 97, 114),          // trackBg;
       QColor(109, 174, 178),        // selected track Bg;
       QColor(0x00, 0x00, 0x00),     // selected track Fg;

--- a/muse3/muse/gconfig.h
+++ b/muse3/muse/gconfig.h
@@ -48,6 +48,16 @@ enum newDrumRecordCondition_t
 
 namespace MusEGlobal {
 
+// font scaling factors
+struct FntFac {
+    static constexpr double F1 = 0.7;
+    static constexpr double F2 = 1.0;
+    static constexpr double F3 = 1.0;
+    static constexpr double F4 = 0.8;
+    static constexpr double F5 = 0.8;
+    static constexpr double F6 = 0.8;
+};
+
 // Obsolete. There is only 'New' drum tracks now.
 // enum drumTrackPreference_t
 // {
@@ -174,6 +184,7 @@ struct GlobalConfigValues {
       QColor bigTimeBackgroundColor;
       QColor waveEditBackgroundColor;
       QFont fonts[NUM_FONTS];
+      bool autoAdjustFontSize;
       QColor trackBg;
       QColor selectTrackBg;
       QColor selectTrackFg;


### PR DESCRIPTION
As discussed in other places...
I think I found a way to enable scaling the fonts automatically without any incompatible changes. On the other hand, full customizability is still ensured, as the user can switch the new option off and set the font sizes individually as desired.

![image](https://user-images.githubusercontent.com/10009541/72632393-7ae4b100-3956-11ea-972c-4956cddf8171.png)
