### PR TITLE
Pr cascade stylesheets

### DIFF
--- a/muse3/muse/components/appearance.cpp
+++ b/muse3/muse/components/appearance.cpp
@@ -599,6 +599,9 @@ void Appearance::resetValues()
       cursorSizeSpin->blockSignals(true);
       cursorSizeSpin->setValue(config->cursorSize);
       cursorSizeSpin->blockSignals(false);
+
+      cascadeStylesheetsCheckBox->setChecked(config->cascadeStylesheets);
+
       // Grab all the colours.
       updateColorItems();
 

--- a/muse3/muse/components/appearance.cpp
+++ b/muse3/muse/components/appearance.cpp
@@ -847,6 +847,11 @@ bool Appearance::apply()
           config->cursorSize = cursorSizeSpin->value();
       }
 
+      if (config->cascadeStylesheets != cascadeStylesheetsCheckBox->isChecked()) {
+          restart_required = true;
+          config->cascadeStylesheets = cascadeStylesheetsCheckBox->isChecked();
+      }
+
       if (radioButtonDrawOutline->isChecked())
         config->waveDrawing = MusEGlobal::WaveOutLine;
       else

--- a/muse3/muse/components/appearancebase.ui
+++ b/muse3/muse/components/appearancebase.ui
@@ -1384,7 +1384,10 @@
           <item row="1" column="0">
            <widget class="QCheckBox" name="cascadeStylesheetsCheckBox">
             <property name="toolTip">
-             <string>If a user style sheet for the current theme exists and is selected, it will be merged with the default style sheet. The user style sheet takes precedence in case of identical selectors and styles.</string>
+             <string>If a user style sheet for one of  the MusE color schemes exists
+and is selected, it will be merged with the default style sheet
+for this scheme. The user style sheet takes precedence and 
+overwrites identical settings in the default style sheet.</string>
             </property>
             <property name="text">
              <string>Cascade default and user style sheets</string>

--- a/muse3/muse/components/appearancebase.ui
+++ b/muse3/muse/components/appearancebase.ui
@@ -1367,6 +1367,13 @@
           <item row="0" column="0">
            <widget class="QLineEdit" name="styleSheetPath"/>
           </item>
+          <item row="0" column="2">
+           <widget class="QToolButton" name="defaultStyleSheet">
+            <property name="text">
+             <string>...</string>
+            </property>
+           </widget>
+          </item>
           <item row="0" column="1">
            <widget class="QToolButton" name="openStyleSheet">
             <property name="text">
@@ -1374,10 +1381,13 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="2">
-           <widget class="QToolButton" name="defaultStyleSheet">
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="cascadeStylesheetsCheckBox">
+            <property name="toolTip">
+             <string>If a user style sheet for the current theme exists and is selected, it will be merged with the default style sheet. The user style sheet takes precedence in case of identical selectors and styles.</string>
+            </property>
             <property name="text">
-             <string>...</string>
+             <string>Cascade default and user style sheets</string>
             </property>
            </widget>
           </item>

--- a/muse3/muse/conf.cpp
+++ b/muse3/muse/conf.cpp
@@ -1077,6 +1077,9 @@ void readConfiguration(Xml& xml, bool doReadMidiPortConfig, bool doReadGlobalCon
 
                         else if (tag == "cursorSize")
                             MusEGlobal::config.cursorSize = xml.parseInt();
+
+                        else if (tag == "cascadeStylesheets")
+                            MusEGlobal::config.cascadeStylesheets = xml.parseInt();
                         
                         //else if (tag == "midiSyncInfo")
                         //      readConfigMidiSyncInfo(xml);
@@ -1936,6 +1939,7 @@ void MusE::writeGlobalConfiguration(int level, MusECore::Xml& xml) const
 
       xml.intTag(level, "iconSize", MusEGlobal::config.iconSize);
       xml.intTag(level, "cursorSize", MusEGlobal::config.cursorSize);
+      xml.intTag(level, "cascadeStylesheets", MusEGlobal::config.cascadeStylesheets);
       
       MusEGlobal::writePluginGroupConfiguration(level, xml);
 

--- a/muse3/muse/gconfig.cpp
+++ b/muse3/muse/gconfig.cpp
@@ -209,6 +209,7 @@ GlobalConfigValues config = {
 
       18,                           // iconSize
       18,                           // cursorSize (for custom cursors)
+      false,                        // cascadeStylesheets
       
       false,                        // enableAlsaMidiDriver Whether to enable the ALSA midi driver
       384,                          // division;

--- a/muse3/muse/gconfig.h
+++ b/muse3/muse/gconfig.h
@@ -272,6 +272,7 @@ struct GlobalConfigValues {
 
       int iconSize;
       int cursorSize;
+      bool cascadeStylesheets;
 
       bool enableAlsaMidiDriver; // Whether to enable the ALSA midi driver
       int division;

--- a/muse3/muse/helper.cpp
+++ b/muse3/muse/helper.cpp
@@ -1930,10 +1930,41 @@ void loadStyleSheetFile(const QString& s)
 {
     if(MusEGlobal::debugMsg)
       fprintf(stderr, "loadStyleSheetFile:%s\n", s.toLatin1().constData());
+
     if(s.isEmpty())
     {
       qApp->setStyleSheet(s);
       return;
+    }
+
+    if (MusEGlobal::config.cascadeStylesheets) {
+        QString style = QFileInfo(s).baseName();
+        QString stylePathUser = MusEGlobal::configPath + "/themes/" + style + ".qss";
+        QString stylePathDef = MusEGlobal::museGlobalShare + "/themes/" + style + ".qss";
+
+        if (QFile::exists(stylePathUser) && QFile::exists(stylePathDef)) {
+            QFile fdef(stylePathDef);
+            if (!fdef.open(QIODevice::ReadOnly)) {
+                printf("loading style sheet <%s> failed\n", qPrintable(s));
+                return;
+            }
+            QFile fuser(stylePathUser);
+            if (!fuser.open(QIODevice::ReadOnly)) {
+                printf("loading style sheet <%s> failed\n", qPrintable(s));
+                fdef.close();
+                return;
+            }
+
+            QByteArray sdef = fdef.readAll();
+            QByteArray suser = fuser.readAll();
+            QString sheet(QString::fromUtf8(sdef.data()) + '\n' + QString::fromUtf8(suser.data()));
+            qApp->setStyleSheet(sheet);
+
+            fdef.close();
+            fuser.close();
+
+            return;
+        }
     }
 
     QFile cf(s);


### PR DESCRIPTION
Usecase:
I have my own stylesheet for a theme. When the default theme stylesheet is updated by the devs, I have to compare and adjust my user stylesheet every time to get the new features.
So I want to use the default stylesheet as a base and make only selective delta changes in my user stylesheeet.

This should now be possible with new option.