### PR TITLE
Fix drumlist colors

### DIFF
--- a/muse3/muse/components/appearance.cpp
+++ b/muse3/muse/components/appearance.cpp
@@ -219,11 +219,14 @@ Appearance::Appearance(Arranger* a, QWidget* parent)
            new IdListViewItem(0x41d, id, "Controller graph color");
            new IdListViewItem(0x423, id, "Controller graph background");
            new IdListViewItem(0x421, id, "Background");
-           new IdListViewItem(0x422, id, "Drum list");
            new IdListViewItem(0x429, id, "Raster beat");
            new IdListViewItem(0x42a, id, "Raster bar");
            new IdListViewItem(0x42e, id, "Raster fine");
-
+           new IdListViewItem(0x42f, id, "Divider line");
+           new IdListViewItem(0x422, id, "Drum list background");
+           new IdListViewItem(0x440, id, "Drum list font");
+           new IdListViewItem(0x441, id, "Drum list selection");
+           new IdListViewItem(0x442, id, "Drum list selection font");
 
       id = new IdListViewItem(0, itemList, "Wave Editor");
            new IdListViewItem(0x300, id, "Background");
@@ -405,6 +408,11 @@ QColor* Appearance::globalConfigColorFromId(int id) const
       case 0x42c: return &MusEGlobal::config.partCanvasCoarseRasterColor; break;
       case 0x42d: return &MusEGlobal::config.partCanvasFineRasterColor; break;
       case 0x42e: return &MusEGlobal::config.midiCanvasFineColor; break;
+      case 0x42f: return &MusEGlobal::config.midiDividerColor; break;
+
+      case 0x440: return &MusEGlobal::config.drumListFont; break;
+      case 0x441: return &MusEGlobal::config.drumListSel; break;
+      case 0x442: return &MusEGlobal::config.drumListSelFont; break;
 
       case 0x500: return &MusEGlobal::config.mixerBg;   break;
       case 0x501: return &MusEGlobal::config.midiTrackLabelBg;   break;

