### PR TITLE
Splitter states not saved at application quit

### DIFF
--- a/muse3/ChangeLog
+++ b/muse3/ChangeLog
@@ -8,6 +8,7 @@
         Status bar is mainly used for context-sensitive help, to improve 
         usability for new users. Many status tips created, more to come.
         Default status text shows audio driver and related data. (kybos)
+    - Fix: Make sure current splitter sizes are saved on application quit. (kybos)
 06.10.2020
     - Fix: Replace marker icons by SVG. (kybos)
     - Theme: Color tab text (active/hover) for better visibility. (kybos)

--- a/muse3/muse/app.cpp
+++ b/muse3/muse/app.cpp
@@ -1904,6 +1904,9 @@ void MusE::closeEvent(QCloseEvent* event)
       QSettings settings;
       settings.setValue("MusE/geometry", saveGeometry());
 
+      // this must be done here as the close events of child windows are not called on quit
+      saveStateTopLevels();
+
       saveStateExtra();
 
       writeGlobalConfiguration();
@@ -4791,6 +4794,12 @@ void MusE::addTabbedDock(Qt::DockWidgetArea area, QDockWidget *dock)
 //        dock->raise(); // doesn't work, Qt problem (kybos)
         QTimer::singleShot(0, [dock](){ dock->raise(); });
     }
