### PR TITLE
Fixes for color settings

### DIFF
--- a/muse3/muse/conf.cpp
+++ b/muse3/muse/conf.cpp
@@ -1579,7 +1579,8 @@ static void writeSeqConfiguration(int level, Xml& xml, bool writePortInfo)
       }
       
       
-static void writeConfigurationColors(int level, MusECore::Xml& xml, bool partColorNames = true)
+void writeConfigurationColors(int level, MusECore::Xml& xml, bool partColorNames)
+//static void writeConfigurationColors(int level, MusECore::Xml& xml, bool partColorNames = true)
 {
      for (int i = 0; i < 16; ++i) {
             xml.colorTag(level, QString("palette") + QString::number(i), MusEGlobal::config.palette[i]);

--- a/muse3/muse/conf.h
+++ b/muse3/muse/conf.h
@@ -62,6 +62,7 @@ namespace MusECore {
 extern bool readConfiguration();
 extern bool readConfiguration(const char *configFile);
 extern void readConfiguration(Xml& xml, bool doReadMidiPortConfig, bool doReadGlobalConfig);
+extern void writeConfigurationColors(int level, MusECore::Xml& xml, bool partColorNames = true);
 }
 
 #endif


### PR DESCRIPTION
Appearance/Styles:
Removed confusing popup about resetting theme colours when changing the theme. Now the current colours are saved to user colour settings file before, so they never get lost.