### PR TITLE
Fix styles - different color for disabled widgets

### DIFF
--- a/muse3/share/themes/Ardour.qss
+++ b/muse3/share/themes/Ardour.qss
@@ -3,6 +3,10 @@ QWidget {
       color: rgb(193,193,197);
 }
 
+QWidget:!enabled {
+	color: rgb(150,150,154);
+}
+
 QToolBar QToolButton {
       background-color: rgb(93,94,106);
       border-color: rgb(70,70,70);
@@ -12,15 +16,6 @@ QToolBar QToolButton {
       padding: 1px;
 
 }
-
-/* What's this doing here? QAction is not a QWidget
-QAction {
-      background-color: rgb(150,150,150);
-     spacing: 3px;
-     padding: 1px 4px;
-     background: transparent;
-     border-radius: 4px;
- } */
 
 /*QMenu::item {
      background-color: rgb(150,150,150);

--- a/muse3/share/themes/Dark Theme.qss
+++ b/muse3/share/themes/Dark Theme.qss
@@ -3,6 +3,10 @@ QWidget {
       color: rgb(120,120,120);
 }
 
+QWidget:!enabled {
+	color: rgb(80,80,80);
+}
+
 QToolBar QToolButton {
       background-color: rgb(50,50,50);
       border-color: rgb(70,70,70);
@@ -12,15 +16,6 @@ QToolBar QToolButton {
       padding: 1px;
 
 }
-
-/* What's this doing here? QAction is not a QWidget
-QAction {
-      background-color: rgb(150,150,150);
-     spacing: 3px;
-     padding: 1px 4px;
-     background: transparent;
-     border-radius: 4px;
- }*/
 
 QMenu::item:selected {
      background-color: rgb(40,90,40);


### PR DESCRIPTION
I noticed that there was absolutely no difference between active and inactive widgets in Dark and Ardour styles. I made the colour a little darker for both so the difference is visible.