### PR TITLE
harmonize VST support in UI

### DIFF
--- a/muse3/ChangeLog
+++ b/muse3/ChangeLog
@@ -1,3 +1,7 @@
+16.02.2020:
+    - Removed the VST tab referencing Wine VST and relabeled Native VST as VST (rj)
+    - Remove Wine VST plugin type in dropdown as we only support that through
+      dssi-vst and it is dead since many years
 15.02.2020:
     - Fixed issue with plugin scan #763, where a valid vst plugin but nonfunctional was never
       added to the cache and hence caused a rescan every time (rj)

--- a/muse3/muse/components/genset.cpp
+++ b/muse3/muse/components/genset.cpp
@@ -323,8 +323,9 @@ void GlobalSettingsConfig::updateSettings()
       pluginDssiPathList->clear();
       pluginDssiPathList->addItems(MusEGlobal::config.pluginDssiPathList);
 
-      pluginVstPathList->clear();
-      pluginVstPathList->addItems(MusEGlobal::config.pluginVstPathList);
+// removed since they do not contain anything currently
+//      pluginVstPathList->clear();
+//      pluginVstPathList->addItems(MusEGlobal::config.pluginVstPathList);
 
       pluginLinuxVstPathList->clear();
       pluginLinuxVstPathList->addItems(MusEGlobal::config.pluginLinuxVstPathList);
@@ -535,9 +536,10 @@ void GlobalSettingsConfig::apply()
       for (int i = 0; i < pluginDssiPathList->count(); ++i)
             MusEGlobal::config.pluginDssiPathList << pluginDssiPathList->item(i)->text();
 
-      MusEGlobal::config.pluginVstPathList.clear();
-      for (int i = 0; i < pluginVstPathList->count(); ++i)
-            MusEGlobal::config.pluginVstPathList << pluginVstPathList->item(i)->text();
+// removed since they do not contain anything currently
+//      MusEGlobal::config.pluginVstPathList.clear();
+//      for (int i = 0; i < pluginVstPathList->count(); ++i)
+//            MusEGlobal::config.pluginVstPathList << pluginVstPathList->item(i)->text();
 
       MusEGlobal::config.pluginLinuxVstPathList.clear();
       for (int i = 0; i < pluginLinuxVstPathList->count(); ++i)
@@ -726,10 +728,11 @@ void GlobalSettingsConfig::addPluginPath()
         path = pluginDssiPathList->currentItem()->text();
     break;
     
-    case VstTab:
-      if(pluginVstPathList->currentItem())
-        path = pluginVstPathList->currentItem()->text();
-    break;
+// removed since they do not contain anything currently
+//    case VstTab:
+//      if(pluginVstPathList->currentItem())
+//        path = pluginVstPathList->currentItem()->text();
+//    break;
     
     case LinuxVstTab:
       if(pluginLinuxVstPathList->currentItem())
@@ -760,9 +763,10 @@ void GlobalSettingsConfig::addPluginPath()
       pluginDssiPathList->addItem(new_path);
     break;
     
-    case VstTab:
-      pluginVstPathList->addItem(new_path);
-    break;
+// removed since they do not contain anything currently
+//    case VstTab:
+//      pluginVstPathList->addItem(new_path);
+//    break;
     
     case LinuxVstTab:
       pluginLinuxVstPathList->addItem(new_path);
@@ -792,10 +796,11 @@ void GlobalSettingsConfig::editPluginPath()
         path = pluginDssiPathList->currentItem()->text();
     break;
     
-    case VstTab:
-      if(pluginVstPathList->currentItem())
-        path = pluginVstPathList->currentItem()->text();
-    break;
+// removed since they do not contain anything currently
+//    case VstTab:
+//      if(pluginVstPathList->currentItem())
+//        path = pluginVstPathList->currentItem()->text();
+//    break;
     
     case LinuxVstTab:
       if(pluginLinuxVstPathList->currentItem())
@@ -828,10 +833,11 @@ void GlobalSettingsConfig::editPluginPath()
         pluginDssiPathList->currentItem()->setText(new_path);
     break;
     
-    case VstTab:
-      if(pluginVstPathList->currentItem())
-        pluginVstPathList->currentItem()->setText(new_path);
-    break;
+// removed since they do not contain anything currently
+//    case VstTab:
+//      if(pluginVstPathList->currentItem())
+//        pluginVstPathList->currentItem()->setText(new_path);
+//    break;
     
     case LinuxVstTab:
       if(pluginLinuxVstPathList->currentItem())
@@ -872,10 +878,11 @@ void GlobalSettingsConfig::removePluginPath()
         delete item;
     break;
     
-    case VstTab:
-      foreach(QListWidgetItem* item, pluginVstPathList->selectedItems())
-        delete item;
-    break;
+// removed since they do not contain anything currently
+//    case VstTab:
+//      foreach(QListWidgetItem* item, pluginVstPathList->selectedItems())
+//        delete item;
+//    break;
     
     case LinuxVstTab:
       foreach(QListWidgetItem* item, pluginLinuxVstPathList->selectedItems())
@@ -905,9 +912,10 @@ void GlobalSettingsConfig::movePluginPathUp()
       list = pluginDssiPathList;
     break;
     
