### PR TITLE
Fix item ctrl copy also in drum editor

### DIFF
--- a/muse3/muse/midiedit/dcanvas.cpp
+++ b/muse3/muse/midiedit/dcanvas.cpp
@@ -407,8 +407,11 @@ bool DrumCanvas::moveItem(MusECore::Undo& operations, CItem* item, const QPoint&
       int ntick        = (rasterize ? editor->rasterVal(x) : x) - dest_part->tick();
       if (ntick < 0)
             ntick = 0;
+
+      event.setSelected(false);
       MusECore::Event newEvent   = event.clone();
-      
+      newEvent.setSelected(true);
+
       int ev_pitch = instrument_map[instrument].pitch;
       newEvent.setPitch(ev_pitch);
       newEvent.setTick(ntick);


### PR DESCRIPTION
Refer to #756.
Do the same for the drum editor.