--- a/muse3/muse/conf.cpp
+++ b/muse3/muse/conf.cpp
@@ -1069,10 +1069,20 @@ void readConfiguration(Xml& xml, bool doReadMidiPortConfig, bool doReadGlobalCon
                         else if (tag == "midiCanvasBarColor")
                               MusEGlobal::config.midiCanvasBarColor = readColor(xml);
 
+                        else if (tag == "midiDividerColor")
+                            MusEGlobal::config.midiDividerColor = readColor(xml);
+
                         else if (tag == "midiControllerViewBackgroundColor")
                               MusEGlobal::config.midiControllerViewBg = readColor(xml);
+
                         else if (tag == "drumListBackgroundColor")
                               MusEGlobal::config.drumListBg = readColor(xml);
+                        else if (tag == "drumListFont")
+                            MusEGlobal::config.drumListFont = readColor(xml);
+                        else if (tag == "drumListSel")
+                            MusEGlobal::config.drumListSel = readColor(xml);
+                        else if (tag == "drumListSelFont")
+                            MusEGlobal::config.drumListSelFont = readColor(xml);
 
                         else if (tag == "maxAliasedPointSize")
 
@@ -1678,9 +1688,13 @@ void writeConfigurationColors(int level, MusECore::Xml& xml, bool partColorNames
       xml.colorTag(level, "midiCanvasFineColor", MusEGlobal::config.midiCanvasFineColor);
       xml.colorTag(level, "midiCanvasBeatColor", MusEGlobal::config.midiCanvasBeatColor);
       xml.colorTag(level, "midiCanvasBarColor", MusEGlobal::config.midiCanvasBarColor);
+      xml.colorTag(level, "midiDividerColor", MusEGlobal::config.midiDividerColor);
 
       xml.colorTag(level, "midiControllerViewBackgroundColor", MusEGlobal::config.midiControllerViewBg);
       xml.colorTag(level, "drumListBackgroundColor", MusEGlobal::config.drumListBg);
+      xml.colorTag(level, "drumListFont", MusEGlobal::config.drumListFont);
+      xml.colorTag(level, "drumListSel", MusEGlobal::config.drumListSel);
+      xml.colorTag(level, "drumListSelFont", MusEGlobal::config.drumListSelFont);
 }
       
 

--- a/muse3/muse/gconfig.cpp
+++ b/muse3/muse/gconfig.cpp
@@ -168,10 +168,14 @@ GlobalConfigValues config = {
       QColor(255, 255, 255),        // Midi editor canvas
       QColor(255, 255, 255),        // midiControllerViewBg
       QColor(255, 255, 255),        // drumListBg
+      Qt::black,                    // drumListFont
+      Qt::yellow,                   // drumListSel
+      Qt::black,                    // drumListSelFont
       QColor(255, 255, 255),        // rulerCurrent
       QColor(210, 210, 210),        // midiCanvasFineColor
       QColor(130, 130, 130),        // midiCanvasBeatColor
       Qt::black,                    // midiCanvasBarColor
+      Qt::gray,                     // midiDividerColor
       Qt::lightGray,                // waveNonselectedPart
       Qt::darkGray,                 // wavePeakColor
       Qt::black,                    // waveRmsColor

--- a/muse3/muse/gconfig.h
+++ b/muse3/muse/gconfig.h
@@ -227,10 +227,14 @@ struct GlobalConfigValues {
       QColor midiCanvasBg;
       QColor midiControllerViewBg;
       QColor drumListBg;
+      QColor drumListFont;
+      QColor drumListSel;
+      QColor drumListSelFont;
       QColor rulerCurrent;
       QColor midiCanvasFineColor;
       QColor midiCanvasBeatColor;
       QColor midiCanvasBarColor;
+      QColor midiDividerColor;
 
       QColor waveNonselectedPart;
       QColor wavePeakColor;

--- a/muse3/muse/midiedit/dcanvas.cpp
+++ b/muse3/muse/midiedit/dcanvas.cpp
@@ -740,7 +740,7 @@ void DrumCanvas::drawCanvas(QPainter& p, const QRect& mr, const QRegion& rg)
 
       QPen pen;
       pen.setCosmetic(true);
-      pen.setColor(Qt::gray);
+      pen.setColor(MusEGlobal::config.midiDividerColor);
       p.setPen(pen);
       
       //---------------------------------------------------

--- a/muse3/muse/midiedit/dlist.cpp
+++ b/muse3/muse/midiedit/dlist.cpp
@@ -268,9 +268,9 @@ void DList::draw(QPainter& p, const QRect& mr, const QRegion&)
       //    Tracks
       //---------------------------------------------------
 
-      p.setPen(Qt::black);
+      p.setPen(MusEGlobal::config.drumListFont);
       QColor override_col(Qt::gray);
-      override_col.setAlpha(64);
+      override_col.setAlpha(_alphaOverlay);
 
       QFont fnt(p.font());
       QRect rtmp = map(QRect(0, 0, 0, TH));
@@ -284,8 +284,12 @@ void DList::draw(QPainter& p, const QRect& mr, const QRegion&)
             if (yy > uy + uh)
                   break;
             MusECore::DrumMap* dm = &ourDrumMap[instrument];
-            if (dm == currentlySelected)
-                  p.fillRect(ux, yy, uw, TH, Qt::yellow);
+            if (dm == currentlySelected) {
+                  p.fillRect(ux, yy, uw, TH, MusEGlobal::config.drumListSel);
+                  p.setPen(MusEGlobal::config.drumListSelFont);
+            } else {
+                p.setPen(MusEGlobal::config.drumListFont);
+            }
 //            else
 //                  p.eraseRect(x, yy, w, TH); DELETETHIS?
             QHeaderView *h = header;
@@ -300,7 +304,7 @@ void DList::draw(QPainter& p, const QRect& mr, const QRegion&)
                   int x   = h->sectionPosition(k);
                   int w   = h->sectionSize(k);
                   //QRect r = p.combinedTransform().mapRect(QRect(x+2, yy, w-4, TH));  // Gives inconsistent positions. Source shows wrong operation for our needs.
-                  QRect r = map(QRect(x+2, yy, w-4, TH));                              // Use our own map instead.
+                  QRect r = map(QRect(x, yy, w, TH));                              // Use our own map instead.
                   QString s;
                   int align = Qt::AlignVCenter | Qt::AlignHCenter;
 
@@ -373,7 +377,7 @@ void DList::draw(QPainter& p, const QRect& mr, const QRegion&)
                                 if (!hidden && !shown)
                                   printf("THIS SHOULD NEVER HAPPEN: in DList::draw(): instrument %i's track group is empty. strange...\n", instrument);
 
-                                const QPixmap* pm = NULL;
+                                const QPixmap* pm = nullptr;
 
                                 if (shown && !hidden)
                                       pm = eyeIcon;
@@ -382,7 +386,7 @@ void DList::draw(QPainter& p, const QRect& mr, const QRegion&)
                                 else if (shown && hidden)
                                       pm = eyeGrayIcon;
                                 else //if (!shown && !hidden)
-                                      pm = NULL;
+                                      pm = nullptr;
 
                                 if (pm)
                                 {
@@ -418,13 +422,13 @@ void DList::draw(QPainter& p, const QRect& mr, const QRegion&)
                               if(isWorkingItem == MusECore::WorkingDrumMapEntry::NoOverride)
                                 p.fillRect(r, override_col);
                               if (dm->mute) {
-                                    p.setPen(Qt::red);
+//                                    p.setPen(Qt::red);
                                     const QPixmap& pm = *muteIcon;
                                     p.drawPixmap(
                                        r.x() + r.width()/2 - pm.width()/2,
                                        r.y() + r.height()/2 - pm.height()/2,
                                        pm);
-                                    p.setPen(Qt::black);
+//                                    p.setPen(Qt::black);
                                     }
                               break;
                         case COL_NAME:
@@ -628,7 +632,7 @@ void DList::draw(QPainter& p, const QRect& mr, const QRegion&)
       //    horizontal lines
       //---------------------------------------------------
 
-      p.setPen(Qt::gray);
+      p.setPen(MusEGlobal::config.midiDividerColor);
       int yy  = (uy / TH) * TH;
       for (; yy < uy + uh; yy += TH) {
             p.drawLine(ux, yy, ux + uw, yy);
@@ -1744,10 +1748,10 @@ void DList::init(QHeaderView* h, QWidget* parent)
       connect(header, SIGNAL(sectionMoved(int, int,int)), SLOT(moved(int,int,int)));
       setFocusPolicy(Qt::StrongFocus);
       drag = NORMAL;
-      editor = 0;
-      val_editor = 0;
-      pitch_editor = 0;
-      editEntry = 0;
+      editor = nullptr;
+      val_editor = nullptr;
+      pitch_editor = nullptr;
+      editEntry = nullptr;
 
       if (ourDrumMapSize!=0)
       {
@@ -1756,7 +1760,7 @@ void DList::init(QHeaderView* h, QWidget* parent)
       }
       else
       {
-        currentlySelected = NULL;
+        currentlySelected = nullptr;
       }
       
       selectedColumn = -1;
@@ -1766,6 +1770,7 @@ void DList::init(QHeaderView* h, QWidget* parent)
 DList::DList(QHeaderView* h, QWidget* parent, int ymag, DrumCanvas* dcanvas_)
    : MusEGui::View(parent, 1, ymag)
       {
+      _alphaOverlay = 64;
       dcanvas=dcanvas_;
       ourDrumMap=dcanvas->getOurDrumMap();
       ourDrumMapSize=dcanvas->getOurDrumMapSize();
@@ -1777,7 +1782,8 @@ DList::DList(QHeaderView* h, QWidget* parent, int ymag, DrumCanvas* dcanvas_)
 DList::DList(QHeaderView* h, QWidget* parent, int ymag, MusECore::DrumMap* dm, int dmSize)
    : MusEGui::View(parent, 1, ymag)
       {
-      dcanvas=NULL;
+      _alphaOverlay = 64;
+      dcanvas = nullptr;
       ourDrumMap=dm;
       ourDrumMapSize=dmSize;
       

--- a/muse3/muse/midiedit/dlist.h
+++ b/muse3/muse/midiedit/dlist.h
@@ -137,6 +137,9 @@ class DPitchEdit: public PitchEdit
 class DList : public View {
       Q_OBJECT
 
+      Q_PROPERTY(quint8 alphaOverlay READ alphaOverlay WRITE setAlphaOverlay)
+
+      int _alphaOverlay;
       MusEGui::DrumCanvas* dcanvas;
       MusECore::DrumMap* ourDrumMap;
       int ourDrumMapSize;
@@ -202,6 +205,8 @@ class DList : public View {
       virtual ~DList();
       int getSelectedInstrument();
 
+      quint8 alphaOverlay() { return _alphaOverlay; }
+      void setAlphaOverlay(quint8 i) { _alphaOverlay = i; }
       };
 
 } // namespace MusEGui

--- a/muse3/muse/midiedit/prcanvas.cpp
+++ b/muse3/muse/midiedit/prcanvas.cpp
@@ -1481,7 +1481,8 @@ void PianoCanvas::drawCanvas(QPainter& p, const QRect& mr, const QRegion& rg)
 
       QPen pen;
       pen.setCosmetic(true);
-      pen.setColor(Qt::black);
+      pen.setColor(MusEGlobal::config.midiDividerColor);
+//      pen.setColor(Qt::black);
       p.setPen(pen);
       
       //---------------------------------------------------


### PR DESCRIPTION
Fixing drum list colour problems, especially with dark bg (currently only bg colour can be set):

![image](https://user-images.githubusercontent.com/10009541/80858808-21319980-8c5c-11ea-8b4a-d4f1d8627680.png)

Drawing artefacts have been corrected (HiDPI problem again?).
All relevant colours can be customized now, also the horizontal/vertical divider lines in the midi editors (they were hard-coded and too intrusive with dark bg).
The alpha overlay value in drum list can be changed too, exposed as css property.

![image](https://user-images.githubusercontent.com/10009541/80859003-cac55a80-8c5d-11ea-9c74-2f78c3c26a4d.png)