+}
+
+void MusE::saveStateTopLevels() {
+
+    for (const auto& it : toplevels)
+        it->storeSettings();
 }
 
 void MusE::saveStateExtra() {

--- a/muse3/muse/app.h
+++ b/muse3/muse/app.h
@@ -274,6 +274,7 @@ class MusE : public QMainWindow
     void closeDocks();
     void addTabbedDock(Qt::DockWidgetArea area, QDockWidget *widget);
     void saveStateExtra();
+    void saveStateTopLevels();
     bool findOpenEditor(const TopWin::ToplevelType type, MusECore::PartList* pl);
     bool findOpenListEditor(MusECore::PartList* pl);
     bool filterInvalidParts(const TopWin::ToplevelType type, MusECore::PartList* pl);

--- a/muse3/muse/arranger/arranger.cpp
+++ b/muse3/muse/arranger/arranger.cpp
@@ -42,6 +42,7 @@
 #include <QCursor>
 #include <QPoint>
 #include <QRect>
+#include <QSettings>
 
 #include "arranger.h"
 #include "song.h"
@@ -549,12 +550,21 @@ Arranger::Arranger(ArrangerView* parent, const char* name)
 
 void Arranger::setDefaultSplitterSizes()
 {
-  QList<int> vallist;
-  vallist.append(trackInfoWidget->sizeHint().width());
-  list->resize(250, 100);
-  vallist.append(tlistLayout->sizeHint().width());
-  vallist.append(1);
-  split->setSizes(vallist);
+    QSettings s;
+    if (split->restoreState(s.value("Arranger/splitState").toByteArray()))
+        return;
+
+    QList<int> vallist;
+    vallist.append(trackInfoWidget->sizeHint().width());
+    list->resize(250, 100);
+    vallist.append(tlistLayout->sizeHint().width());
+    vallist.append(1);
+    split->setSizes(vallist);
+}
+
+void Arranger::storeSplitterSizes() {
+    QSettings s;
+    s.setValue("Arranger/splitState", split->saveState());
 }
 
 void Arranger::initTracklistHeader()

--- a/muse3/muse/arranger/arranger.h
+++ b/muse3/muse/arranger/arranger.h
@@ -208,6 +208,7 @@ class Arranger : public QWidget {
       void setDefaultSplitterSizes();
       void updateHeaderCustomColumns();
       void toggleTrackInfo();
+      void storeSplitterSizes();
       
       unsigned cursorValue() { return cursVal; }
       

--- a/muse3/muse/arranger/arrangerview.cpp
+++ b/muse3/muse/arranger/arrangerview.cpp
@@ -367,6 +367,10 @@ void ArrangerView::closeEvent(QCloseEvent* e)
     e->ignore();
 }
 
+void ArrangerView::storeSettings() {
+    arranger->storeSplitterSizes();
+}
+
 void ArrangerView::writeStatus(int level, MusECore::Xml& xml) const
 {
   xml.tag(level++, "arrangerview");

--- a/muse3/muse/arranger/arrangerview.h
+++ b/muse3/muse/arranger/arrangerview.h
@@ -49,109 +49,110 @@ class Xml;
 
 class ArrangerView : public TopWin
 {
-	Q_OBJECT
+    Q_OBJECT
 
-	private:
+private:
 
-		enum cmd_enum
-			{CMD_CUT, CMD_COPY, CMD_COPY_RANGE, CMD_PASTE, CMD_INSERTMEAS, CMD_PASTE_CLONE,
-			CMD_PASTE_TO_TRACK, CMD_PASTE_CLONE_TO_TRACK, CMD_PASTE_DIALOG, CMD_DELETE,
-			CMD_SELECT_ALL, CMD_SELECT_NONE, CMD_SELECT_INVERT,
-			CMD_SELECT_ILOOP, CMD_SELECT_OLOOP, CMD_SELECT_PARTS,
-			CMD_DELETE_TRACK, CMD_DUPLICATE_TRACK, CMD_EXPAND_PART, CMD_SHRINK_PART, CMD_CLEAN_PART,
-			CMD_QUANTIZE, CMD_VELOCITY, CMD_CRESCENDO, CMD_NOTELEN, CMD_TRANSPOSE,
-			CMD_ERASE, CMD_MOVE, CMD_FIXED_LEN, CMD_DELETE_OVERLAPS, CMD_LEGATO     };
+    enum cmd_enum
+    {CMD_CUT, CMD_COPY, CMD_COPY_RANGE, CMD_PASTE, CMD_INSERTMEAS, CMD_PASTE_CLONE,
+        CMD_PASTE_TO_TRACK, CMD_PASTE_CLONE_TO_TRACK, CMD_PASTE_DIALOG, CMD_DELETE,
+        CMD_SELECT_ALL, CMD_SELECT_NONE, CMD_SELECT_INVERT,
+        CMD_SELECT_ILOOP, CMD_SELECT_OLOOP, CMD_SELECT_PARTS,
+        CMD_DELETE_TRACK, CMD_DUPLICATE_TRACK, CMD_EXPAND_PART, CMD_SHRINK_PART, CMD_CLEAN_PART,
+        CMD_QUANTIZE, CMD_VELOCITY, CMD_CRESCENDO, CMD_NOTELEN, CMD_TRANSPOSE,
+        CMD_ERASE, CMD_MOVE, CMD_FIXED_LEN, CMD_DELETE_OVERLAPS, CMD_LEGATO     };
 
-		virtual void closeEvent(QCloseEvent*);
+    void closeEvent(QCloseEvent*) override;
 
-		QGridLayout* mainGrid;
-		QWidget* mainw;
+    QGridLayout* mainGrid;
+    QWidget* mainw;
 
-		EditToolBar* editTools;
-		VisibleTracks* visTracks;
+    EditToolBar* editTools;
+    VisibleTracks* visTracks;
 
-		Arranger* arranger;
+    Arranger* arranger;
 
-		// Edit Menu actions
-		QMenu* select;
-		QMenu* addTrack;
+    // Edit Menu actions
+    QMenu* select;
+    QMenu* addTrack;
     QMenu* insertTrack;
 
-		QAction *strGlobalCutAction, *strGlobalInsertAction, *strGlobalSplitAction;
+    QAction *strGlobalCutAction, *strGlobalInsertAction, *strGlobalSplitAction;
     QAction *strGlobalCutSelAction, *strGlobalInsertSelAction, *strGlobalSplitSelAction;
     QAction *trackAMidiAction, *trackADrumAction, *trackAWaveAction, *trackAOutputAction, *trackAGroupAction;
-		QAction *trackAInputAction, *trackAAuxAction;
+    QAction *trackAInputAction, *trackAAuxAction;
     QAction *trackIMidiAction, *trackIDrumAction, *trackIWaveAction, *trackIOutputAction, *trackIGroupAction;
     QAction *trackIInputAction, *trackIAuxAction;
 
-		QAction *editDeleteAction,*editCutAction, *editCopyAction, *editCopyRangeAction;
-		QAction *editPasteAction, *editPasteCloneAction, *editPasteToTrackAction, *editPasteCloneToTrackAction, *editPasteDialogAction;
-		QAction *editInsertEMAction, *editPasteC2TAction, *editDeleteSelectedAction, *editSelectAllAction, *editDeselectAllAction;
+    QAction *editDeleteAction,*editCutAction, *editCopyAction, *editCopyRangeAction;
+    QAction *editPasteAction, *editPasteCloneAction, *editPasteToTrackAction, *editPasteCloneToTrackAction, *editPasteDialogAction;
+    QAction *editInsertEMAction, *editPasteC2TAction, *editDeleteSelectedAction, *editSelectAllAction, *editDeselectAllAction;
     QAction *editDuplicateSelTrackAction;
-		QAction *editInvertSelectionAction, *editInsideLoopAction, *editOutsideLoopAction, *editAllPartsAction;
-		QAction *midiTransformerAction;
-		QAction *editCleanPartsAction, *editShrinkPartsAction, *editExpandPartsAction;
+    QAction *editInvertSelectionAction, *editInsideLoopAction, *editOutsideLoopAction, *editAllPartsAction;
+    QAction *midiTransformerAction;
+    QAction *editCleanPartsAction, *editShrinkPartsAction, *editExpandPartsAction;
 
-		QAction* func_quantize_action;
-		QAction* func_notelen_action;
-		QAction* func_velocity_action;
-		QAction* func_cresc_action;
-		QAction* func_transpose_action;
-		QAction* func_erase_action;
-		QAction* func_move_action;
-		QAction* func_fixed_len_action;
-		QAction* func_del_overlaps_action;
-		QAction* func_legato_action;
+    QAction* func_quantize_action;
+    QAction* func_notelen_action;
+    QAction* func_velocity_action;
+    QAction* func_cresc_action;
+    QAction* func_transpose_action;
+    QAction* func_erase_action;
+    QAction* func_move_action;
+    QAction* func_fixed_len_action;
+    QAction* func_del_overlaps_action;
+    QAction* func_legato_action;
 
-	private slots:
-		void globalCut();
-		void globalInsert();
-		void globalSplit();
+private slots:
+    void globalCut();
+    void globalInsert();
+    void globalSplit();
     void openCurrentTrackSynthGui();
-        void globalCutSel();
-        void globalInsertSel();
-        void globalSplitSel();
-        void cmd(int);
-        void addNewTrack(QAction* action);
-        void insertNewTrack(QAction* action);
-        void configCustomColumns();
-        void toggleMixerStrip();
+    void globalCutSel();
+    void globalInsertSel();
+    void globalSplitSel();
+    void cmd(int);
+    void addNewTrack(QAction* action);
+    void insertNewTrack(QAction* action);
+    void configCustomColumns();
+    void toggleMixerStrip();
 
-	signals:
-		void isDeleting(MusEGui::TopWin*);
-		void closed();
+signals:
+    void isDeleting(MusEGui::TopWin*);
+    void closed();
 
-	public slots:
-		void scoreNamingChanged();
-		void updateScoreMenus();
-		void clipboardChanged();
-		void selectionChanged(); // NOTE: This is received upon EITHER a part or track selection change from the Arranger.
-		void updateShortcuts();
-		void updateVisibleTracksButtons();
-		virtual void focusCanvas();
+public slots:
+    void scoreNamingChanged();
+    void updateScoreMenus();
+    void clipboardChanged();
+    void selectionChanged(); // NOTE: This is received upon EITHER a part or track selection change from the Arranger.
+    void updateShortcuts();
+    void updateVisibleTracksButtons();
+    virtual void focusCanvas() override;
 
-	public:
-		ArrangerView(QWidget* parent = 0);
-		~ArrangerView();
+public:
+    ArrangerView(QWidget* parent = nullptr);
+    ~ArrangerView() override;
 
-		QAction *startScoreEditAction, *startPianoEditAction, *startDrumEditAction, *startListEditAction, *startWaveEditAction;
-        QMenu* editorNewSubmenu;
-        QAction *startPianoEditNewAction, *startDrumEditNewAction, *startListEditNewAction, *startWaveEditNewAction;
-        QAction *openCurrentTrackSynthGuiAction;
-		QMenu *scoreSubmenu, *scoreOneStaffPerTrackSubsubmenu, *scoreAllInOneSubsubmenu;
+    QAction *startScoreEditAction, *startPianoEditAction, *startDrumEditAction, *startListEditAction, *startWaveEditAction;
+    QMenu* editorNewSubmenu;
+    QAction *startPianoEditNewAction, *startDrumEditNewAction, *startListEditNewAction, *startWaveEditNewAction;
+    QAction *openCurrentTrackSynthGuiAction;
+    QMenu *scoreSubmenu, *scoreOneStaffPerTrackSubsubmenu, *scoreAllInOneSubsubmenu;
 
-		void populateAddTrack();
+    void populateAddTrack();
 
-		Arranger* getArranger() const;
+    Arranger* getArranger() const;
 
-		void writeStatus(int level, MusECore::Xml& xml) const;
-		void readStatus(MusECore::Xml& xml);
-		static void readConfiguration(MusECore::Xml&);
-		void writeConfiguration(int, MusECore::Xml&);
-		
-		// Appends given tag list with item objects according to options. Avoids duplicate events or clone events.
-		// Special: We 'abuse' a controller event's length, normally 0, to indicate visual item length.
-		void tagItems(MusECore::TagEventList* tag_list, const MusECore::EventTagOptionsStruct& options) const;
+    void writeStatus(int level, MusECore::Xml& xml) const override;
+    void readStatus(MusECore::Xml& xml) override;
+    static void readConfiguration(MusECore::Xml&);
+    void writeConfiguration(int, MusECore::Xml&);
+    void storeSettings() override;
+
+    // Appends given tag list with item objects according to options. Avoids duplicate events or clone events.
+    // Special: We 'abuse' a controller event's length, normally 0, to indicate visual item length.
+    void tagItems(MusECore::TagEventList* tag_list, const MusECore::EventTagOptionsStruct& options) const;
 };
 
 }  // namespace MusEGui

--- a/muse3/muse/cobject.cpp
+++ b/muse3/muse/cobject.cpp
@@ -764,6 +764,8 @@ void TopWin::setWindowTitle (const QString& title)
     muse->updateWindowMenu();
 }
 
