### PR TITLE
Pr fix wrong slider groove height

### DIFF
--- a/muse3/ChangeLog
+++ b/muse3/ChangeLog
@@ -1,3 +1,5 @@
+22.06.2010
+	- Fix slider/meter groove misalignment in mixer strip. (kybos)
 20.06.2010
     - Cmake option changes (Tim): Removed ancient ENABLE_VST and ENABLE_EXPERIMENTAL,
        and dangerous ENABLE_LV2_MAKE_PATH, and enabled ENABLE_PYTHON by default since

--- a/muse3/muse/components/slider.cpp
+++ b/muse3/muse/components/slider.cpp
@@ -69,16 +69,16 @@ namespace MusEGui {
 
 Slider::Slider(QWidget *parent, const char *name,
                Qt::Orientation orient,
-               ScalePos scalePos, 
-               int grooveWidth, 
-               QColor fillColor, 
+               ScalePos scalePos,
+               int grooveWidth,
+               QColor fillColor,
                ScaleDraw::TextHighlightMode textHighlightMode,
                QColor handleColor)
       : SliderBase(parent,name), d_scalePos(scalePos), d_grooveWidth(grooveWidth),
         d_fillColor(fillColor), d_handleColor(handleColor)
       {
       setPagingButtons(Qt::RightButton);
-      
+
       d_thumbLength = 16;
       d_thumbHalf = 8;
       d_thumbWidth = 16;
@@ -175,7 +175,7 @@ void Slider::setThumbWidth(int w)
 
 
 //------------------------------------------------------------
-//.-  
+//.-
 //.F  Slider::scaleChange
 //  Notify changed scale
 //
@@ -198,7 +198,7 @@ void Slider::scaleChange()
 //.-
 //.F  Slider::fontChange
 //  Notify change in font
-//  
+//
 //.u  Syntax
 //.f   Slider::fontChange(const QFont &oldFont)
 //
@@ -227,7 +227,7 @@ void Slider::drawThumb(QPainter *p, const QRect &r)
   thumbGrad.setColorAt(0, thumb_edge);
   thumbGrad.setColorAt(0.5, thumb_center);
   thumbGrad.setColorAt(1, thumb_edge);
-  
+
   const double rpos = (value(ConvertNone) - minValue(ConvertNone)) / (maxValue(ConvertNone) - minValue(ConvertNone));
 
   if(d_orient == Qt::Horizontal)
@@ -243,24 +243,24 @@ void Slider::drawThumb(QPainter *p, const QRect &r)
       crh = r.height() - 2 * d_mMargin;
       thh = r.height();
     }
-    
+
     const QRect cr(r.x(),
                    r.y() + d_mMargin,
                    r.width(),
                    //r.height() - 2*d_mMargin);
                    crh);
-    
+
     const int dist1 = int(double(cr.width() - d_thumbLength) * rpos);
     const int ipos =  cr.x() + dist1;
     markerPos = ipos + d_thumbHalf;
-    
+
     //
     //  Draw thumb
     //
-        
-    QPainterPath thumb_rect = MusECore::roundedPath(ipos, r.y(), 
-                                          //d_thumbLength, r.height(), 
-                                          d_thumbLength, thh, 
+
+    QPainterPath thumb_rect = MusECore::roundedPath(ipos, r.y(),
+                                          //d_thumbLength, r.height(),
+                                          d_thumbLength, thh,
                                           d_radiusHandle, d_radiusHandle,
                                           (MusECore::Corner) (MusECore::UpperLeft | MusECore::UpperRight | MusECore::LowerLeft | MusECore::LowerRight) );
 
@@ -268,7 +268,7 @@ void Slider::drawThumb(QPainter *p, const QRect &r)
 //     thumbGrad.setFinalStop(QPointF(0, cr.y() + cr.height()));
     thumbGrad.setStart(QPointF(ipos, 0));
     thumbGrad.setFinalStop(QPointF(ipos + d_thumbLength, 0));
-        
+
     if(d_fillThumb)
       p->fillPath(thumb_rect, QBrush(thumbGrad));
     else
@@ -276,7 +276,7 @@ void Slider::drawThumb(QPainter *p, const QRect &r)
       p->setPen(pal.shadow().color());
       p->drawPath(thumb_rect);
     }
-        
+
     // center line
     p->fillRect(ipos + d_thumbHalf, cr.y(), 1, cr.height(), pal.dark().color());
   }
