### PR TITLE
Fix custom columns handling

### DIFF
--- a/muse3/muse/arranger/arranger.cpp
+++ b/muse3/muse/arranger/arranger.cpp
@@ -79,8 +79,7 @@
 
 namespace MusEGui {
 
-std::vector<Arranger::custom_col_t> Arranger::custom_columns;     //FINDMICH TODO: eliminate all usage of new_custom_columns
-std::vector<Arranger::custom_col_t> Arranger::new_custom_columns; //and instead let the arranger update without restarting muse!
+std::vector<Arranger::custom_col_t> Arranger::custom_columns;
 QByteArray Arranger::header_state;
 static const char* gArrangerRasterStrings[] = {
       QT_TRANSLATE_NOOP("MusEGui::Arranger", "Off"), QT_TRANSLATE_NOOP("MusEGui::Arranger", "Bar"), "1/2", "1/4", "1/8", "1/16"
@@ -91,12 +90,12 @@ void Arranger::writeCustomColumns(int level, MusECore::Xml& xml)
 {
   xml.tag(level++, "custom_columns");
   
-  for (unsigned i=0;i<new_custom_columns.size();i++)
+  for (unsigned i = 0; i < custom_columns.size(); i++)
   {
     xml.tag(level++, "column");
-    xml.strTag(level, "name", new_custom_columns[i].name);
-    xml.intTag(level, "ctrl", new_custom_columns[i].ctrl);
-    xml.intTag(level, "affected_pos", new_custom_columns[i].affected_pos);
+    xml.strTag(level, "name", custom_columns[i].name);
+    xml.intTag(level, "ctrl", custom_columns[i].ctrl);
+    xml.intTag(level, "affected_pos", custom_columns[i].affected_pos);
     xml.etag(--level, "column");
   }
   
@@ -113,7 +112,6 @@ void Arranger::readCustomColumns(MusECore::Xml& xml)
             switch (token) {
                   case MusECore::Xml::Error:
                   case MusECore::Xml::End:
-                        new_custom_columns=custom_columns;
                         return;
                   case MusECore::Xml::TagStart:
                         if (tag == "column")
@@ -124,7 +122,6 @@ void Arranger::readCustomColumns(MusECore::Xml& xml)
                   case MusECore::Xml::TagEnd:
                         if (tag == "custom_columns")
                         {
-                              new_custom_columns=custom_columns;
                               return;
                         }
                   default:
@@ -398,7 +395,7 @@ Arranger::Arranger(ArrangerView* parent, const char* name)
       header->setColumnLabel(tr("Automation"), COL_AUTOMATION);
       header->setColumnLabel(tr("Clef"), COL_CLEF);
       for (unsigned i = 0; i < custom_columns.size(); i++)
-         header->setColumnLabel(custom_columns[i].name, COL_CUSTOM_MIDICTRL_OFFSET+i);
+         header->setColumnLabel(custom_columns[i].name, COL_CUSTOM_MIDICTRL_OFFSET + i);
 
       header->setSectionResizeMode(COL_TRACK_IDX, QHeaderView::Interactive);
       header->setSectionResizeMode(COL_INPUT_MONITOR, QHeaderView::Fixed);
@@ -1328,5 +1325,20 @@ void Arranger::horizontalZoom(int mag, const QPoint& glob_pos)
     hscroll->setMag(hscroll->mag() + mag, cp.x());
 }
 
+void Arranger::updateHeaderCustomColumns()
+{
+    for (int i = COL_CUSTOM_MIDICTRL_OFFSET; i < header->count(); i++)
+        header->removeColumn(i);
+
+    header->headerDataChanged(Qt::Horizontal, COL_CUSTOM_MIDICTRL_OFFSET, header->count());
+
+    for (unsigned i = 0; i < custom_columns.size(); i++) {
+        header->setColumnLabel(custom_columns[i].name, COL_CUSTOM_MIDICTRL_OFFSET + i);
+        header->showSection(COL_CUSTOM_MIDICTRL_OFFSET + i);
+    }
+
+    setHeaderSizes();
+    list->redraw();
+}
 
 } // namespace MusEGui

--- a/muse3/muse/arranger/arranger.cpp
+++ b/muse3/muse/arranger/arranger.cpp
@@ -397,6 +397,8 @@ Arranger::Arranger(ArrangerView* parent, const char* name)
       header->setColumnLabel(tr("T"), COL_TIMELOCK);
       header->setColumnLabel(tr("Automation"), COL_AUTOMATION);
       header->setColumnLabel(tr("Clef"), COL_CLEF);
+      for (unsigned i = 0; i < custom_columns.size(); i++)
+         header->setColumnLabel(custom_columns[i].name, COL_CUSTOM_MIDICTRL_OFFSET+i);
 
       header->setSectionResizeMode(COL_TRACK_IDX, QHeaderView::Interactive);
       header->setSectionResizeMode(COL_INPUT_MONITOR, QHeaderView::Fixed);
@@ -410,7 +412,7 @@ Arranger::Arranger(ArrangerView* parent, const char* name)
       header->setSectionResizeMode(COL_TIMELOCK, QHeaderView::Fixed);
       header->setSectionResizeMode(COL_AUTOMATION, QHeaderView::Interactive);
       header->setSectionResizeMode(COL_CLEF, QHeaderView::Interactive);
-      for (unsigned i=0;i<custom_columns.size();i++)
+      for (unsigned i = 0; i < custom_columns.size(); i++)
         header->setSectionResizeMode(COL_CUSTOM_MIDICTRL_OFFSET+i, QHeaderView::Interactive);
 
       // 04/18/17 Time lock remains unused. Disabled until a use is found.

--- a/muse3/muse/arranger/arranger.h
+++ b/muse3/muse/arranger/arranger.h
@@ -168,8 +168,7 @@ class Arranger : public QWidget {
           affected_pos=a;
         }
       };
-      static std::vector<custom_col_t> custom_columns;     //FINDMICH TODO: eliminate all usage of new_custom_columns
-      static std::vector<custom_col_t> new_custom_columns; //and instead let the arranger update without restarting muse!
+      static std::vector<custom_col_t> custom_columns;
 
       Arranger(ArrangerView* parent, const char* name = 0);
 
@@ -193,6 +192,7 @@ class Arranger : public QWidget {
       void clear();
       void songIsClearing() { canvas->songIsClearing(); }
       void setDefaultSplitterSizes();
+      void updateHeaderCustomColumns();
       
       unsigned cursorValue() { return cursVal; }
       

--- a/muse3/muse/arranger/arrangerview.cpp
+++ b/muse3/muse/arranger/arrangerview.cpp
@@ -924,11 +924,15 @@ void ArrangerView::globalSplitSel() { MusECore::globalSplit(true); }
 
 void ArrangerView::configCustomColumns()
 {
-  ArrangerColumns* dialog = new ArrangerColumns(this);
-  dialog->exec();
-  delete dialog;
-  
-  QMessageBox::information(this, tr("Changed Settings"), tr("The changed arranger column settings\ncannot be applied while MusE is running.\nTo apply the changes, please restart MusE."));
+    auto tmp = Arranger::custom_columns;
+    ArrangerColumns* dialog = new ArrangerColumns(this);
+    int rc = dialog->exec();
+    delete dialog;
+
+    if (rc == QDialog::Accepted)
+        arranger->updateHeaderCustomColumns();
+    else
+        Arranger::custom_columns = tmp;
 }
 
 } // namespace MusEGui

--- a/muse3/muse/arranger/arrangerview.h
+++ b/muse3/muse/arranger/arrangerview.h
@@ -117,12 +117,12 @@ class ArrangerView : public TopWin
 		void globalCut();
 		void globalInsert();
 		void globalSplit();
-                void globalCutSel();
-                void globalInsertSel();
-                void globalSplitSel();
-                void cmd(int);
-                void addNewTrack(QAction* action);
-                void configCustomColumns();
+        void globalCutSel();
+        void globalInsertSel();
+        void globalSplitSel();
+        void cmd(int);
+        void addNewTrack(QAction* action);
+        void configCustomColumns();
 
 	signals:
 		void isDeleting(MusEGui::TopWin*);

--- a/muse3/muse/arranger/tlist.cpp
+++ b/muse3/muse/arranger/tlist.cpp
@@ -482,16 +482,16 @@ void TList::paint(const QRect& r)
                                 }
                                 break;
                           default:
