### PR TITLE
Better position for color selection dialog

### DIFF
--- a/muse3/muse/components/appearance.cpp
+++ b/muse3/muse/components/appearance.cpp
@@ -1173,6 +1173,8 @@ void Appearance::chooseColorClicked()
   else
     setColorDialogWindowText();
     
+  QRect r = this->geometry();
+  _colorDialog->move(r.x() + 250, r.y() + 170);
   _colorDialog->show();
   _colorDialog->raise();
 }


### PR DESCRIPTION
Positioning the color selection dlg a little to the side so the currently processed color in the list is still visible (appearance dlg -> color tab). 
 