### PR TITLE
Fix cursor not changing in ctrl views

### DIFF
--- a/muse3/muse/ctrl/ctrlcanvas.cpp
+++ b/muse3/muse/ctrl/ctrlcanvas.cpp
@@ -2683,6 +2683,7 @@ void CtrlCanvas::setTool(int t)
             }
 
       cancelMouseOps();
+      setCursor();
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Should fix the bug described by Robert in #766:

> A related bug that has been there forever is that the icon does not change if you change to pencil after the mouse has entered the controller automation area. Being a heavy shortcut user one hand always rests on the keyboard shortcuts. You can try it by pressing A up in the editor, move the mouse to the controller area and press D, the icon does not change, toolbar changes though.

