### PR TITLE
Drum edit color issues

### DIFF
--- a/muse3/muse/ctrl/ctrlcanvas.cpp
+++ b/muse3/muse/ctrl/ctrlcanvas.cpp
@@ -247,8 +247,8 @@ CtrlCanvas::CtrlCanvas(MidiEditor* e, QWidget* parent, int xmag,
    const char* name, CtrlPanel* pnl) : View(parent, xmag, 1, name)
       {
       if (MusEGlobal::config.canvasBgPixmap.isEmpty()) {
-            setBg(MusEGlobal::config.midiCanvasBg);
-            setBg(QPixmap());
+          setBg(MusEGlobal::config.midiControllerViewBg);
+          setBg(QPixmap());
       }
       else {
             setBg(QPixmap(MusEGlobal::config.canvasBgPixmap));

--- a/muse3/muse/midiedit/drumedit.cpp
+++ b/muse3/muse/midiedit/drumedit.cpp
@@ -1789,6 +1789,7 @@ void DrumEdit::configChanged()
       else {
             canvas->setBg(QPixmap(MusEGlobal::config.canvasBgPixmap));
       }
+      dlist->setBg(MusEGlobal::config.drumListBg);
       initShortcuts();
       }
 


### PR DESCRIPTION
1. Controller view in the midi editors was initialized with wrong colour.
2. Live colour update for drum list did not work.