+void TopWin::storeSettings() {}
+
 //void TopWin::windowStateChanged(Qt::WindowStates oldState, Qt::WindowStates newState)
 //{
 //    // Due to bug in Oxygen and Breeze at least on *buntu 16.04 LTS and some other distros,

--- a/muse3/muse/cobject.h
+++ b/muse3/muse/cobject.h
@@ -75,11 +75,12 @@ class TopWin : public QMainWindow
       static void readConfiguration(ToplevelType, MusECore::Xml&);
       static void writeConfiguration(ToplevelType, int, MusECore::Xml&);
       
+      virtual void storeSettings();
       
       bool isMdiWin() const;
       QMdiSubWindow* getMdiWin() const { return mdisubwin; }
 
-      TopWin(ToplevelType t, QWidget* parent=0, const char* name=0, Qt::WindowFlags f = Qt::Window);
+      TopWin(ToplevelType t, QWidget* parent=nullptr, const char* name=nullptr, Qt::WindowFlags f = Qt::Window);
       virtual ~TopWin();
          
       bool sharesToolsAndMenu() const { return _sharesToolsAndMenu; }
@@ -93,7 +94,6 @@ class TopWin : public QMainWindow
       virtual void removeToolBar(QToolBar*);
       virtual void removeToolBarBreak(QToolBar*);
       virtual void addToolBar(Qt::ToolBarArea, QToolBar*);