-                                if (section>=COL_CUSTOM_MIDICTRL_OFFSET)
+                                if (section >= COL_CUSTOM_MIDICTRL_OFFSET)
                                 {
                                   if (track->isMidiTrack())
                                   {
-                                    int col_ctrl_no=Arranger::custom_columns[section-COL_CUSTOM_MIDICTRL_OFFSET].ctrl;
+                                    int col_ctrl_no=Arranger::custom_columns[section - COL_CUSTOM_MIDICTRL_OFFSET].ctrl;
                                     MusECore::MidiTrack* mt=dynamic_cast<MusECore::MidiTrack*>(track);
                                     MusECore::MidiPort* mp = &MusEGlobal::midiPorts[mt->outPort()];
                                     MusECore::MidiController* mctl = mp->midiController(col_ctrl_no);
                                     int val;
-                                    if (Arranger::custom_columns[section-COL_CUSTOM_MIDICTRL_OFFSET].affected_pos ==
+                                    if (Arranger::custom_columns[section - COL_CUSTOM_MIDICTRL_OFFSET].affected_pos ==
                                         Arranger::custom_col_t::AFFECT_BEGIN)
                                       val=mt->getControllerChangeAtTick(0,col_ctrl_no,MusECore::CTRL_VAL_UNKNOWN);
                                     else

--- a/muse3/muse/components/arrangercolumns.cpp
+++ b/muse3/muse/components/arrangercolumns.cpp
@@ -111,9 +111,9 @@ void ArrangerColumns::somethingChanged()
 		int lnum = spinBoxLCtrlNo->value();
 		int ctrl_number = MusECore::MidiController::genNum(t, hnum, lnum);
 
-		Arranger::new_custom_columns[row].name=nameEdit->text();
-		Arranger::new_custom_columns[row].ctrl=ctrl_number;
-		Arranger::new_custom_columns[row].affected_pos=(affectBeginButton->isChecked() ? Arranger::custom_col_t::AFFECT_BEGIN : Arranger::custom_col_t::AFFECT_CPOS);
+        Arranger::custom_columns[row].name=nameEdit->text();
+        Arranger::custom_columns[row].ctrl=ctrl_number;
+        Arranger::custom_columns[row].affected_pos=(affectBeginButton->isChecked() ? Arranger::custom_col_t::AFFECT_BEGIN : Arranger::custom_col_t::AFFECT_CPOS);
 
 		listWidget->currentItem()->setText(getListEntryString(row));
 	}
@@ -121,14 +121,14 @@ void ArrangerColumns::somethingChanged()
 
 QString ArrangerColumns::getListEntryString(int row)
 {
-	return "\""+Arranger::new_custom_columns[row].name+"\": "+MusECore::midiCtrlNumString(Arranger::new_custom_columns[row].ctrl, true);
+    return "\""+Arranger::custom_columns[row].name+"\": "+MusECore::midiCtrlNumString(Arranger::custom_columns[row].ctrl, true);
 }
 
 void ArrangerColumns::initList()
 {
 	listWidget->clear();
 	
-	for (unsigned int i=0;i<Arranger::new_custom_columns.size(); i++)
+    for (unsigned int i=0;i<Arranger::custom_columns.size(); i++)
 		listWidget->addItem(getListEntryString(i));
 }
 
@@ -146,8 +146,8 @@ void ArrangerColumns::itemSelected(int i)
 		frame->setEnabled(true);
 		delBtn->setEnabled(true);
 		
-		nameEdit->setText(Arranger::new_custom_columns[i].name);
-		int num=Arranger::new_custom_columns[i].ctrl;
+        nameEdit->setText(Arranger::custom_columns[i].name);
+        int num=Arranger::custom_columns[i].ctrl;
 		int idx = ctrlType->findData(MusECore::midiControllerType(num));
 		if(idx != -1)
 		  ctrlType->setCurrentIndex(idx);
@@ -161,8 +161,8 @@ void ArrangerColumns::itemSelected(int i)
 		else
 			spinBoxLCtrlNo->setValue(0);
 		
-		affectBeginButton->setChecked(Arranger::new_custom_columns[i].affected_pos == Arranger::custom_col_t::AFFECT_BEGIN);
-		affectCposButton->setChecked(Arranger::new_custom_columns[i].affected_pos == Arranger::custom_col_t::AFFECT_CPOS);
+        affectBeginButton->setChecked(Arranger::custom_columns[i].affected_pos == Arranger::custom_col_t::AFFECT_BEGIN);
+        affectCposButton->setChecked(Arranger::custom_columns[i].affected_pos == Arranger::custom_col_t::AFFECT_CPOS);
 	}
 	
 	ignoreSomethingChanged=false;
@@ -170,7 +170,7 @@ void ArrangerColumns::itemSelected(int i)
 
 void ArrangerColumns::addEntry()
 {
-	Arranger::new_custom_columns.push_back(Arranger::custom_col_t(0,QString("?")));
+    Arranger::custom_columns.push_back(Arranger::custom_col_t(0,QString("?")));
 	listWidget->addItem(getListEntryString(listWidget->count()));
 	listWidget->setCurrentRow(listWidget->count()-1);
 }
@@ -181,9 +181,9 @@ void ArrangerColumns::delEntry()
 	
 	if (row!=-1)
 	{
-		std::vector<Arranger::custom_col_t>::iterator it=Arranger::new_custom_columns.begin();
+        std::vector<Arranger::custom_col_t>::iterator it=Arranger::custom_columns.begin();
 		advance(it, row);
-		Arranger::new_custom_columns.erase(it);
+        Arranger::custom_columns.erase(it);
 
 		initList();
 		

--- a/muse3/muse/components/header.cpp
+++ b/muse3/muse/components/header.cpp
@@ -55,6 +55,7 @@ void Header::readStatus(MusECore::Xml& xml)
                 case MusECore::Xml::TagEnd:
                       if (tag ==objectName())
                             return;
+                      break;
                 default:
                       break;
                 }
@@ -157,15 +158,17 @@ void Header::mousePressEvent ( QMouseEvent * e )
     p->disconnect();
     p->clear();
     p->setTitle(tr("Track Info Columns"));
-    QAction* act = 0;
+    QAction* act = nullptr;
 
     for(int i=0; i < count(); i++) {
-        QIcon icon = itemModel->horizontalHeaderItem(logicalIndex(i))->icon();
+        const QIcon& icon = itemModel->horizontalHeaderItem(logicalIndex(i))->icon();
         if (!icon.isNull()) {
-            act = p->addAction(icon, "\t - "+ itemModel->horizontalHeaderItem(logicalIndex(i))->toolTip());
+            act = p->addAction(icon, "\t - " + itemModel->horizontalHeaderItem(logicalIndex(i))->toolTip());
         } else {
-            act = p->addAction(itemModel->horizontalHeaderItem(logicalIndex(i))->text() +
-                               "\t - "+ itemModel->horizontalHeaderItem(logicalIndex(i))->toolTip());
+            QString tt = itemModel->horizontalHeaderItem(logicalIndex(i))->toolTip();
+            if (tt.isEmpty())
+                tt = tr("Custom column");
+            act = p->addAction(itemModel->horizontalHeaderItem(logicalIndex(i))->text() + "\t - " + tt);
         }
 
         act->setCheckable(true);
@@ -181,15 +184,22 @@ void Header::mousePressEvent ( QMouseEvent * e )
   }
 
   QHeaderView::mousePressEvent(e);
-
 }
