### PR TITLE
Limit namespace std to necessary functions

### DIFF
--- a/src/muse/midiedit/scoreedit.cpp
+++ b/src/muse/midiedit/scoreedit.cpp
@@ -46,7 +46,7 @@
 
 #include <iostream>
 #include <sstream>
-using namespace std;
+using std::cout, std::endl, std::cerr, std::ostringstream;
 
 #include "app.h"
 #include "xml.h"


### PR DESCRIPTION
While compiling under MinGW, is namespaces conflict, so using entire std namespace is not good idea.