-
       
       void resize(int w, int h);
 //      void resize(const QSize&);

--- a/muse3/muse/midiedit/drumedit.cpp
+++ b/muse3/muse/midiedit/drumedit.cpp
@@ -144,29 +144,34 @@ void DrumEdit::closeEvent(QCloseEvent* e)
       {
       _isDeleting = true;  // Set flag so certain signals like songChanged, which may cause crash during delete, can be ignored.
 
-      QSettings settings;
-      settings.setValue("Drumedit/windowState", saveState());
-
-      //Store values of the horizontal splitter
-      QList<int> sizes = split2->sizes();
-      QList<int>::iterator it = sizes.begin();
-      //There are only 2 values stored in the sizelist, size of dlist widget and dcanvas widget      
-      _dlistWidthInit = *it;
-      it++;
-      _dcanvasWidthInit = *it;
-      
-      //Store values of the horizontal splitter
-      sizes.clear();
-      sizes = hsplitter->sizes();
-      it = sizes.begin();
-      //There are only 2 values stored in the sizelist, size of trackinfo widget and canvas widget
-      _trackInfoWidthInit = *it;
-      it++;
-      _canvasWidthInit = *it;
+      storeSettings();
     
       emit isDeleting(static_cast<TopWin*>(this));
       e->accept();
       }
+
+void DrumEdit::storeSettings() {
+
+    QSettings settings;
+    settings.setValue("Drumedit/windowState", saveState());
+
+    //Store values of the horizontal splitter
+    QList<int> sizes = split2->sizes();
+    QList<int>::iterator it = sizes.begin();
+    //There are only 2 values stored in the sizelist, size of dlist widget and dcanvas widget
+    _dlistWidthInit = *it;
+    it++;
+    _dcanvasWidthInit = *it;
+
+    //Store values of the horizontal splitter
+    sizes.clear();
+    sizes = hsplitter->sizes();
+    it = sizes.begin();
+    //There are only 2 values stored in the sizelist, size of trackinfo widget and canvas widget
+    _trackInfoWidthInit = *it;
+    it++;
+    _canvasWidthInit = *it;
+}
 
 //---------------------------------------------------------
 //   DrumEdit

