### PR TITLE
Replace std::random_shuffle for C++17 compliance.

### DIFF
--- a/src/muse/app.cpp
+++ b/src/muse/app.cpp
@@ -49,6 +49,7 @@
 #include <iostream>
 #include <algorithm>
 //#include <typeinfo>
+#include <random>
 
 #include "app.h"
 #include "master/lmaster.h"
@@ -2743,7 +2744,8 @@ void MusE::showDidYouKnowDialog()
       didYouKnow.tipList.append(tipMessage);
     }
 
-    std::random_shuffle(didYouKnow.tipList.begin(),didYouKnow.tipList.end());
+    std::random_device randomDevice;
+    std::shuffle(didYouKnow.tipList.begin(), didYouKnow.tipList.end(), randomDevice);
 
     didYouKnow.show();
     if( didYouKnow.exec()) {


### PR DESCRIPTION
The std::random_shuffle algorithm has been removed in C++17, see:

https://en.cppreference.com/w/cpp/algorithm/random_shuffle

Build fails with compilers that actually enforce C++17 compliance, particularly on FreeBSD / Clang.
Replace this code with the newer std::shuffle algorithm.

I did some brief testing and the random "Did you know" dialog seems to work.