### PR TITLE
Piano roll multi resize (fixes #748)

### DIFF
--- a/muse3/ChangeLog
+++ b/muse3/ChangeLog
@@ -1,3 +1,18 @@
+18.03.2020
+	- Enable multiple resizing in piano roll (#748) (kybos)
+	- Enable CTRL+Left Mouse Click item selection in edit mode in piano roll (kybos)
+17.03.2020
+	- Add more information to note tooltips in midi editors (kybos)
+	- Remove fixed track heigth from file templates, to enforce global setting (kybos)
+09.03.2020
+	- Transfer Help content to github wiki, link Manual to wiki in MusE (kybos)
+08.03.2020
+	- Fix EditPaste cursor HiDPI issue in midi editors->controller views (kybos)
+05.03.2020
+	- Fix tool cursor not changing in midi editors->controller views (kybos)
+	- Fix background color setting ignored in midi editors->controller views (kybos)
+04.03.2020
+	- Add tool context menu to Score Editor (kybos)
 28.02.2020:
     - LV2: Now shows MidiName patch names (gmsynth.lv2 for example). (Tim)
     - Added share/rdf/README to describe what's there and why.

--- a/muse3/muse/components/canvas.cpp
+++ b/muse3/muse/components/canvas.cpp
@@ -914,7 +914,11 @@ void Canvas::viewMousePressEvent(QMouseEvent* event)
                                   setCursor();
 
                                   if (supportsMultipleResize) {
-                                      selectItem(curItem, true);
+                                      if (!curItem->isSelected()) {
+                                        deselectAll();
+                                        deselect_all = true;
+                                        selectItem(curItem, true);
+                                      }
                                       if (resizeDirection == RESIZE_TO_THE_RIGHT)
                                           resizeSelected(start.x() - curItem->x() - curItem->width());
                                       else

--- a/muse3/muse/components/canvas.cpp
+++ b/muse3/muse/components/canvas.cpp
@@ -82,7 +82,9 @@ Canvas::Canvas(QWidget* parent, int sx, int sy, const char* name)
       resizeDirection= RESIZE_TO_THE_RIGHT;
 
       supportsResizeToTheLeft = false;
-      
+      supportsMultipleResize = false;
+      multiResize = false;
+
       scrollSpeed=30;    // hardcoded scroll jump
 
       drag    = DRAG_OFF;

--- a/muse3/muse/components/canvas.h
+++ b/muse3/muse/components/canvas.h
@@ -132,7 +132,6 @@ class Canvas : public View {
 
       bool supportsResizeToTheLeft;
       bool supportsMultipleResize;
-      bool multiResize;
 
       void setLasso(const QRect& r);
       void resizeToTheLeft(const QPoint &pos);

--- a/muse3/muse/components/canvas.h
+++ b/muse3/muse/components/canvas.h
@@ -131,9 +131,12 @@ class Canvas : public View {
       QMenu* canvasPopupMenu;
 
       bool supportsResizeToTheLeft;
+      bool supportsMultipleResize;
+      bool multiResize;
 
       void setLasso(const QRect& r);
       void resizeToTheLeft(const QPoint &pos);
+      void resizeSelected(const int &dist, const bool left = false);
       virtual void setCursor();
       virtual void setMouseOverItemCursor();
       virtual void viewKeyPressEvent(QKeyEvent* event);

--- a/muse3/muse/components/citem.h
+++ b/muse3/muse/components/citem.h
@@ -73,6 +73,7 @@ class CItem {
       virtual QRect bbox() const           { return QRect(); }
       virtual void setBBox(const QRect&)   { }
       virtual void move(const QPoint&)     { }
+      virtual void setTopLeft(const QPoint&)     { }
       virtual bool contains(const QPoint&) const  { return false; }
       virtual bool intersects(const QRect&) const { return false; }
 
@@ -115,6 +116,10 @@ class BItem : public CItem {
             _bbox.moveTopLeft(tl);
             _pos = tl;
             }
+      void setTopLeft(const QPoint &tl) {
+          _bbox.setTopLeft(tl);
+          _pos = tl;
+      }
       bool contains(const QPoint& p) const  { return _bbox.contains(p); }
       bool intersects(const QRect& r) const { return r.intersects(_bbox); }
       };

--- a/muse3/muse/midiedit/prcanvas.cpp
+++ b/muse3/muse/midiedit/prcanvas.cpp
@@ -1126,7 +1126,7 @@ void PianoCanvas::resizeItem(CItem* item, bool noSnap, bool rasterize)         /
     unsigned max_diff_len = 0;
     MusECore::Part* part;
 
-    for (auto it: items) {
+    for (auto &it: items) {
         if (!it.second->isSelected())
             continue;
 

--- a/muse3/muse/midiedit/prcanvas.cpp
+++ b/muse3/muse/midiedit/prcanvas.cpp
@@ -101,6 +101,7 @@ PianoCanvas::PianoCanvas(MidiEditor* pr, QWidget* parent, int sx, int sy)
       colorMode = 0;
       for (int i=0;i<128;i++) noteHeldDown[i]=false;
       supportsResizeToTheLeft = true;
+      supportsMultipleResize = true;
       
       steprec=new MusECore::StepRec(noteHeldDown);
       
@@ -1117,54 +1118,65 @@ void PianoCanvas::newItem(CItem* item, bool noSnap)
 //---------------------------------------------------------
 
 void PianoCanvas::resizeItem(CItem* item, bool noSnap, bool rasterize)         // experimental changes to try dynamically extending parts
-      {
-      NEvent* nevent = (NEvent*) item;
-      MusECore::Event event    = nevent->event();
-      MusECore::Event newEvent = event.clone();
-      int len;
+{
+    Q_UNUSED(item)
+    Q_UNUSED(rasterize)
 
-      MusECore::Part* part = nevent->part();
+    MusECore::Undo operations;
+    unsigned max_diff_len = 0;
+    MusECore::Part* part;
 
-      if (noSnap)
+    for (auto it: items) {
+        if (!it.second->isSelected())
+            continue;
+
+        part = it.second->part();
+
+        QPoint topLeft = QPoint(qMax((unsigned)it.second->x(), part->tick()), it.second->y());
+        it.second->setTopLeft(raster(topLeft));
+
+        NEvent* nevent = (NEvent*) it.second;
+        MusECore::Event event    = nevent->event();
+        MusECore::Event newEvent = event.clone();
+        int len;
+
+        if (noSnap)
             len = nevent->width();
-      else {
+        else {
             unsigned tick = event.tick() + part->tick();
             len = editor->rasterVal(tick + nevent->width()) - tick;
             if (len <= 0)
-                  len = editor->raster();
-      }
-
-      MusECore::Undo operations;
-      int diff = event.tick()+len-part->lenTick();
-      
-      if((nevent->mp() != nevent->pos()) && (resizeDirection == RESIZE_TO_THE_LEFT))
-      {
-         int x = nevent->mp().x();
-         if (x < 0)
-               x = 0;
-         int ntick = (rasterize ? editor->rasterVal(x) : x) - part->tick();
-         if (ntick < 0)
-               ntick = 0;
-         newEvent.setTick(ntick);
-      }
-
-      if (! ((diff > 0) && part->hasHiddenEvents()) ) //operation is allowed
-      {
-        newEvent.setLenTick(len);
-        operations.push_back(MusECore::UndoOp(MusECore::UndoOp::ModifyEvent,newEvent, event, nevent->part(), false, false));
-        
-        if (diff > 0)// part must be extended?
-        {
-              schedule_resize_all_same_len_clone_parts(part, event.tick()+len, operations);
-              printf("resizeItem: extending\n");
+                len = editor->raster();
         }
-      }
 
-      //else forbid action by not performing it
-      MusEGlobal::song->applyOperationGroup(operations);
-      songChanged(SC_EVENT_MODIFIED); //this forces an update of the itemlist, which is necessary
-                                      //to remove "forbidden" events from the list again
-      }
+        int diff = event.tick() + len - part->lenTick();
+
+        if (resizeDirection == RESIZE_TO_THE_LEFT) {
+            int x = qMax(0, nevent->x());
+            int ntick = qMax(0u, x - part->tick());
+            newEvent.setTick(ntick);
+        }
+
+        if (! ((diff > 0) && part->hasHiddenEvents()) ) //operation is allowed
+        {
+            newEvent.setLenTick(len);
+            operations.push_back(MusECore::UndoOp(MusECore::UndoOp::ModifyEvent, newEvent, event, nevent->part(), false, false));
+
+            if (diff > 0) // part must be extended?
+                max_diff_len = qMax(event.tick() + len, max_diff_len);
+        }
+    }
+
+    if (max_diff_len > 0) {
+        schedule_resize_all_same_len_clone_parts(part, max_diff_len, operations);
+        printf("resizeItem: extending\n");
+    }
+
+    //else forbid action by not performing it
+    MusEGlobal::song->applyOperationGroup(operations);
+    songChanged(SC_EVENT_MODIFIED); //this forces an update of the itemlist, which is necessary
+    //to remove "forbidden" events from the list again
+}
 
 //---------------------------------------------------------
 //   deleteItem


### PR DESCRIPTION
Hi guys,
Please check this PR. I tested everything as far as possible, also the many corner cases, so I hope I did not break anything (and even corrected some bugs in the item resizing). 
Function: In piano roll, edit mode (pencil), when Ctrl is held all selected items are resized.
Thanks.