--- a/muse3/muse/midiedit/drumedit.h
+++ b/muse3/muse/midiedit/drumedit.h
@@ -68,150 +68,152 @@ class EditToolBar;
 //---------------------------------------------------------
 
 class DrumEdit : public MidiEditor {
-      Q_OBJECT
+    Q_OBJECT
 
-   public:
-      enum group_mode_t { DONT_GROUP, GROUP_SAME_CHANNEL, GROUP_MAX };
-  
-   private:
-      group_mode_t _group_mode;
-      bool _ignore_hide;
-      
-      QMenu* menuEdit, *menuFunctions, *menuSelect;
-      PopupMenu* addControllerMenu;
+public:
+    enum group_mode_t { DONT_GROUP, GROUP_SAME_CHANNEL, GROUP_MAX };
 
-      int tickValue;
-      int lenValue;
-      int pitchValue;
-      int veloOnValue;
-      int veloOffValue;
-      bool firstValueSet;
-      int tickOffset;
-      int lenOffset;
-      int pitchOffset;
-      int veloOnOffset;
-      int veloOffOffset;
-      bool deltaMode;
-      int lastSelections;
+private:
+    group_mode_t _group_mode;
+    bool _ignore_hide;
 
-      MusEGui::NoteInfo* info;
-      QToolButton* addctrl;
-      QToolButton* srec;
-      QToolButton* midiin;
-      QToolButton* speaker;
-      MusEGui::EditToolBar* tools2;
-      bool _playEvents;
+    QMenu* menuEdit, *menuFunctions, *menuSelect;
+    PopupMenu* addControllerMenu;
 
-      MusEGui::Toolbar1* toolbar;
-      MusEGui::Splitter* hsplitter;
-      MusEGui::Splitter* split1;
-      MusEGui::Splitter* split2;
-      QWidget* split1w1;
-      DList* dlist;
-      MusEGui::Header* header;
-      QToolBar* tools;
-      QComboBox *stepLenWidget;
+    int tickValue;
+    int lenValue;
+    int pitchValue;
+    int veloOnValue;
+    int veloOffValue;
+    bool firstValueSet;
+    int tickOffset;
+    int lenOffset;
+    int pitchOffset;
+    int veloOnOffset;
+    int veloOffOffset;
+    bool deltaMode;
+    int lastSelections;
 
-      static int _rasterInit;
-      static int _trackInfoWidthInit;
-      static int _canvasWidthInit;
-      static int _dlistWidthInit, _dcanvasWidthInit;
-      static bool _ignore_hide_init;
+    MusEGui::NoteInfo* info;
+    QToolButton* addctrl;
+    QToolButton* srec;
+    QToolButton* midiin;
+    QToolButton* speaker;
+    MusEGui::EditToolBar* tools2;
+    bool _playEvents;
 
-      // Initial view state.
-      MusECore::MidiPartViewState _viewState;
-      
-      QAction *cutAction, *copyAction, *copyRangeAction, *pasteAction;
-      QAction *pasteToCurPartAction, *pasteDialogAction, *deleteAction;
-      QAction *fixedAction, *veloAction, *crescAction, *quantizeAction;
-      QAction *sallAction, *snoneAction, *invAction, *inAction , *outAction;
-      QAction *prevAction, *nextAction;
-      QAction *groupNoneAction, *groupChanAction, *groupMaxAction;
-      QAction *addControllerAction;
-      QAction *startListEditAction;
-      
-      void initShortcuts();
-      void setupNewCtrl(CtrlEdit* ctrlEdit);
+    MusEGui::Toolbar1* toolbar;
+    MusEGui::Splitter* hsplitter;
+    MusEGui::Splitter* split1;
+    MusEGui::Splitter* split2;
+    QWidget* split1w1;
+    DList* dlist;
+    MusEGui::Header* header;
+    QToolBar* tools;
+    QComboBox *stepLenWidget;
 
-      virtual void closeEvent(QCloseEvent*);
-      QWidget* genToolbar(QWidget* parent);
-      virtual void keyPressEvent(QKeyEvent*);
+    static int _rasterInit;
+    static int _trackInfoWidthInit;
+    static int _canvasWidthInit;
+    static int _dlistWidthInit, _dcanvasWidthInit;
+    static bool _ignore_hide_init;
 
-      void setHeaderToolTips();
-      void setHeaderWhatsThis();
-      
-      // Sets up a reasonable zoom minimum and/or maximum based on
-      //  the current global midi division (ticks per quarter note)
-      //  which has a very wide range (48 - 12288).
-      // Also sets the canvas and time scale offsets accordingly.
-      void setupHZoomRange();
+    // Initial view state.
+    MusECore::MidiPartViewState _viewState;
 
-   private slots:
-      void setRaster(int);
-      void noteinfoChanged(MusEGui::NoteInfo::ValType type, int val);
-      void removeCtrl(CtrlEdit* ctrl);
-      void cmd(int);
-      void clipboardChanged(); // enable/disable "Paste"
-      void selectionChanged(); // enable/disable "Copy" & "Paste"
-      void load();
-      void save();
-      void reset();
-      void setTime(unsigned);
-      void follow(int);
-      void newCanvasWidth(int);
-      void configChanged();
-      void songChanged1(MusECore::SongChangedStruct_t);
-      void setStep(QString);
-      void setSpeaker(bool);
-      void addCtrlClicked();
-      void ctrlPopupTriggered(QAction* act);
-      void ctrlMenuAboutToShow();
-      void ctrlMenuAboutToHide();
+    QAction *cutAction, *copyAction, *copyRangeAction, *pasteAction;
+    QAction *pasteToCurPartAction, *pasteDialogAction, *deleteAction;
+    QAction *fixedAction, *veloAction, *crescAction, *quantizeAction;
+    QAction *sallAction, *snoneAction, *invAction, *inAction , *outAction;
+    QAction *prevAction, *nextAction;
+    QAction *groupNoneAction, *groupChanAction, *groupMaxAction;
+    QAction *addControllerAction;
+    QAction *startListEditAction;
 
-      void updateGroupingActions();
-      void set_ignore_hide(bool);
-      void showAllInstruments();
-      void hideAllInstruments();
-      void hideUnusedInstruments();
-      void hideEmptyInstruments();
-      
-      void deltaModeChanged(bool);
-      void midiNote(int pitch, int velo);
+    void initShortcuts();
+    void setupNewCtrl(CtrlEdit* ctrlEdit);
 
-   public slots:
-      void setSelection(int tick, MusECore::Event&, MusECore::Part*, bool update);
-      void soloChanged(bool);       // called by Solo button
-      void execDeliveredScript(int);
-      void execUserScript(int);
-      void focusCanvas();
-      void ourDrumMapChanged(bool);
-      void horizontalZoom(bool zoom_in, const QPoint& glob_pos);
-      void horizontalZoom(int mag, const QPoint& glob_pos);
-      virtual void updateHScrollRange();
-      void storeInitialViewState() const;
+    void closeEvent(QCloseEvent*) override;
+    QWidget* genToolbar(QWidget* parent);
+    void keyPressEvent(QKeyEvent*) override;
 
-   signals:
-      void isDeleting(MusEGui::TopWin*);
+    void setHeaderToolTips();
+    void setHeaderWhatsThis();
 
-   public:
-      DrumEdit(MusECore::PartList*, QWidget* parent = 0, const char* name = 0,
-               unsigned initPos = INT_MAX, bool showDefaultControls = false);
-      virtual void readStatus(MusECore::Xml&);
-      virtual void writeStatus(int, MusECore::Xml&) const;
-      static void readConfiguration(MusECore::Xml& xml);
-      static void writeConfiguration(int, MusECore::Xml&);
-      
-      CtrlEdit* addCtrl(int ctl_num = MusECore::CTRL_VELOCITY);
+    // Sets up a reasonable zoom minimum and/or maximum based on
+    //  the current global midi division (ticks per quarter note)
+    //  which has a very wide range (48 - 12288).
+    // Also sets the canvas and time scale offsets accordingly.
+    void setupHZoomRange();
 
-      MusECore::MidiPartViewState getViewState() const;
+private slots:
+    void setRaster(int) override;
+    void noteinfoChanged(MusEGui::NoteInfo::ValType type, int val);
+    void removeCtrl(CtrlEdit* ctrl);
+    void cmd(int);
+    void clipboardChanged(); // enable/disable "Paste"
+    void selectionChanged(); // enable/disable "Copy" & "Paste"
+    void load();
+    void save();
+    void reset();
+    void setTime(unsigned);
+    void follow(int);
+    void newCanvasWidth(int);
+    void configChanged();
+    void songChanged1(MusECore::SongChangedStruct_t);
+    void setStep(QString);
+    void setSpeaker(bool);
+    void addCtrlClicked();
+    void ctrlPopupTriggered(QAction* act);
+    void ctrlMenuAboutToShow();
+    void ctrlMenuAboutToHide();
 
-      int changeRaster(int val);
+    void updateGroupingActions();
+    void set_ignore_hide(bool);
+    void showAllInstruments();
+    void hideAllInstruments();
+    void hideUnusedInstruments();
+    void hideEmptyInstruments();
 
-      group_mode_t group_mode() { return _group_mode; }
-      bool ignore_hide() { return _ignore_hide; }
-      
-      QVector<instrument_number_mapping_t>& get_instrument_map() { return static_cast<DrumCanvas*>(canvas)->get_instrument_map(); }
-      };
+    void deltaModeChanged(bool);
+    void midiNote(int pitch, int velo);
+
+public slots:
+    void setSelection(int tick, MusECore::Event&, MusECore::Part*, bool update);
+    void soloChanged(bool);       // called by Solo button
+    void execDeliveredScript(int);
+    void execUserScript(int);
+    void focusCanvas() override;
+    void ourDrumMapChanged(bool);
+    void horizontalZoom(bool zoom_in, const QPoint& glob_pos);
+    void horizontalZoom(int mag, const QPoint& glob_pos);
+    virtual void updateHScrollRange() override;
+    void storeInitialViewState() const override;
+
+signals:
+    void isDeleting(MusEGui::TopWin*);
+
+public:
+    DrumEdit(MusECore::PartList*, QWidget* parent = nullptr, const char* name = nullptr,
+             unsigned initPos = INT_MAX, bool showDefaultControls = false);
+    virtual void readStatus(MusECore::Xml&) override;
+    virtual void writeStatus(int, MusECore::Xml&) const override;
+    static void readConfiguration(MusECore::Xml& xml);
+    static void writeConfiguration(int, MusECore::Xml&);
+
+    CtrlEdit* addCtrl(int ctl_num = MusECore::CTRL_VELOCITY);
+
+    MusECore::MidiPartViewState getViewState() const;
+
+    int changeRaster(int val);
+
+    group_mode_t group_mode() { return _group_mode; }
+    bool ignore_hide() { return _ignore_hide; }
+
+    QVector<instrument_number_mapping_t>& get_instrument_map() { return static_cast<DrumCanvas*>(canvas)->get_instrument_map(); }
+
+    void storeSettings() override;
+};
 
 } // namespace MusEGui
 

