### PR TITLE
Add static link possibility of modules

### DIFF
--- a/src/awl/CMakeLists.txt
+++ b/src/awl/CMakeLists.txt
@@ -96,9 +96,9 @@ file (GLOB awl_source_files
 ## Define target
 ##
 
-# Always build this shared now. It is no longer linked into the main app.
-# add_library ( awl ${MODULES_BUILD}
-add_library ( awl SHARED
+# Not always dynamic linking is good eg. Windows
+# add_library ( awl SHARED
+add_library ( awl ${MODULES_BUILD}
       ${awl_source_files}
       ${awl_mocs}
       )

--- a/src/libs/time_stretch/CMakeLists.txt
+++ b/src/libs/time_stretch/CMakeLists.txt
@@ -32,7 +32,8 @@ file (GLOB time_stretch_source_files
 ## Define target
 ##
 # add_library(muse_time_stretch_module ${MODULES_BUILD}
-add_library(time_stretch_module SHARED
+#add_library(time_stretch_module SHARED
+add_library(time_stretch_module ${MODULES_BUILD}
       ${time_stretch_source_files}
       )
 

--- a/src/libs/wave/CMakeLists.txt
+++ b/src/libs/wave/CMakeLists.txt
@@ -32,7 +32,8 @@ file (GLOB wave_source_files
 ## Define target
 ##
 # add_library(muse_time_stretch_module ${MODULES_BUILD}
-add_library(wave_module SHARED
+#add_library(wave_module SHARED
+add_library(wave_module ${MODULES_BUILD}
       ${wave_source_files}
       )
 


### PR DESCRIPTION
In Windows, dynamic linking of some libraries causes undefined reference error. Static linking in Windows is more preferred.