### PR TITLE
Remove track height from templates

### DIFF
--- a/muse3/share/templates/audio.med
+++ b/muse3/share/templates/audio.med
@@ -28,7 +28,6 @@
       <solo>0</solo>
       <off>0</off>
       <channels>2</channels>
-      <height>20</height>
       <locked>1</locked>
       <selected>1</selected>
       <prefader>0</prefader>
@@ -48,7 +47,6 @@
       <solo>0</solo>
       <off>0</off>
       <channels>2</channels>
-      <height>20</height>
       <locked>1</locked>
       <prefader>0</prefader>
       <sendMetronome>0</sendMetronome>
@@ -69,7 +67,6 @@
       <solo>0</solo>
       <off>0</off>
       <channels>1</channels>
-      <height>20</height>
       <locked>0</locked>
       <prefader>0</prefader>
       <sendMetronome>0</sendMetronome>
@@ -90,7 +87,6 @@
       <solo>0</solo>
       <off>0</off>
       <channels>1</channels>
-      <height>20</height>
       <locked>1</locked>
       <prefader>0</prefader>
       <sendMetronome>0</sendMetronome>
@@ -111,7 +107,6 @@
       <solo>0</solo>
       <off>0</off>
       <channels>1</channels>
-      <height>20</height>
       <locked>0</locked>
       <prefader>0</prefader>
       <sendMetronome>0</sendMetronome>
@@ -132,7 +127,6 @@
       <solo>0</solo>
       <off>0</off>
       <channels>1</channels>
-      <height>20</height>
       <locked>0</locked>
       <prefader>0</prefader>
       <sendMetronome>0</sendMetronome>
@@ -153,7 +147,6 @@
       <solo>0</solo>
       <off>0</off>
       <channels>1</channels>
-      <height>20</height>
       <locked>1</locked>
       <prefader>0</prefader>
       <sendMetronome>0</sendMetronome>
@@ -174,7 +167,6 @@
       <solo>0</solo>
       <off>0</off>
       <channels>1</channels>
-      <height>20</height>
       <locked>0</locked>
       <prefader>0</prefader>
       <sendMetronome>0</sendMetronome>
@@ -195,7 +187,6 @@
       <solo>0</solo>
       <off>0</off>
       <channels>2</channels>
-      <height>20</height>
       <locked>1</locked>
       <prefader>0</prefader>
       <sendMetronome>0</sendMetronome>
@@ -214,7 +205,6 @@
       <solo>0</solo>
       <off>0</off>
       <channels>2</channels>
-      <height>20</height>
       <locked>1</locked>
       <prefader>0</prefader>
       <sendMetronome>0</sendMetronome>

--- a/muse3/share/templates/default.med
+++ b/muse3/share/templates/default.med
@@ -28,7 +28,6 @@
       <solo>0</solo>
       <off>0</off>
       <channels>2</channels>
-      <height>20</height>
       <locked>0</locked>
       <selected>1</selected>
       <prefader>0</prefader>

--- a/muse3/share/templates/midiGM.med
+++ b/muse3/share/templates/midiGM.med
@@ -28,7 +28,6 @@
       <solo>0</solo>
       <off>0</off>
       <channels>0</channels>
-      <height>20</height>
       <locked>0</locked>
       <selected>1</selected>
       <device>-1</device>
@@ -50,7 +49,6 @@
       <solo>0</solo>
       <off>0</off>
       <channels>0</channels>
-      <height>20</height>
       <locked>0</locked>
       <device>-1</device>
       <channel>1</channel>
@@ -71,7 +69,6 @@
       <solo>0</solo>
       <off>0</off>
       <channels>0</channels>
-      <height>20</height>
       <locked>0</locked>
       <device>-1</device>
       <channel>2</channel>
@@ -92,7 +89,6 @@
       <solo>0</solo>
       <off>0</off>
       <channels>0</channels>
-      <height>20</height>
       <locked>0</locked>
       <device>-1</device>
       <channel>3</channel>
@@ -113,7 +109,6 @@
       <solo>0</solo>
       <off>0</off>
       <channels>0</channels>
-      <height>20</height>
       <locked>0</locked>
       <device>-1</device>
       <channel>9</channel>

--- a/muse3/share/templates/monorecord.med
+++ b/muse3/share/templates/monorecord.med
@@ -28,7 +28,6 @@
       <solo>0</solo>
       <off>0</off>
       <channels>1</channels>
-      <height>20</height>
       <locked>1</locked>
       <prefader>0</prefader>
       <sendMetronome>1</sendMetronome>
@@ -47,7 +46,6 @@
       <solo>0</solo>
       <off>0</off>
       <channels>1</channels>
-      <height>20</height>
       <locked>1</locked>
       <prefader>0</prefader>
       <sendMetronome>0</sendMetronome>
@@ -66,7 +64,6 @@
       <solo>0</solo>
       <off>0</off>
       <channels>1</channels>
-      <height>20</height>
       <locked>0</locked>
       <selected>1</selected>
       <prefader>0</prefader>

--- a/muse3/share/templates/synti.med
+++ b/muse3/share/templates/synti.med
@@ -28,7 +28,6 @@
       <solo>0</solo>
       <off>0</off>
       <channels>2</channels>
-      <height>20</height>
       <locked>0</locked>
       <prefader>0</prefader>
       <sendMetronome>1</sendMetronome>
@@ -47,7 +46,6 @@
       <solo>0</solo>
       <off>1</off>
       <channels>1</channels>
-      <height>20</height>
       <locked>0</locked>
       <prefader>0</prefader>
       <sendMetronome>0</sendMetronome>
@@ -82,7 +80,6 @@
       <solo>0</solo>
       <off>0</off>
       <channels>1</channels>
-      <height>20</height>
       <locked>0</locked>
       <prefader>0</prefader>
       <sendMetronome>0</sendMetronome>
@@ -121,7 +118,6 @@
       <solo>0</solo>
       <off>0</off>
       <channels>0</channels>
-      <height>20</height>
       <locked>0</locked>
       <selected>1</selected>
       <device>199</device>


### PR DESCRIPTION
Track height should be read from the global setting when loading a template. 
Parameter removed from all templates.