@@ -293,32 +293,32 @@ void Slider::drawThumb(QPainter *p, const QRect &r)
       crw = r.width() - 2 * d_mMargin;
       thw = r.width();
     }
-    
+
     const QRect cr(r.x() + d_mMargin,
                    r.y(),
                    //r.width() - 2*d_mMargin,
                    crw,
                    r.height());
-    
+
     const int dist1 = int(double(cr.height() - d_thumbLength) * (1.0 - rpos));
     const int ipos = cr.y() + dist1;
     markerPos = ipos + d_thumbHalf;
-    
+
     //
     //  Draw thumb
     //
-        
-    QPainterPath thumb_rect = MusECore::roundedPath(r.x(), ipos, 
+
+    QPainterPath thumb_rect = MusECore::roundedPath(r.x(), ipos,
                                           //r.width(), d_thumbLength,
                                           thw, d_thumbLength,
                                           d_radiusHandle, d_radiusHandle,
                                           (MusECore::Corner) (MusECore::UpperLeft | MusECore::UpperRight | MusECore::LowerLeft | MusECore::LowerRight) );
-        
+
 //     thumbGrad.setStart(QPointF(cr.x(), 0));
 //     thumbGrad.setFinalStop(QPointF(cr.x() + cr.width(), 0));
     thumbGrad.setStart(QPointF(0, ipos));
     thumbGrad.setFinalStop(QPointF(0, ipos + d_thumbLength));
-        
+
     if(d_fillThumb)
       p->fillPath(thumb_rect, QBrush(thumbGrad));
     else
@@ -326,16 +326,16 @@ void Slider::drawThumb(QPainter *p, const QRect &r)
       p->setPen(pal.shadow().color());
       p->drawPath(thumb_rect);
     }
-        
+
     // center line
     p->fillRect(cr.x(), ipos + d_thumbHalf, cr.width(), 1, pal.dark().color());
   }
-  
+
 }
 
 //------------------------------------------------------------
 //    drawSlider
-//     Draw the slider into the specified rectangle.  
+//     Draw the slider into the specified rectangle.
 //------------------------------------------------------------
 
 void Slider::drawSlider(QPainter *p, const QRect &r)
@@ -346,7 +346,7 @@ void Slider::drawSlider(QPainter *p, const QRect &r)
 
     // for the full side
     const double rpos = (value(ConvertNone)  - minValue(ConvertNone)) / (maxValue(ConvertNone) - minValue(ConvertNone));
-    
+
     QColor f_mask_min(d_fillColor.isValid() ? d_fillColor : pal.highlight().color());
     QColor f_mask_max(f_mask_min);
     if (d_useGradient) {
@@ -355,7 +355,7 @@ void Slider::drawSlider(QPainter *p, const QRect &r)
         f_mask_max.setAlpha(255);
     }
     QLinearGradient f_mask;
