### PR TITLE
Fix event copy selection in piano roll (fixes #747)

### DIFF
--- a/muse3/muse/midiedit/prcanvas.cpp
+++ b/muse3/muse/midiedit/prcanvas.cpp
@@ -1012,7 +1012,9 @@ bool PianoCanvas::moveItem(MusECore::Undo& operations, CItem* item, const QPoint
       NEvent* nevent = (NEvent*) item;
       MusECore::Event event    = nevent->event();
       int npitch     = y2pitch(pos.y());
+      event.setSelected(false);
       MusECore::Event newEvent = (dtype == MOVE_COPY) ? event.duplicate() : event.clone();
+      newEvent.setSelected(true);
       int x          = pos.x();
       if (x < 0)
             x = 0;


### PR DESCRIPTION
The selection only seems to work when set directly in this function.
All the later selection modifications for the dragged events in the higher level code don't have any effect.