### PR TITLE
Improve note tooltips in midi editors

### DIFF
--- a/muse3/muse/components/canvas.h
+++ b/muse3/muse/components/canvas.h
@@ -63,7 +63,7 @@ class Canvas : public View {
       bool canScrollUp;
       bool canScrollDown;
 
-      CItem *findCurrentItem(const QPoint &cStart);
+//      CItem *findCurrentItem(const QPoint &cStart);
       
       // Whether we have grabbed the mouse.
       bool _mouseGrabbed;
@@ -225,6 +225,7 @@ class Canvas : public View {
       void showCursor(bool show = true);
       // Sets or resets the _mouseGrabbed flag and grabs or releases the mouse.
       void setMouseGrab(bool grabbed = false);
+      CItem *findCurrentItem(const QPoint &cStart);
       
    public slots:
       void setTool(int t);

--- a/muse3/muse/components/genset.cpp
+++ b/muse3/muse/components/genset.cpp
@@ -212,6 +212,7 @@ void GlobalSettingsConfig::updateSettings()
       monitorOnRecordCheckBox->setChecked(MusEGlobal::config.monitorOnRecord);
       lineEditStyleHackCheckBox->setChecked(MusEGlobal::config.lineEditStyleHack);
       showNoteNamesCheckBox->setChecked(MusEGlobal::config.showNoteNamesInPianoRoll);
+      showNoteTooltipsCheckBox->setChecked(MusEGlobal::config.showNoteTooltips);
       preferMidiVolumeDbCheckBox->setChecked(MusEGlobal::config.preferMidiVolumeDb);
       warnIfBadTimingCheckBox->setChecked(MusEGlobal::config.warnIfBadTiming);
       warnOnFileVersionsCheckBox->setChecked(MusEGlobal::config.warnOnFileVersions);
@@ -450,6 +451,7 @@ void GlobalSettingsConfig::apply()
       MusEGlobal::config.monitorOnRecord = monitorOnRecordCheckBox->isChecked();
       MusEGlobal::config.lineEditStyleHack = lineEditStyleHackCheckBox->isChecked();
       MusEGlobal::config.showNoteNamesInPianoRoll = showNoteNamesCheckBox->isChecked();
+      MusEGlobal::config.showNoteTooltips = showNoteTooltipsCheckBox->isChecked();
       MusEGlobal::config.preferMidiVolumeDb = preferMidiVolumeDbCheckBox->isChecked();
       MusEGlobal::config.showSplashScreen = showSplash->isChecked();
       MusEGlobal::config.showDidYouKnow   = showDidYouKnow->isChecked();

--- a/muse3/muse/components/gensetbase.ui
+++ b/muse3/muse/components/gensetbase.ui
@@ -992,90 +992,6 @@
        <string>Audio</string>
       </attribute>
       <layout class="QGridLayout">
-       <item row="1" column="0">
-        <widget class="QGroupBox" name="groupBox13">
-         <property name="title">
-          <string>External Waveditor</string>
-         </property>
-         <layout class="QGridLayout">
-          <property name="topMargin">
-           <number>2</number>
-          </property>
-          <property name="bottomMargin">
-           <number>2</number>
-          </property>
-          <property name="spacing">
-           <number>2</number>
-          </property>
-          <item row="0" column="0">
-           <layout class="QGridLayout" name="gridLayoutwaveEditor">
-            <item row="0" column="0">
-             <layout class="QHBoxLayout" name="qhboxLayoutWaveEditor">
-              <item>
-               <widget class="QLabel" name="textLabel2_2">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                  <horstretch>1</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>External Waveditor command</string>
-                </property>
-                <property name="wordWrap">
-                 <bool>false</bool>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <spacer name="spacer13">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeType">
-                 <enum>QSizePolicy::Expanding</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>60</width>
-                  <height>23</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item>
-               <widget class="QLineEdit" name="externalWavEditorSelect">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                  <horstretch>2</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="textLabel1_6">
-              <property name="font">
-               <font>
-                <pointsize>8</pointsize>
-                <italic>true</italic>
-               </font>
-              </property>
-              <property name="text">
-               <string>Note: External editor opened from the internal editor.</string>
-              </property>
-              <property name="wordWrap">
-               <bool>false</bool>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
        <item row="2" column="0">
         <widget class="QGroupBox" name="deviceAudioGroupBox">
          <property name="title">
@@ -1193,8 +1109,11 @@
           <property name="bottomMargin">
            <number>2</number>
           </property>
-          <property name="spacing">
+          <property name="horizontalSpacing">
            <number>2</number>
+          </property>
+          <property name="verticalSpacing">
+           <number>4</number>
           </property>
           <item row="0" column="1">
            <widget class="QSpinBox" name="minSliderSelect">
@@ -1426,6 +1345,90 @@ Adjusts responsiveness of audio controls and
          </layout>
         </widget>
        </item>
+       <item row="1" column="0">
+        <widget class="QGroupBox" name="groupBox13">
+         <property name="title">
+          <string>External Waveditor</string>
+         </property>
+         <layout class="QGridLayout">
+          <property name="topMargin">
+           <number>2</number>
+          </property>
+          <property name="bottomMargin">
+           <number>2</number>
+          </property>
+          <property name="spacing">
+           <number>2</number>
+          </property>
+          <item row="0" column="0">
+           <layout class="QGridLayout" name="gridLayoutwaveEditor">
+            <item row="0" column="0">
+             <layout class="QHBoxLayout" name="qhboxLayoutWaveEditor">
+              <item>
+               <widget class="QLabel" name="textLabel2_2">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>1</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>External Waveditor command</string>
+                </property>
+                <property name="wordWrap">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="spacer13">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::Expanding</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>60</width>
+                  <height>23</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QLineEdit" name="externalWavEditorSelect">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                  <horstretch>2</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="textLabel1_6">
+              <property name="font">
+               <font>
+                <pointsize>8</pointsize>
+                <italic>true</italic>
+               </font>
+              </property>
+              <property name="text">
+               <string>Note: External editor opened from the internal editor.</string>
+              </property>
+              <property name="wordWrap">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
        <item row="3" column="0">
         <widget class="QGroupBox" name="audioConvertersGroupBox">
          <property name="title">
@@ -1454,6 +1457,19 @@ Adjusts responsiveness of audio controls and
           </item>
          </layout>
         </widget>
+       </item>
+       <item row="4" column="0">
+        <spacer name="verticalSpacer_12">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
      </widget>
@@ -1855,6 +1871,19 @@ Certain operations will also force them to be resent,
              </layout>
             </widget>
            </item>
+           <item>
+            <spacer name="verticalSpacer_13">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
           </layout>
          </widget>
         </widget>
@@ -2252,6 +2281,13 @@ Turn off to reduce clutter.</string>
            <widget class="QCheckBox" name="showNoteNamesCheckBox">
             <property name="text">
              <string>Show note names on notes in pianoroll</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="showNoteTooltipsCheckBox">
+            <property name="text">
+             <string>Show note tooltips in midi editors</string>
             </property>
            </widget>
           </item>

--- a/muse3/muse/conf.cpp
+++ b/muse3/muse/conf.cpp
@@ -1239,6 +1239,8 @@ void readConfiguration(Xml& xml, bool doReadMidiPortConfig, bool doReadGlobalCon
                               MusEGlobal::config.mixdownPath = xml.parse1();
                         else if (tag == "showNoteNamesInPianoRoll")
                               MusEGlobal::config.showNoteNamesInPianoRoll = xml.parseInt();
+                        else if (tag == "showNoteTooltips")
+                            MusEGlobal::config.showNoteTooltips = xml.parseInt();
                         else if (tag == "noPluginScaling")
                               MusEGlobal::config.noPluginScaling = xml.parseInt();
                         else if (tag == "openMDIWinMaximized")
@@ -1901,6 +1903,7 @@ void MusE::writeGlobalConfiguration(int level, MusECore::Xml& xml) const
       xml.intTag(level, "lv2UiBehavior", static_cast<int>(MusEGlobal::config.lv2UiBehavior));
       xml.strTag(level, "mixdownPath", MusEGlobal::config.mixdownPath);
       xml.intTag(level, "showNoteNamesInPianoRoll", MusEGlobal::config.showNoteNamesInPianoRoll);
+      xml.intTag(level, "showNoteTooltips", MusEGlobal::config.showNoteTooltips);
       xml.intTag(level, "noPluginScaling", MusEGlobal::config.noPluginScaling);
       xml.intTag(level, "openMDIWinMaximized", MusEGlobal::config.openMDIWinMaximized);
 

--- a/muse3/muse/gconfig.cpp
+++ b/muse3/muse/gconfig.cpp
@@ -342,6 +342,7 @@ GlobalConfigValues config = {
       false,                        // commonProjectLatency
       "",                           // mixdownPath
       true,                         // showNoteNamesInPianoRoll
+      true,                         // showNoteTooltipsCheckBox
       false,                        // noPluginScaling
       false,                        // openMDIWinMaximized
       false                         // selectionsUndoable Whether selecting parts or events is undoable.

--- a/muse3/muse/gconfig.h
+++ b/muse3/muse/gconfig.h
@@ -400,6 +400,7 @@ struct GlobalConfigValues {
       bool commonProjectLatency;
       QString mixdownPath;
       bool showNoteNamesInPianoRoll;
+      bool showNoteTooltips;
       // Whether selecting parts or events is undoable.
       // If set, it can be somewhat tedious for the user to step through all the undo/redo items.
       bool selectionsUndoable;

--- a/muse3/muse/midiedit/dcanvas.cpp
+++ b/muse3/muse/midiedit/dcanvas.cpp
@@ -2003,12 +2003,52 @@ void DrumCanvas::mouseMove(QMouseEvent* event) {
 
     EventCanvas::mouseMove(event);
 
+    static CItem* hoverItem = nullptr;
+
     if (_tool & (MusEGui::PointerTool | MusEGui::PencilTool | MusEGui::RubberTool | MusEGui::CursorTool)) {
+
+        QString str;
+        CItem* item = findCurrentItem(event->pos());
+        if (item && hoverItem == item)
+            return;
+
         int pitch = drumEditor->get_instrument_map()[y2pitch(event->pos().y())].pitch;
         if (track()->drummap()[pitch].name.isEmpty())
-            QToolTip::showText(event->globalPos(), MusECore::pitch2string(pitch));
+            str = MusECore::pitch2string(pitch) + " (" + QString::number(pitch) + ")";
         else
-            QToolTip::showText(event->globalPos(), track()->drummap()[pitch].name);
+            str = track()->drummap()[pitch].name + " (" + MusECore::pitch2string(pitch)
+                    + "/" + QString::number(pitch) + ")";
+
+        if (item) {
+            hoverItem = item;
+
+            MusECore::Pos start(item->event().tick() + item->part()->tick());
+
+            int bar, beat, tick, hour, min, sec, msec;
+
+            start.mbt(&bar, &beat, &tick);
+            QString str_bar = QString("%1.%2.%3")
+                .arg(bar + 1,  4, 10, QLatin1Char('0'))
+                .arg(beat + 1, 2, 10, QLatin1Char('0'))
+                .arg(tick,     3, 10, QLatin1Char('0'));
+
+            start.msmu(&hour, &min, &sec, &msec, nullptr);
+            QString str_time = QString("%1:%2:%3.%4")
+                .arg(hour,  2, 10, QLatin1Char('0'))
+                .arg(min,   2, 10, QLatin1Char('0'))
+                .arg(sec,   2, 10, QLatin1Char('0'))
+                .arg(msec,  3, 10, QLatin1Char('0'));
+
+            str = tr("Note: ") + str + "\n"
+                    + tr("Velocity: ") + QString::number(item->event().velo()) + "\n"
+                    + tr("Start (bar): ") +  str_bar + "\n"
+                    + tr("Start (time): ") + str_time;
+
+        } else {
+            hoverItem = nullptr;
+        }
+
+        QToolTip::showText(event->globalPos(), str);
     }
 }
 

--- a/muse3/muse/midiedit/dcanvas.cpp
+++ b/muse3/muse/midiedit/dcanvas.cpp
@@ -2003,6 +2003,9 @@ void DrumCanvas::mouseMove(QMouseEvent* event) {
 
     EventCanvas::mouseMove(event);
 
+    if (!MusEGlobal::config.showNoteTooltips)
+        return;
+
     static CItem* hoverItem = nullptr;
 
     if (_tool & (MusEGui::PointerTool | MusEGui::PencilTool | MusEGui::RubberTool | MusEGui::CursorTool)) {

--- a/muse3/muse/midiedit/prcanvas.cpp
+++ b/muse3/muse/midiedit/prcanvas.cpp
@@ -1862,17 +1862,66 @@ void PianoCanvas::resizeEvent(QResizeEvent* ev)
       }
 
 //---------------------------------------------------------
-//   mouseMove
+//   mouseMove (override)
 //---------------------------------------------------------
 
 void PianoCanvas::mouseMove(QMouseEvent* event) {
 
     EventCanvas::mouseMove(event);
 
+    static CItem* hoverItem = nullptr;
+
     if (_tool & (MusEGui::PointerTool | MusEGui::PencilTool | MusEGui::RubberTool)) {
-        int pitch = y2pitch(event->pos().y());
-        QToolTip::showText(event->globalPos(), MusECore::pitch2string(pitch) + " (" + QString::number(pitch) + ")" );
+
+        QString str;
+        CItem* item = findCurrentItem(event->pos());
+        if (item) {
+            if (hoverItem == item)
+                return;
+
+            hoverItem = item;
+
+            int pitch = item->event().pitch();
+            MusECore::Pos start(item->event().tick() + item->part()->tick());
+
+            int bar, beat, tick, hour, min, sec, msec;
+
+            start.mbt(&bar, &beat, &tick);
+            QString str_bar = QString("%1.%2.%3")
+                .arg(bar + 1,  4, 10, QLatin1Char('0'))
+                .arg(beat + 1, 2, 10, QLatin1Char('0'))
+                .arg(tick,     3, 10, QLatin1Char('0'));
+
+            start.msmu(&hour, &min, &sec, &msec, nullptr);
+            QString str_time = QString("%1:%2:%3.%4")
+                .arg(hour,  2, 10, QLatin1Char('0'))
+                .arg(min,   2, 10, QLatin1Char('0'))
+                .arg(sec,   2, 10, QLatin1Char('0'))
+                .arg(msec,  3, 10, QLatin1Char('0'));
+
+            str = tr("Note: ") + MusECore::pitch2string(pitch) + " (" + QString::number(pitch) + ")\n"
+                    + tr("Velocity: ") + QString::number(item->event().velo()) + "\n"
+                    + tr("Start (bar): ") +  str_bar + "\n"
+                    + tr("Start (time): ") + str_time + "\n"
+                    + tr("Length (ticks): ") + QString::number(item->event().lenTick());
+
+        } else {
+            hoverItem = nullptr;
+            int pitch = y2pitch(event->pos().y());
+            str = MusECore::pitch2string(pitch) + " (" + QString::number(pitch) + ")";
+        }
+
+        QToolTip::showText(event->globalPos(), str);
     }
+}
+
+//---------------------------------------------------------
+//   genItemPopup (override)
+//---------------------------------------------------------
+QMenu* PianoCanvas::genItemPopup(MusEGui::CItem* item) {
+    // no context menu available, use for item selection
+    item->setSelected(true);
+    return nullptr;
 }
 
 } // namespace MusEGui

--- a/muse3/muse/midiedit/prcanvas.cpp
+++ b/muse3/muse/midiedit/prcanvas.cpp
@@ -1869,6 +1869,9 @@ void PianoCanvas::mouseMove(QMouseEvent* event) {
 
     EventCanvas::mouseMove(event);
 
+    if (!MusEGlobal::config.showNoteTooltips)
+        return;
+
     static CItem* hoverItem = nullptr;
 
     if (_tool & (MusEGui::PointerTool | MusEGui::PencilTool | MusEGui::RubberTool)) {
@@ -1920,7 +1923,7 @@ void PianoCanvas::mouseMove(QMouseEvent* event) {
 //---------------------------------------------------------
 QMenu* PianoCanvas::genItemPopup(MusEGui::CItem* item) {
     // no context menu available, use for item selection
-    item->setSelected(true);
+    item->setSelected(!item->isSelected());
     return nullptr;
 }
 

--- a/muse3/muse/midiedit/prcanvas.h
+++ b/muse3/muse/midiedit/prcanvas.h
@@ -93,6 +93,7 @@ class PianoCanvas : public EventCanvas {
       virtual void curPartChanged();
       virtual void resizeEvent(QResizeEvent*);
       void mouseMove(QMouseEvent* event) override;
+      QMenu* genItemPopup(MusEGui::CItem* item) override;
 
    private slots:
       void midiNote(int pitch, int velo);


### PR DESCRIPTION
1. More information in tooltip when over a note.
2. Global setting to switch off note tooltips.
3. Right click in piano roll toggles selection.