### PR TITLE
Link with libatomic if needed for the architecture

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -532,6 +532,10 @@ endif (ENABLE_VST_VESTIGE)
 ##
 
 if (ENABLE_LV2)
+find_package(ECM REQUIRED NO_MODULE)
+set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
+include(CheckAtomic)
+
 set (muse_sord_ver "0.16.0")
 set (muse_lv2_ver "1.18.0")
 set (muse_lilv_ver "0.24.0" )

--- a/src/README
+++ b/src/README
@@ -76,6 +76,9 @@ details.
 
       - LADSPA (development file ladspa.h)
          www.ladspa.org
+      
+      - extra-cmake-modules >= 5.94.0
+         http://invent.kde.org/frameworks/extra-cmake-modules
 
          
   =============================

--- a/src/muse/CMakeLists.txt
+++ b/src/muse/CMakeLists.txt
@@ -357,6 +357,10 @@ if(LV2_SUPPORT)
             OUTPUT_NAME muse_lv2host_module
             )
             
+      if(NOT HAVE_CXX_ATOMICS_WITHOUT_LIB)
+            target_link_libraries(lv2host_module atomic)
+      endif()
+
       target_link_libraries(lv2host_module ${LILV_LIBRARIES})
       target_link_libraries(lv2host_module ${SORD_LIBRARIES})
       target_link_libraries(lv2host_module ${LV2_LIBRARIES})


### PR DESCRIPTION
Muse fails to build for riscv64 because it requires linking with libatomic for this specific architecture. This will fix the issue with riscv64 and any other architecture that has this libatomic link issue. Please note that building muse with these changes will require the extra-cmake-modules package to be installed first (I updated the README file accordingly).