### PR TITLE
Disable Q_OBJECT on non linux systems

### DIFF
--- a/src/muse/driver/qttimer.h
+++ b/src/muse/driver/qttimer.h
@@ -38,7 +38,9 @@ namespace MusECore {
 //---------------------------------------------------------
 
 class InnerTimer : public QObject {
+  #ifdef __linux__
   Q_OBJECT
+  #endif
   int writePipe;
   long int tickCount;
   QBasicTimer timer;


### PR DESCRIPTION
Compiling on MinGW throws undefined vtable reference