-    case VstTab:
-      list = pluginVstPathList;
-    break;
+// removed since they do not contain anything currently
+//    case VstTab:
+//      list = pluginVstPathList;
+//    break;
     
     case LinuxVstTab:
       list = pluginLinuxVstPathList;
@@ -945,9 +953,10 @@ void GlobalSettingsConfig::movePluginPathDown()
       list = pluginDssiPathList;
     break;
     
-    case VstTab:
-      list = pluginVstPathList;
-    break;
+// removed since they do not contain anything currently
+//    case VstTab:
+//      list = pluginVstPathList;
+//    break;
     
     case LinuxVstTab:
       list = pluginLinuxVstPathList;

--- a/muse3/muse/components/gensetbase.ui
+++ b/muse3/muse/components/gensetbase.ui
@@ -746,26 +746,9 @@
                </item>
               </layout>
              </widget>
-             <widget class="QWidget" name="pluginVstPathTab">
-              <attribute name="title">
-               <string>VST</string>
-              </attribute>
-              <layout class="QVBoxLayout" name="verticalLayout_14">
-               <item>
-                <widget class="QListWidget" name="pluginVstPathList">
-                 <property name="alternatingRowColors">
-                  <bool>true</bool>
-                 </property>
-                 <property name="selectionMode">
-                  <enum>QAbstractItemView::ExtendedSelection</enum>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
              <widget class="QWidget" name="pluginLinuxVstPathTab">
               <attribute name="title">
-               <string>Linux VST</string>
+               <string>VST</string>
               </attribute>
               <layout class="QVBoxLayout" name="verticalLayout_11">
                <item>
@@ -1393,7 +1376,7 @@ Adjusts responsiveness of audio controls and
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>534</width>
+            <width>540</width>
             <height>485</height>
            </rect>
           </property>
@@ -2245,8 +2228,8 @@ Turn off to reduce clutter.</string>
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>512</width>
-               <height>444</height>
+               <width>514</width>
+               <height>438</height>
               </rect>
              </property>
              <layout class="QGridLayout" name="gridLayout_6">
@@ -2612,8 +2595,8 @@ Otherwise, hold Ctrl to keep them open.</string>
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>510</width>
-               <height>410</height>
+               <width>524</width>
+               <height>411</height>
               </rect>
              </property>
              <layout class="QHBoxLayout" name="horizontalLayout_3">

--- a/muse3/muse/components/plugindialog.cpp
+++ b/muse3/muse/components/plugindialog.cpp
@@ -139,7 +139,8 @@ PluginDialog::PluginDialog(QWidget* parent)
       ui.pluginType->addItem("LADSPA", SEL_TYPE_LADSPA);
       ui.pluginType->addItem("LV2", SEL_TYPE_LV2);
       ui.pluginType->addItem("VST", SEL_TYPE_VST);
-      ui.pluginType->addItem("Wine VST", SEL_TYPE_WINE_VST);
+//      ui.pluginType->addItem("Wine VST", SEL_TYPE_WINE_VST);
+
       connect (ui.pluginType,SIGNAL(currentIndexChanged(int)), SLOT(filterType(int)));
 
       for (int i=0; i < ui.pluginType->count(); i++) {

--- a/muse3/muse/helper.cpp
+++ b/muse3/muse/helper.cpp
@@ -1260,10 +1260,12 @@ QMenu* populateAddSynth(QWidget* parent)
   {
     synth = *i;
     type = synth->synthType();
-#ifdef DSSI_SUPPORT
-    if (type == MusECore::Synth::DSSI_SYNTH && ((MusECore::DssiSynth*)synth)->isDssiVst() ) // Place Wine VSTs in a separate sub menu
-      type = MusECore::Synth::VST_SYNTH;
-#endif
+
+// dssi-vst is dead, really no point in keeping this case around
+//#ifdef DSSI_SUPPORT
+//    if (type == MusECore::Synth::DSSI_SYNTH && ((MusECore::DssiSynth*)synth)->isDssiVst() ) // Place Wine VSTs in a separate sub menu
+//      type = MusECore::Synth::VST_SYNTH;
+//#endif
 
     if(type >= ntypes)
       continue; 

--- a/muse3/muse/synth.cpp
+++ b/muse3/muse/synth.cpp
@@ -81,7 +81,7 @@ namespace MusECore {
 extern void connectNodes(AudioTrack*, AudioTrack*);
 bool SynthI::_isVisible=false;
 
-const char* synthTypes[] = { "METRONOME", "MESS", "DSSI", "Wine VST", "Native VST (synths)", "Native VST (effects)", "LV2 (synths)", "LV2 (effects)", "UNKNOWN" };
+const char* synthTypes[] = { "METRONOME", "MESS", "DSSI", "Wine VST", "VST (synths)", "VST (effects)", "LV2 (synths)", "LV2 (effects)", "UNKNOWN" };
 QString synthType2String(Synth::Type type) { return QString(synthTypes[type]); }
 
 Synth::Type string2SynthType(const QString& type)


### PR DESCRIPTION
Here's a stab at fixing some VST inconsistencies.
It might have sounded dramatic in the mail and made to look bigger than it is. I have made only changes to what is visible in the UI (and to me that is fine). 

- Plugin path dialog only has one type of VST plugins now: VST. Config still stores both kinds.
- Right click menu has been relabeled VST instead of Native VST
- Wine VST from the plugin filter dropdown has been removed.