--- a/muse3/muse/midiedit/pianoroll.cpp
+++ b/muse3/muse/midiedit/pianoroll.cpp
@@ -1310,19 +1310,24 @@ void PianoRoll::closeEvent(QCloseEvent* e)
       {
       _isDeleting = true;  // Set flag so certain signals like songChanged, which may cause crash during delete, can be ignored.
 
-      QSettings settings;
-      settings.setValue("Pianoroll/windowState", saveState());
-
-      //Store values of the horizontal splitter
-      QList<int> sizes = hsplitter->sizes();
-      QList<int>::iterator it = sizes.begin();
-      _trackInfoWidthInit = *it; //There are only 2 values stored in the sizelist, size of trackinfo widget and canvas widget
-      it++;
-      _canvasWidthInit = *it;
+      storeSettings();
     
       emit isDeleting(static_cast<TopWin*>(this));
       e->accept();
       }
+
+void PianoRoll::storeSettings() {
+
+    QSettings settings;
+    settings.setValue("Pianoroll/windowState", saveState());
+
+    //Store values of the horizontal splitter
+    QList<int> sizes = hsplitter->sizes();
+    QList<int>::iterator it = sizes.begin();
+    _trackInfoWidthInit = *it; //There are only 2 values stored in the sizelist, size of trackinfo widget and canvas widget
+    it++;
+    _canvasWidthInit = *it;
+}
 
 //---------------------------------------------------------
 //   readConfiguration