+
 void Header::changeColumns(QAction *a)
 {
-  int section = a->data().toInt();
-  if (isSectionHidden(section))
-    showSection(section);
-  else
-    hideSection(section);
+    int section = a->data().toInt();
+    if (isSectionHidden(section))
+        showSection(section);
+    else
+        hideSection(section);
+
+    resizeSection(section, sectionSizeHint(section));
+}
+
+void Header::removeColumn(int col)
+{
+    itemModel->removeColumn(col);
 }
 
 } // namespace MusEGui

--- a/muse3/muse/components/header.h
+++ b/muse3/muse/components/header.h
@@ -51,6 +51,7 @@ class Header : public QHeaderView {
       void setToolTip(int col, const QString &text);
       void setWhatsThis(int col, const QString &text);
       void mousePressEvent ( QMouseEvent * e );
+      void removeColumn(int col);
     private slots:
       void changeColumns(QAction* a);
 };


### PR DESCRIPTION
While I was at the header fixes I noticed that there were some open issues and work in progress related to the custom columns. I tried to finish what was apparently originally intended. I hope I did not miss anything critical.

1. Clean up the two duplicate vectors (custom_columns vs new_custom_columns) and related code.
2. Enable dynamic adding/removing of custom columns (without the need to restart the complete app, as it was the case before).
3. Allow the user to cancel the Custom columns modal dialog, without applying the settings (not possible before).

