### PR TITLE
Add right click single selection

### DIFF
--- a/muse3/ChangeLog
+++ b/muse3/ChangeLog
@@ -1,8 +1,10 @@
 18.03.2020
 	- Enable multiple resizing in piano roll (#748) (kybos)
 	- Enable CTRL+Left Mouse Click item selection in edit mode in piano roll (kybos)
+	- Enable Right Mouse Click for exclusive single selection in edit mode/piano roll (kybos)
 17.03.2020
 	- Add more information to note tooltips in midi editors (kybos)
+	- Add global setting for switching off the note tooltips (kybos)
 	- Remove fixed track heigth from file templates, to enforce global setting (kybos)
 09.03.2020
 	- Transfer Help content to github wiki, link Manual to wiki in MusE (kybos)

--- a/muse3/muse/midiedit/prcanvas.cpp
+++ b/muse3/muse/midiedit/prcanvas.cpp
@@ -1934,8 +1934,9 @@ void PianoCanvas::mouseMove(QMouseEvent* event) {
 //   genItemPopup (override)
 //---------------------------------------------------------
 QMenu* PianoCanvas::genItemPopup(MusEGui::CItem* item) {
-    // no context menu available, use for item selection
-    item->setSelected(!item->isSelected());
+    // no context menu available, use for single item selection
+    deselectAll();
+    item->setSelected(true);
     return nullptr;
 }
 


### PR DESCRIPTION
Mouse right click selects item exclusively in piano roll edit mode.