-	   
+
     if (d_orient == Qt::Horizontal)
         {
 
@@ -368,35 +368,35 @@ void Slider::drawSlider(QPainter *p, const QRect &r)
         //
         // Draw background
         //
-        
+
         const int dist1 = int(double(cr.width() - (d_fillThumb ? d_thumbLength : d_thumbHalf)) * rpos);
         const int ipos =  cr.x() + dist1;
         markerPos = ipos + d_thumbHalf;
 
         //
         // Draw groove empty right side
-        // 
-	   
+        //
+
         if(d_fillEmptySide)
         {
-          QPainterPath e_rect = MusECore::roundedPath(ipos + (d_fillThumb ? d_thumbLength : d_thumbHalf), cr.y(), 
-                                            cr.width() - (d_fillThumb ? d_thumbLength : d_thumbHalf) - dist1, cr.height(), 
+          QPainterPath e_rect = MusECore::roundedPath(ipos + (d_fillThumb ? d_thumbLength : d_thumbHalf), cr.y(),
+                                            cr.width() - (d_fillThumb ? d_thumbLength : d_thumbHalf) - dist1, cr.height(),
                                             d_radius, d_radius, (MusECore::Corner) (MusECore::UpperRight | MusECore::LowerRight) );
-    
+
           p->fillPath(e_rect, f_mask_min);
         }
-   
-   
+
+
         //
         // Draw groove full left side
         //
-           
+
         f_mask.setColorAt(0, f_mask_min);
         f_mask.setColorAt(1, f_mask_max);
         f_mask.setStart(QPointF(cr.x(), cr.y()));
         f_mask.setFinalStop(QPointF(cr.x() + ipos + (d_fillThumb ? 0 : d_thumbHalf), cr.y()));
-          
-        QPainterPath f_rect = MusECore::roundedPath(cr.x(), cr.y(), 
+
+        QPainterPath f_rect = MusECore::roundedPath(cr.x(), cr.y(),
                                           ipos + (d_fillThumb ? 0 : d_thumbHalf), cr.height(),
                                           d_radius, d_radius,
                                           (MusECore::Corner) (MusECore::LowerLeft | MusECore::UpperLeft) );
@@ -410,28 +410,34 @@ void Slider::drawSlider(QPainter *p, const QRect &r)
                        d_grooveWidth,
                        r.height());
 
+        QPainterPath clip_path = MusECore::roundedPath(cr.x(), cr.y() + d_thumbHalf,
+                                          cr.width(), r.height() - d_thumbLength,
+                                          d_radius, d_radius,
+                                          (MusECore::Corner) (MusECore::All) );
+        p->setClipPath(clip_path);
+
         //
         // Draw background
         //
-        
+
         const int dist1 = int(double(cr.height() - (d_fillThumb ? d_thumbLength : d_thumbHalf)) * (1.0 - rpos));
         const int ipos = cr.y() + dist1;
         markerPos = ipos + d_thumbHalf;
 
         //
         // Draw groove empty upper filling
-        // 
+        //
 
         if(d_fillEmptySide)
         {
-          QPainterPath e_rect = MusECore::roundedPath(cr.x(), cr.y(), 
+          QPainterPath e_rect = MusECore::roundedPath(cr.x(), cr.y(),
                                             cr.width(), ipos + (d_fillThumb ? 0 : d_thumbHalf),
                                             d_radius, d_radius,
                                             (MusECore::Corner) (MusECore::UpperLeft | MusECore::UpperRight) );
-              
+
           p->fillPath(e_rect, QBrush(f_mask_min));
-        }            
-            
+        }
+
         //
         // Draw groove lower filling mask
         //
@@ -440,12 +446,14 @@ void Slider::drawSlider(QPainter *p, const QRect &r)
         f_mask.setColorAt(1, f_mask_min);
         f_mask.setStart(QPointF(cr.x(), markerPos));
         f_mask.setFinalStop(QPointF(cr.x(), cr.y() + cr.height()));
-            
-        QPainterPath f_rect = MusECore::roundedPath(cr.x(), ipos + (d_fillThumb ? d_thumbLength : d_thumbHalf), 
+
+        QPainterPath f_rect = MusECore::roundedPath(cr.x(), ipos + (d_fillThumb ? d_thumbLength : d_thumbHalf),
                                           cr.width(), cr.height() - (d_fillThumb ? d_thumbLength : d_thumbHalf) - dist1,
                                           d_radius, d_radius, (MusECore::Corner) (MusECore::LowerLeft | MusECore::LowerRight) );
-	    
+
         p->fillPath(f_rect, QBrush(f_mask));
+
+        p->setClipPath(QPainterPath(), Qt::NoClip);
         }
 
 }
@@ -473,18 +481,18 @@ double Slider::getValue( const QPoint &p)
 
   if(borderlessMouse() && d_scrollMode != ScrDirect)
   {
-    DEBUG_SLIDER(stderr, "Slider::getValue value:%.20f p x:%d y:%d step:%.20f x change:%.20f\n", 
+    DEBUG_SLIDER(stderr, "Slider::getValue value:%.20f p x:%d y:%d step:%.20f x change:%.20f\n",
                          val, p.x(), p.y(), step(), p.x() * step());
     if(d_orient == Qt::Horizontal)
       return val + p.x() * step();
     else
       return val - p.y() * step();
   }
-  
+
   const double min = minValue(ConvertNone);
   const double max = maxValue(ConvertNone);
   const double drange = max - min;
-  
+
   if(d_orient == Qt::Horizontal)
   {
     if(r.width() <= d_thumbLength)
@@ -536,9 +544,9 @@ double Slider::moveValue(const QPoint &deltaP, bool fineMode)
 
   if((fineMode || borderlessMouse()) && d_scrollMode != ScrDirect)
   {
-    DEBUG_SLIDER(stderr, "Slider::moveValue value:%.20f p x:%d y:%d step:%.20f x change:%.20f\n", 
+    DEBUG_SLIDER(stderr, "Slider::moveValue value:%.20f p x:%d y:%d step:%.20f x change:%.20f\n",
                          val, deltaP.x(), deltaP.y(), step(), deltaP.x() * step());
-    
+
     double newval;
     if(d_orient == Qt::Horizontal)
       newval = val + deltaP.x() * step();
@@ -547,7 +555,7 @@ double Slider::moveValue(const QPoint &deltaP, bool fineMode)
     d_valAccum = newval; // Reset.
     return newval;
   }
-  
+
   const double min = minValue(ConvertNone);
   const double max = maxValue(ConvertNone);
   const double drange = max - min;
@@ -563,8 +571,8 @@ double Slider::moveValue(const QPoint &deltaP, bool fineMode)
       const double dval_diff = (drange * dpos) / dwidth;
       d_valAccum += dval_diff;
       rv = rint(d_valAccum / step()) * step();
-      
-      DEBUG_SLIDER(stderr, "Slider::moveValue Horizontal value:%.20f p dx:%d dy:%d drange:%.20f step:%.20f dval_diff:%.20f d_valAccum:%.20f rv:%.20f\n", 
+
+      DEBUG_SLIDER(stderr, "Slider::moveValue Horizontal value:%.20f p dx:%d dy:%d drange:%.20f step:%.20f dval_diff:%.20f d_valAccum:%.20f rv:%.20f\n",
                        val, deltaP.x(), deltaP.y(), drange, step(), dval_diff, d_valAccum, rv);
     }
   }
@@ -579,8 +587,8 @@ double Slider::moveValue(const QPoint &deltaP, bool fineMode)
       const double dval_diff = (drange * dpos) / dheight;
       d_valAccum += dval_diff;
       rv = rint(d_valAccum / step()) * step();
-      
-      DEBUG_SLIDER(stderr, "Slider::moveValue Vertical value:%.20f p dx:%d dy:%d drange:%.20f step:%.20f dval_diff:%.20f d_valAccum:%.20f rv:%.20f\n", 
+
+      DEBUG_SLIDER(stderr, "Slider::moveValue Vertical value:%.20f p dx:%d dy:%d drange:%.20f step:%.20f dval_diff:%.20f d_valAccum:%.20f rv:%.20f\n",
                        val, deltaP.x(), deltaP.y(), drange, step(), dval_diff, d_valAccum, rv);
     }
   }
@@ -612,7 +620,7 @@ void Slider::getScrollMode( QPoint &p, const Qt::MouseButton &button, const Qt::
     direction = 0;
     return;
   }
-  
+
   if(borderlessMouse())
   {
     if(button != Qt::NoButton && d_sliderRect.contains(p))
@@ -639,18 +647,18 @@ void Slider::getScrollMode( QPoint &p, const Qt::MouseButton &button, const Qt::
         double rpos;
 
         cr = d_sliderRect;
-  
+
         rpos = (value(ConvertNone)  - minValue(ConvertNone)) / (maxValue(ConvertNone) - minValue(ConvertNone));
-  
+
         if(d_orient == Qt::Horizontal)
         {
           dist1 = int(double(cr.width() - d_thumbLength) * rpos);
           ipos =  cr.x() + dist1;
           mp = ipos + d_thumbHalf;
-        
+
           p.setX(mp);
           cp = mapToGlobal( QPoint(mp, p.y()) );
-        }  
+        }
         else
         {
           dist1 = int(double(cr.height() - d_thumbLength) * (1.0 - rpos));
@@ -658,7 +666,7 @@ void Slider::getScrollMode( QPoint &p, const Qt::MouseButton &button, const Qt::
           mp = ipos + d_thumbHalf;
           p.setY(mp);
           cp = mapToGlobal( QPoint(p.x(), mp) );
-        }  
+        }
         cursor().setPos(cp.x(), cp.y());
         return;
       }
@@ -670,10 +678,10 @@ void Slider::getScrollMode( QPoint &p, const Qt::MouseButton &button, const Qt::
        currentPos = p.x();
       else
        currentPos = p.y();
-      
+
       if(d_sliderRect.contains(p))
       {
-        if((currentPos > markerPos - d_thumbHalf)  
+        if((currentPos > markerPos - d_thumbHalf)
             && (currentPos < markerPos + d_thumbHalf))
         {
           DEBUG_SLIDER(stderr, "Slider::getScrollMode ScrMouse\n");
@@ -695,7 +703,7 @@ void Slider::getScrollMode( QPoint &p, const Qt::MouseButton &button, const Qt::
       }
     }
   }
-  
+
   scrollMode = ScrNone;
   direction = 0;
 }
@@ -716,7 +724,7 @@ void Slider::paintEvent(QPaintEvent* /*ev*/)
 
   if(d_thumbLength != 0)
     drawThumb(&p, d_sliderRect);
-  if(d_scalePos != None) 
+  if(d_scalePos != None)
   {
 //     p.fillRect(rect(), palette().window());
     p.setRenderHint(QPainter::Antialiasing, false);
@@ -1011,9 +1019,9 @@ void Slider::setScaleBackBone(bool v)
 void Slider::valueChange()
       {
       update();
-      
+
       // HACK
-      // In direct mode let the inherited classes (this) call these in their valueChange() methods, 
+      // In direct mode let the inherited classes (this) call these in their valueChange() methods,
       //  so that they may be called BEFORE valueChanged signal is emitted by the setPosition() call above.
       // ScrDirect mode only happens once upon press with a modifier. After that, another mode is set.
       // Hack: Since valueChange() is NOT called if nothing changed, in that case these are called for us by the SliderBase.
@@ -1022,13 +1030,13 @@ void Slider::valueChange()
         processSliderPressed(id());
         emit sliderPressed(value(), id());
       }
-      
+
       // Emits valueChanged if tracking enabled.
       SliderBase::valueChange();
       }
 
 //------------------------------------------------------------
-//.-  
+//.-
 //.F  Slider::rangeChange
 //  Notify change of range
 //
@@ -1087,12 +1095,12 @@ QSize Slider::sizeHint() const
       const QFontMetrics fm = fontMetrics();
       int msWidth = 0, msHeight = 0;
 
-      if (d_scalePos != None) 
+      if (d_scalePos != None)
       {
         msWidth = d_scale.maxWidth(fm, false);
         msHeight = d_scale.maxHeight(fm);
 
-        switch(d_orient) 
+        switch(d_orient)
         {
           case Qt::Vertical:
           {
@@ -1104,14 +1112,14 @@ QSize Slider::sizeHint() const
               case Right:
                 w = 2*d_xMargin + d_thumbWidth + smw + 2;
               break;
-              
+
               case InsideVertical:
               {
                 const int aw = smw > d_thumbWidth ? smw : d_thumbWidth;
                 w = 2*d_xMargin + aw + 2;
               }
               break;
-              
+
               case Top:
               case Bottom:
               case InsideHorizontal:
@@ -1120,7 +1128,7 @@ QSize Slider::sizeHint() const
             }
           }
           break;
-            
+
           case Qt::Horizontal:
           {
             w = horizontal_hint;
@@ -1131,14 +1139,14 @@ QSize Slider::sizeHint() const
               case Bottom:
                 h = 2*d_yMargin + d_thumbWidth + smh;
               break;
-              
+
               case InsideHorizontal:
               {
                 const int ah = smh > d_thumbWidth ? smh : d_thumbWidth;
                 h = 2*d_yMargin + ah;
               }
               break;
-              
+
               case Left:
               case Right:
               case InsideVertical:
@@ -1151,7 +1159,7 @@ QSize Slider::sizeHint() const
       }
       else
       {      // no scale
-        switch(d_orient) 
+        switch(d_orient)
         {
           case Qt::Vertical:
                 w = 16;

--- a/muse3/muse/components/slider.h
+++ b/muse3/muse/components/slider.h
@@ -153,27 +153,27 @@ class Slider : public SliderBase, public ScaleIf
 
   void setMargins(int x, int y);
   int grooveWidth() const { return d_grooveWidth; }
-  void setGrooveWidth(int w) { d_grooveWidth = w; update(); }
+  void setGrooveWidth(int w) { d_grooveWidth = w; }
   
 //  QColor fillColor() const { return d_fillColor; }
   void setFillColor(const QColor& color) { d_fillColor = color; update(); }
   void setHandleColor(const QColor& color) { d_handleColor = color; update(); }
   
   bool fillThumb() const { return d_fillThumb; }
-  void setFillThumb(bool v) { d_fillThumb = v; update(); }
+  void setFillThumb(bool v) { d_fillThumb = v; }
   
   bool fillEmptySide() const { return d_fillEmptySide; }
-  void setFillEmptySide(bool v) { d_fillEmptySide = v; update(); }
+  void setFillEmptySide(bool v) { d_fillEmptySide = v; }
   
   virtual QSize sizeHint() const;
   void setSizeHint(uint w, uint h);
 
-  void setRadius(int r) { d_radius = r; update(); }
-  void setRadiusHandle(int r) { d_radiusHandle = r; update(); }
-  void setHandleHeight(int h) { d_thumbLength = h; update(); }
-  void setHandleWidth(int w) { d_thumbWidth = w; d_thumbHalf = d_thumbLength / 2; update(); }
-  void setUseGradient(bool b) { d_useGradient = b; update(); }
-  void setScalePos(ScalePos s) { d_scalePos = s; update(); }
+  void setRadius(int r) { d_radius = r; }
+  void setRadiusHandle(int r) { d_radiusHandle = r; }
+  void setHandleHeight(int h) { d_thumbLength = h; }
+  void setHandleWidth(int w) { d_thumbWidth = w; d_thumbHalf = d_thumbLength / 2; }
+  void setUseGradient(bool b) { d_useGradient = b; }
+  void setScalePos(ScalePos s) { d_scalePos = s; }
       };
 
 } // namespace MusEGui

--- a/muse3/muse/components/utils.h
+++ b/muse3/muse/components/utils.h
@@ -40,7 +40,7 @@
 
 namespace MusECore {
 
-enum Corner { UpperLeft = 0x1, UpperRight = 0x2, LowerLeft = 0x4, LowerRight = 0x8 };
+enum Corner { UpperLeft = 0x1, UpperRight = 0x2, LowerLeft = 0x4, LowerRight = 0x8, All = 0xF };
 
 extern QString bitmap2String(int bm);
 extern int string2bitmap(const QString& str);

--- a/muse3/muse/mixer/astrip.cpp
+++ b/muse3/muse/mixer/astrip.cpp
@@ -797,6 +797,7 @@ AudioStripProperties::AudioStripProperties()
     _sliderFillOver = true;
     _sliderUseGradient = true;
     _sliderBackbone = false;
+    _sliderFillHandle = true;
     _sliderGrooveWidth = 14;
     _sliderScalePos = Slider::InsideVertical;
     _meterWidth = Strip::FIXED_METER_WIDTH;
@@ -1420,6 +1421,7 @@ AudioStrip::AudioStrip(QWidget* parent, MusECore::AudioTrack* at, bool hasHandle
       _sliderFillOver = props.sliderFillOver();
       _sliderUseGradient = props.sliderUseGradient();
       _sliderBackbone = props.sliderBackbone();
+      _sliderFillHandle = props.sliderFillHandle();
       _sliderScalePos = props.sliderScalePos();
       _meterWidth = props.meterWidth();
       _meterWidthPerChannel = props.meterWidthPerChannel();
@@ -1628,6 +1630,7 @@ AudioStrip::AudioStrip(QWidget* parent, MusECore::AudioTrack* at, bool hasHandle
       slider->setRadiusHandle(_sliderRadiusHandle);
       slider->setHandleHeight(_sliderHandleHeight);
       slider->setHandleWidth(_sliderHandleWidth);
+      slider->setFillThumb(_sliderFillHandle);
       slider->setGrooveWidth(_sliderGrooveWidth);
       slider->setFillEmptySide(_sliderFillOver);
       slider->setUseGradient(_sliderUseGradient);

--- a/muse3/muse/mixer/astrip.h
+++ b/muse3/muse/mixer/astrip.h
@@ -130,6 +130,7 @@ class AudioStripProperties : QWidget {
     Q_PROPERTY(bool sliderFillOver READ sliderFillOver WRITE setSliderFillOver)
     Q_PROPERTY(bool sliderUseGradient READ sliderUseGradient WRITE setSliderUseGradient)
     Q_PROPERTY(bool sliderBackbone READ sliderBackbone WRITE setSliderBackbone)
+    Q_PROPERTY(bool sliderFillHandle READ sliderFillHandle WRITE setSliderFillHandle)
     Q_PROPERTY(int sliderScalePos READ sliderScalePos WRITE setSliderScalePos)
     Q_PROPERTY(int meterWidth READ meterWidth WRITE setMeterWidth)
     Q_PROPERTY(bool meterWidthPerChannel READ meterWidthPerChannel WRITE setMeterWidthPerChannel)
@@ -144,6 +145,7 @@ class AudioStripProperties : QWidget {
     bool _sliderFillOver;
     bool _sliderUseGradient;
     bool _sliderBackbone;
+    bool _sliderFillHandle;
     int _sliderScalePos;
     int _meterWidth;
     bool _meterWidthPerChannel;
@@ -173,6 +175,8 @@ public:
     void setSliderUseGradient(bool b) { _sliderUseGradient = b; }
     bool sliderBackbone() const { return _sliderBackbone; }
     void setSliderBackbone(bool b) { _sliderBackbone = b; }
+    bool sliderFillHandle() const { return _sliderFillHandle; }
+    void setSliderFillHandle(bool b) { _sliderFillHandle = b; }
 
     int sliderScalePos() const { return _sliderScalePos; }
     void setSliderScalePos(int p) { _sliderScalePos = p; }
@@ -229,6 +233,7 @@ class AudioStrip : public Strip {
       bool _sliderFillOver;
       bool _sliderUseGradient;
       bool _sliderBackbone;
+      bool _sliderFillHandle;
       int _sliderScalePos;
       int _meterWidth;
       bool _meterWidthPerChannel;

--- a/muse3/muse/mixer/mstrip.cpp
+++ b/muse3/muse/mixer/mstrip.cpp
@@ -1405,6 +1405,7 @@ MidiStripProperties::MidiStripProperties()
     _sliderFillOver = true;
     _sliderUseGradient = true;
     _sliderBackbone = false;
+    _sliderFillHandle = true;
     _sliderGrooveWidth = 14;
     _sliderScalePos = Slider::InsideVertical;
     _meterWidth = Strip::FIXED_METER_WIDTH;
@@ -1445,6 +1446,7 @@ MidiStrip::MidiStrip(QWidget* parent, MusECore::MidiTrack* t, bool hasHandle, bo
       _sliderFillOver = props.sliderFillOver();
       _sliderUseGradient = props.sliderUseGradient();
       _sliderBackbone = props.sliderBackbone();
+      _sliderFillHandle = props.sliderFillHandle();
       _sliderScalePos = props.sliderScalePos();
       _meterWidth = props.meterWidth();
       _meterSpacing = props.meterSpacing();
@@ -1600,6 +1602,7 @@ MidiStrip::MidiStrip(QWidget* parent, MusECore::MidiTrack* t, bool hasHandle, bo
       slider->setRadiusHandle(_sliderRadiusHandle);
       slider->setHandleHeight(_sliderHandleHeight);
       slider->setHandleWidth(_sliderHandleWidth);
+      slider->setFillThumb(_sliderFillHandle);
       slider->setGrooveWidth(_sliderGrooveWidth);
       slider->setFillEmptySide(_sliderFillOver);
       slider->setUseGradient(_sliderUseGradient);

--- a/muse3/muse/mixer/mstrip.h
+++ b/muse3/muse/mixer/mstrip.h
@@ -199,6 +199,7 @@ class MidiStripProperties : QWidget {
     Q_PROPERTY(bool sliderFillOver READ sliderFillOver WRITE setSliderFillOver)
     Q_PROPERTY(bool sliderUseGradient READ sliderUseGradient WRITE setSliderUseGradient)
     Q_PROPERTY(bool sliderBackbone READ sliderBackbone WRITE setSliderBackbone)
+    Q_PROPERTY(bool sliderFillHandle READ sliderFillHandle WRITE setSliderFillHandle)
     Q_PROPERTY(int sliderScalePos READ sliderScalePos WRITE setSliderScalePos)
     Q_PROPERTY(int meterWidth READ meterWidth WRITE setMeterWidth)
     Q_PROPERTY(int meterSpacing READ meterSpacing WRITE setMeterSpacing)
@@ -212,6 +213,7 @@ class MidiStripProperties : QWidget {
     bool _sliderFillOver;
     bool _sliderUseGradient;
     bool _sliderBackbone;
+    bool _sliderFillHandle;
     int _sliderScalePos;
     int _meterWidth;
     int _meterSpacing;
@@ -240,6 +242,8 @@ public:
     void setSliderUseGradient(bool b) { _sliderUseGradient = b; }
     bool sliderBackbone() const { return _sliderBackbone; }
     void setSliderBackbone(bool b) { _sliderBackbone = b; }
+    bool sliderFillHandle() const { return _sliderFillHandle; }
+    void setSliderFillHandle(bool b) { _sliderFillHandle = b; }
 
     int sliderScalePos() const { return _sliderScalePos; }
     void setSliderScalePos(int p) { _sliderScalePos = p; }
@@ -280,6 +284,7 @@ class MidiStrip : public Strip {
     bool _sliderFillOver;
     bool _sliderUseGradient;
     bool _sliderBackbone;
+    bool _sliderFillHandle;
     int _sliderScalePos;
     int _meterWidth;
     int _meterSpacing;

--- a/muse3/share/themes/Dark Flat.qss
+++ b/muse3/share/themes/Dark Flat.qss
@@ -218,6 +218,9 @@ MusEGui--AudioStripProperties {
 /* draw vertical line in slider scale
     qproperty-sliderBackbone: true; 
 */
+/* fill slider handle with color
+    qproperty-sliderFillHandle: false; 
+*/
     qproperty-meterWidth: 10;
 /* apply meterWidth for each channel
     qproperty-meterWidthPerChannel: true;
@@ -240,6 +243,9 @@ MusEGui--MidiStripProperties {
     qproperty-sliderScalePos: 2; 
 /* draw vertical line in slider scale
     qproperty-sliderBackbone: true;
+*/
+/* fill slider handle with color
+    qproperty-sliderFillHandle: false; 
 */
     qproperty-meterWidth: 10;
 }


### PR DESCRIPTION
After Tim's recent meter/slider scale alignment, the grooves were misaligned. This was more a slider bug, the groove was unrealistically long. Fixed now.