### PR TITLE
Improve mixer strip display button

### DIFF
--- a/muse3/muse/arranger/arranger.cpp
+++ b/muse3/muse/arranger/arranger.cpp
@@ -367,11 +367,14 @@ Arranger::Arranger(ArrangerView* parent, const char* name)
       trackInfoButton  = new CompactToolButton(this);
       trackInfoButton->setContentsMargins(0, 0, 0, 0);
       trackInfoButton->setIcon(*mixerstripSVGIcon);
-      trackInfoButton->setToolTip(tr("Show mixer strip for current track"));
+      trackInfoButton->setToolTip(tr("Show mixer strip for current track (F5)"));
       trackInfoButton->setCheckable(true);
       trackInfoButton->setChecked(showTrackinfoFlag);
       trackInfoButton->setFocusPolicy(Qt::NoFocus);
-      trackInfoButton->setFixedSize(52, 14);
+      trackInfoButton->setFixedSize(20, 14);
+      trackInfoButton->setDrawFlat(true);
+      trackInfoButton->setShortcut(QKeySequence(Qt::Key_F5));
+      trackInfoButton->setCursor(QCursor(Qt::PointingHandCursor));
       connect(trackInfoButton, SIGNAL(toggled(bool)), SLOT(showTrackInfo(bool)));
 
       genTrackInfo(trackInfoWidget);
@@ -1097,7 +1100,7 @@ void Arranger::controllerChanged(MusECore::Track *t, int ctrlId)
 
 void Arranger::showTrackInfo(bool flag)
       {
-      trackInfoButton->setToolTip(flag ? tr("Hide mixer strip for current track") : tr("Show mixer strip for current track"));
+      trackInfoButton->setToolTip(flag ? tr("Hide mixer strip for current track (F5)") : tr("Show mixer strip for current track (F5)"));
       showTrackinfoFlag = flag;
       trackInfoWidget->setVisible(flag);
       updateTrackInfo(-1);

--- a/muse3/svg/mixerstrip.svg
+++ b/muse3/svg/mixerstrip.svg
@@ -1,44 +1,66 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg id="SVGRoot" width="64px" height="64px" version="1.1" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
- <defs>
-  <linearGradient id="linearGradient1637" x1="31" x2="31" y1="4" y2="61" gradientTransform="matrix(.25 0 0 .80702 -2.75 5.7719)" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#f00" offset="0"/>
-   <stop stop-color="#ffd42a" offset=".29598"/>
-   <stop stop-color="#008000" offset=".5068"/>
-   <stop stop-color="#008000" offset="1"/>
-  </linearGradient>
-  <linearGradient id="linearGradient1655" x1="31" x2="31" y1="4" y2="61" gradientTransform="matrix(.25 0 0 .80702 15.25 5.7719)" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#f00" offset="0"/>
-   <stop stop-color="#ffd42a" offset=".29598"/>
-   <stop stop-color="#008000" offset=".5068"/>
-   <stop stop-color="#008000" offset="1"/>
-  </linearGradient>
-  <linearGradient id="linearGradient1657" x1="31" x2="31" y1="4" y2="61" gradientTransform="matrix(.25 0 0 .80702 33.25 5.7719)" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#f00" offset="0"/>
-   <stop stop-color="#ffd42a" offset=".29598"/>
-   <stop stop-color="#008000" offset=".5068"/>
-   <stop stop-color="#008000" offset="1"/>
-  </linearGradient>
-  <linearGradient id="linearGradient1659" x1="31" x2="31" y1="4" y2="61" gradientTransform="matrix(.25 0 0 .80702 51.25 5.7719)" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#f00" offset="0"/>
-   <stop stop-color="#ffd42a" offset=".29598"/>
-   <stop stop-color="#008000" offset=".5068"/>
-   <stop stop-color="#008000" offset="1"/>
-  </linearGradient>
- </defs>
- <metadata>
-  <rdf:RDF>
-   <cc:Work rdf:about="">
-    <dc:format>image/svg+xml</dc:format>
-    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:title/>
-   </cc:Work>
-  </rdf:RDF>
- </metadata>
- <g fill-rule="evenodd" stroke="#000" stroke-dashoffset="37.795" stroke-linejoin="round">
-  <rect x="1" y="9" width="8" height="46" fill="url(#linearGradient1637)" style="paint-order:fill markers stroke"/>
-  <rect x="55" y="9" width="8" height="46" fill="url(#linearGradient1659)" style="paint-order:fill markers stroke"/>
-  <rect x="37" y="9" width="8" height="46" fill="url(#linearGradient1657)" style="paint-order:fill markers stroke"/>
-  <rect x="19" y="9" width="8" height="46" fill="url(#linearGradient1655)" style="paint-order:fill markers stroke"/>
- </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0beta2 (2b71d25, 2019-12-03)"
+   sodipodi:docname="mixerstrip.svg"
+   id="SVGRoot"
+   version="1.1"
+   viewBox="0 0 64 64"
+   height="64px"
+   width="64px">
+  <defs
+     id="defs815" />
+  <sodipodi:namedview
+     inkscape:document-rotation="0"
+     inkscape:grid-bbox="true"
+     inkscape:window-maximized="1"
+     inkscape:window-y="0"
+     inkscape:window-x="0"
+     inkscape:window-height="1030"
+     inkscape:window-width="1920"
+     showgrid="true"
+     inkscape:current-layer="layer1"
+     inkscape:document-units="px"
+     inkscape:cy="32.176777"
+     inkscape:cx="28.893306"
+     inkscape:zoom="8"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base">
+    <inkscape:grid
+       id="grid1371"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata818">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1">
+    <path
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:connector-curvature="0"
+       id="path1040"
+       d="M 2,45 V 60 H 50 V 20 H 62 L 42,5 22,20 h 12 v 25 z"
+       style="fill:#008000;fill-opacity:1;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
 </svg>


### PR DESCRIPTION
It's that button again... It always looked so bad, not matching the (varying) width of the mixer strip and looking to misplaced down there...
So this is another idea: Make it flat, small and asymmetric by design, so it does not look like a mistake.
I added a keyboard shortcut and different mouse cursor, so it's clear there is an action behind it.
IMO it looks quite nice and clean this way...

![image](https://user-images.githubusercontent.com/10009541/74226950-bfe1d600-4cbd-11ea-8843-372165ddecc5.png)

BTW: The mixer strip is also displayed in the midi/wave editors, but there it can't be hidden.
