### PR TITLE
Fix shortcut hints in PartCanvas and tweak Normalize shortcut

### DIFF
--- a/src/muse/arranger/pcanvas.cpp
+++ b/src/muse/arranger/pcanvas.cpp
@@ -1014,11 +1014,11 @@ QMenu* PartCanvas::genItemPopup(CItem* item)
 
       QAction *act_cut = partPopup->addAction(*cutSVGIcon, tr("C&ut"));
       act_cut->setData(OP_CUT);
-      act_cut->setShortcut(Qt::CTRL+Qt::Key_X);
+      act_cut->setShortcut(shortcuts[SHRT_CUT].key);
 
       QAction *act_copy = partPopup->addAction(*copySVGIcon, tr("&Copy"));
       act_copy->setData(OP_COPY);
-      act_copy->setShortcut(Qt::CTRL+Qt::Key_C);
+	  act_copy->setShortcut(shortcuts[SHRT_COPY].key);
 
       partPopup->addSeparator();
       int rc = npart->part()->nClones();
@@ -1091,7 +1091,7 @@ QMenu* PartCanvas::genItemPopup(CItem* item)
                   act_wfinfo->setData(OP_FILEINFO);
                   QAction *act_wfnorm = partPopup->addAction(tr("Normalize"));
                   act_wfnorm->setData(OP_NORMALIZE);
-                  act_wfnorm->setShortcut(Qt::CTRL+Qt::Key_N);
+                  act_wfnorm->setShortcut(shortcuts[SHRT_PART_NORMALIZE].key);
                   }
                   break;
             case MusECore::Track::AUDIO_OUTPUT:

--- a/src/muse/shortcuts.cpp
+++ b/src/muse/shortcuts.cpp
@@ -411,7 +411,7 @@ void initShortCuts()
       defShrt(SHRT_NEXT_MARKER, Qt::Key_F6, QT_TRANSLATE_NOOP("shortcuts", "Goto Next Marker"), GLOBAL_SHRT,  "me_sel_next");
       defShrt(SHRT_PREV_MARKER, Qt::Key_F5, QT_TRANSLATE_NOOP("shortcuts", "Goto Prev Marker"), GLOBAL_SHRT,  "me_sel_prev");
 
-      defShrt(SHRT_PART_NORMALIZE,  Qt::ALT + Qt::Key_N, QT_TRANSLATE_NOOP("shortcuts", "Normalize"), ARRANG_SHRT, "wave_part_normalize");
+      defShrt(SHRT_PART_NORMALIZE, Qt::ALT + Qt::SHIFT + Qt::Key_N, QT_TRANSLATE_NOOP("shortcuts", "Normalize"), ARRANG_SHRT, "wave_part_normalize");
 
       //-----------------------------------------------------------
       // Mixer:

--- a/src/muse/shortcuts.h
+++ b/src/muse/shortcuts.h
@@ -422,7 +422,7 @@ enum {
     SHRT_PREV_MARKER,
 
     // Arranger
-    SHRT_PART_NORMALIZE, // Alt+N
+    SHRT_PART_NORMALIZE, // Alt+Shift+N
 
     SHRT_TOOL_STRETCH,
     SHRT_TOOL_SAMPLERATE,


### PR DESCRIPTION
- Instead of using hardcoded shortcuts in the item popup of `PartCanvas` the ones configurable in the settings are now retrieved and displayed. (For default settings the shortcut of "Normalize" did already diverge)
- The current default key combination of "Normalize" is shadowed by the "Fu&nctions" menu in the main menu bar. Changing it from Alt+N to Alt+Shift+N seems minimal inversive and make the action accessible again.