--- a/muse3/muse/midiedit/pianoroll.h
+++ b/muse3/muse/midiedit/pianoroll.h
@@ -158,8 +158,8 @@ class PianoRoll : public MidiEditor {
       void setEventColorMode(MidiEventColorMode);
       QWidget* genToolbar(QWidget* parent);
 
-      virtual void closeEvent(QCloseEvent*);
-      virtual void keyPressEvent(QKeyEvent*);
+      virtual void closeEvent(QCloseEvent*) override;
+      virtual void keyPressEvent(QKeyEvent*) override;
       
       void setSpeakerMode(EventCanvas::PlayEventsMode mode);
       
@@ -174,7 +174,7 @@ class PianoRoll : public MidiEditor {
       void noteinfoChanged(MusEGui::NoteInfo::ValType, int);
       void removeCtrl(CtrlEdit* ctrl);
       void soloChanged(bool flag);
-      void setRaster(int);
+      void setRaster(int) override;
       void cmd(int);
       void setSteprec(bool);
       void eventColorModeChanged(MidiEventColorMode);
@@ -200,19 +200,20 @@ class PianoRoll : public MidiEditor {
    public slots:
       void horizontalZoom(bool zoom_in, const QPoint& glob_pos);
       void horizontalZoom(int mag, const QPoint& glob_pos);
-      virtual void updateHScrollRange();
+      void updateHScrollRange() override;
       void execDeliveredScript(int id);
       void execUserScript(int id);
-      void focusCanvas();
-      void storeInitialViewState() const;
+      void focusCanvas() override;
+      void storeInitialViewState() const override;
       
    public:
-      PianoRoll(MusECore::PartList*, QWidget* parent = 0, const char* name = 0,
+      PianoRoll(MusECore::PartList*, QWidget* parent = nullptr, const char* name = nullptr,
                 unsigned initPos = INT_MAX, bool showDefaultControls = false);
-      virtual void readStatus(MusECore::Xml&);
-      virtual void writeStatus(int, MusECore::Xml&) const;
+      void readStatus(MusECore::Xml&) override;
+      void writeStatus(int, MusECore::Xml&) const override;
       static void readConfiguration(MusECore::Xml&);
       static void writeConfiguration(int, MusECore::Xml&);
+      void storeSettings() override;
       CtrlEdit* addCtrl(int ctl_num = MusECore::CTRL_VELOCITY);
       MusECore::MidiPartViewState getViewState() const;
 

--- a/muse3/muse/midiedit/scoreedit.cpp
+++ b/muse3/muse/midiedit/scoreedit.cpp
@@ -754,14 +754,18 @@ void ScoreEdit::closeEvent(QCloseEvent* e)
     _isDeleting = true;  // Set flag so certain signals like songChanged, which may cause crash during delete, can be ignored.
     names.erase(name);
 
-    QSettings settings;
-    //settings.setValue("ScoreEdit/geometry", saveGeometry());
-    settings.setValue("ScoreEdit/windowState", saveState());
+    storeSettings();
 
     emit isDeleting(static_cast<TopWin*>(this));
     e->accept();
 }
 
+void ScoreEdit::storeSettings() {
+
+    QSettings settings;
+    //settings.setValue("ScoreEdit/geometry", saveGeometry());
+    settings.setValue("ScoreEdit/windowState", saveState());
+}
 
 void ScoreEdit::menu_command(int cmd)
 {

--- a/muse3/muse/midiedit/scoreedit.h
+++ b/muse3/muse/midiedit/scoreedit.h
@@ -100,7 +100,7 @@ class ScoreEdit : public TopWin
 {
 	Q_OBJECT
 	private:
-		virtual void closeEvent(QCloseEvent*);
+        void closeEvent(QCloseEvent*) override;
 		
 		void init_name();
 
@@ -172,7 +172,7 @@ class ScoreEdit : public TopWin
 		
 		bool set_name(QString newname, bool emit_signal=true, bool emergency_name=false);
 
-		virtual void keyPressEvent(QKeyEvent*);
+        void keyPressEvent(QKeyEvent*) override;
 		
 	private slots:
 		void menu_command(int);
@@ -196,16 +196,17 @@ class ScoreEdit : public TopWin
 		void canvas_height_changed(int);
 		void viewport_height_changed(int);
 		void song_changed(MusECore::SongChangedStruct_t);
-		void focusCanvas();
+        void focusCanvas() override;
 		
 	public:
-		ScoreEdit(QWidget* parent = 0, const char* name = 0, unsigned initPos = INT_MAX);
-		~ScoreEdit();
+        ScoreEdit(QWidget* parent = nullptr, const char* name = nullptr, unsigned initPos = INT_MAX);
+        ~ScoreEdit() override;
 
-		void writeStatus(int level, MusECore::Xml& xml) const;
-		void readStatus(MusECore::Xml& xml);
+        void writeStatus(int level, MusECore::Xml& xml) const override;
+        void readStatus(MusECore::Xml& xml) override;
 		static void read_configuration(MusECore::Xml&);
 		static void write_configuration(int, MusECore::Xml&);
+        void storeSettings() override;
 		
 		void add_parts(MusECore::PartList* pl, bool all_in_one=false);
 		QString get_name() { return name; }
@@ -274,7 +275,7 @@ class FloEvent
 		MusECore::key_enum key;
 		bool minor;    
 		
-		FloEvent(unsigned ti, int p,int v,int l,typeEnum t, const MusECore::Part* part=NULL, const MusECore::Event* event=NULL)
+        FloEvent(unsigned ti, int p,int v,int l,typeEnum t, const MusECore::Part* part=nullptr, const MusECore::Event* event=nullptr)
 		{
 			pitch=p;
 			vel=v;

--- a/muse3/muse/waveedit/waveedit.cpp
+++ b/muse3/muse/waveedit/waveedit.cpp
@@ -95,20 +95,25 @@ void WaveEdit::closeEvent(QCloseEvent* e)
       {
       _isDeleting = true;  // Set flag so certain signals like songChanged, which may cause crash during delete, can be ignored.
 
-      QSettings settings;
-      //settings.setValue("Waveedit/geometry", saveGeometry());
-      settings.setValue("Waveedit/windowState", saveState());
-      
-      //Store values of the horizontal splitter
-      QList<int> sizes = hsplitter->sizes();
-      QList<int>::iterator it = sizes.begin();
-      _trackInfoWidthInit = *it; //There are only 2 values stored in the sizelist, size of trackinfo widget and canvas widget
-      it++;
-      _canvasWidthInit = *it;
-    
+      storeSettings();
+
       emit isDeleting(static_cast<TopWin*>(this));
       e->accept();
       }
+
+void WaveEdit::storeSettings() {
+
+    QSettings settings;
+    //settings.setValue("Waveedit/geometry", saveGeometry());
+    settings.setValue("Waveedit/windowState", saveState());
+
+    //Store values of the horizontal splitter
+    QList<int> sizes = hsplitter->sizes();
+    QList<int>::iterator it = sizes.begin();
+    _trackInfoWidthInit = *it; //There are only 2 values stored in the sizelist, size of trackinfo widget and canvas widget
+    it++;
+    _canvasWidthInit = *it;
+}
 
 //---------------------------------------------------------
 //   WaveEdit

--- a/muse3/muse/waveedit/waveedit.h
+++ b/muse3/muse/waveedit/waveedit.h
@@ -90,8 +90,8 @@ class WaveEdit : public MidiEditor {
       static int _canvasWidthInit;
       static int colorModeInit;
 
-      virtual void closeEvent(QCloseEvent*);
-      virtual void keyPressEvent(QKeyEvent*);
+      void closeEvent(QCloseEvent*) override;
+      void keyPressEvent(QKeyEvent*) override;
 
       void initShortcuts();
       void setEventColorMode(int);
@@ -114,23 +114,24 @@ class WaveEdit : public MidiEditor {
 
    public slots:
       void configChanged();
-      virtual void updateHScrollRange();
+      virtual void updateHScrollRange() override;
       void horizontalZoom(bool zoom_in, const QPoint& glob_pos);
       void horizontalZoom(int mag, const QPoint& glob_pos);
-      void focusCanvas();
+      void focusCanvas() override;
 
    signals:
       void isDeleting(MusEGui::TopWin*);
 
    public:
-      WaveEdit(MusECore::PartList*, QWidget* parent = 0, const char* name = 0);
-      virtual ~WaveEdit();
-      virtual void readStatus(MusECore::Xml&);
-      virtual void writeStatus(int, MusECore::Xml&) const;
+      WaveEdit(MusECore::PartList*, QWidget* parent = nullptr, const char* name = nullptr);
+      virtual ~WaveEdit() override;
+      virtual void readStatus(MusECore::Xml&) override;
+      virtual void writeStatus(int, MusECore::Xml&) const override;
       static void readConfiguration(MusECore::Xml&);
       static void writeConfiguration(int, MusECore::Xml&);
       // Same as setRaster() but returns the actual value used.
       int changeRaster(int val);
+      void storeSettings() override;
       };
 
 } // namespace MusEGui

--- a/muse3/share/themes/Deep Ocean.cfc
+++ b/muse3/share/themes/Deep Ocean.cfc
@@ -85,7 +85,7 @@
     <rackItemBgActiveColor r="15" g="82" b="148"></rackItemBgActiveColor>
     <rackItemFontColor r="128" g="128" b="128"></rackItemFontColor>
     <rackItemFontActiveColor r="255" g="255" b="255"></rackItemFontActiveColor>
-    <rackItemBorderColor r="18" g="118" b="199"></rackItemBorderColor>
+    <rackItemBorderColor r="40" g="50" b="60"></rackItemBorderColor>
     <rackItemFontColorHover r="170" g="170" b="170"></rackItemFontColorHover>
     <palSwitchBackgroundColor r="90" g="90" b="90"></palSwitchBackgroundColor>
     <palSwitchBgActiveColor r="15" g="82" b="148"></palSwitchBgActiveColor>
@@ -102,7 +102,7 @@
     <bigtimeBackgroundcolor r="0" g="0" b="0"></bigtimeBackgroundcolor>
     <waveEditBackgroundColor r="200" g="200" b="200"></waveEditBackgroundColor>
     <rulerBackgroundColor r="40" g="50" b="60"></rulerBackgroundColor>
-    <rulerForegroundColor r="85" g="170" b="255"></rulerForegroundColor>
+    <rulerForegroundColor r="130" g="174" b="214"></rulerForegroundColor>
     <rulerCurrentColor r="54" g="113" b="42"></rulerCurrentColor>
     <waveNonselectedPart r="192" g="192" b="192"></waveNonselectedPart>
     <wavePeakColor r="128" g="128" b="128"></wavePeakColor>

--- a/muse3/share/themes/Deep Ocean.qss
+++ b/muse3/share/themes/Deep Ocean.qss
@@ -25,7 +25,7 @@ QStatusBar #PaddedValueLabel  {
 }
 
 QStatusBar {
-    color: PeachPuff;
+    color: LightGreen;
 }
 
 QToolButton {
@@ -237,7 +237,7 @@ QTreeView, QListView {
  }
 
 QMdiArea QTabBar::tab:selected {
-    color: lightblue;
+    color: DodgerBlue;
 }
 
 QMdiArea QTabBar::tab:hover {


### PR DESCRIPTION
Splitter states were not saved at application quit, only when an editor window was explicitly closed (because the main window doesn't necessarily call the close event for all child windows). For the arranger is was not implemented at all.