### PR TITLE
Pass LDFLAGS for Jack

### DIFF
--- a/src/muse/driver/CMakeLists.txt
+++ b/src/muse/driver/CMakeLists.txt
@@ -70,6 +70,7 @@ set_target_properties( driver
 ##
 target_link_libraries ( driver
       ${ALSA_LIBRARIES}
+      ${JACK_LDFLAGS}
       ${JACK_LIBRARIES}
       ${QT_LIBRARIES}
       ${RTAUDIO_LIBRARIES}


### PR DESCRIPTION
- this allow building with pipewire-jack

Explanation: with pipewire-jack the headers are not in the standard location. pkg-config return the right thing though. I don't know CMake, though, so if there is a better fix, let me know.