### PR TITLE
Rewrite functions for using standard cpp libs

### DIFF
--- a/src/libs/string/hex_float.cpp
+++ b/src/libs/string/hex_float.cpp
@@ -20,87 +20,27 @@
 //
 //=========================================================
 
-#include <cstdio>
-#include <cstdlib>
-#include <cassert>
-#include <vector>
-#include <locale>
-
+#include <sstream>
 #include <QString>
-
 #include "hex_float.h"
 
 namespace MusELib {
-
 QString museStringFromDouble(double v)
 {
-  // NOTE: snprintf can be locale sensitive! We should force the locale to standard 'C'.
-  // Use a per-thread thread-safe technique instead of setting the global locale.
-  // Note this C locale is NOT the same as the application's C++ locale.
-  // Setting LANG environment variable before running is different than setting our -l switch.
-  locale_t nloc = newlocale(LC_NUMERIC_MASK, "C", (locale_t) 0);
-  assert(nloc != (locale_t) 0);
-  uselocale(nloc);
-
-  bool useh = false;
-  int sz;
-  // How many characters required in the decimal string?
-  // Use a very large precision to get all the digits.
-  sz = std::snprintf(nullptr, 0, "%.100g", v);
-  // If the decimal size is 10 or less, use it.
-  if(sz > 10)
-  {
-    // How many characters required in the hex string?
-    const int hsz = std::snprintf(nullptr, 0, "%a", v);
-    // If the hex size is less than the decimal size, use it.
-    if(hsz < sz)
-    {
-      sz = hsz;
-      useh = true;
+    std::stringstream ss;
+    ss.precision(100);
+    ss.imbue(std::locale("C"));
+    ss << v;
+    if (ss.str().size() > 10) {
+        ss.str("");
+        ss << std::hexfloat << v;
     }
-  }
-  // Note +1 for null terminator since the returned size doesn't include it.
-  std::vector<char> buf(sz + 1);
-  if(useh)
-    std::snprintf(&buf[0], buf.size(), "%a", v);
-  else
-    std::snprintf(&buf[0], buf.size(), "%.100g", v);
-
-  // NOTE: LC_GLOBAL_HANDLE? Seems to be a mistake in the uselocale() documentation example.
-  //uselocale(LC_GLOBAL_HANDLE);
-  // So the new locale is no longer in use.
-  uselocale(LC_GLOBAL_LOCALE);
-  freelocale(nloc);
-
-  return QString(&buf[0]);
+    return QString::fromLatin1(ss.str().c_str());
 }
 
 double museStringToDouble(const QString &s, bool *ok)
 {
-  const char *sc = s.toLatin1().constData();
-  char *end;
-
-  // NOTE: strtod is locale sensitive! We must force the locale to standard 'C'.
-  // Use a per-thread thread-safe technique instead of setting the global locale.
-  // Note this C locale is NOT the same as the application's C++ locale.
-  // Setting LANG environment variable before running is different than setting our -l switch.
-  locale_t nloc = newlocale(LC_NUMERIC_MASK, "C", (locale_t) 0);
-  assert(nloc != (locale_t) 0);
-  uselocale(nloc);
-
-  const double rv = std::strtod(sc, &end);
-  if(ok)
-    // If the conversion fails, strtod sets end = input string.
-    *ok = end != sc;
-
-  // NOTE: LC_GLOBAL_HANDLE? Seems to be a mistake in the uselocale() documentation example.
-  //uselocale(LC_GLOBAL_HANDLE);
-  // So the new locale is no longer in use.
-  uselocale(LC_GLOBAL_LOCALE);
-  freelocale(nloc);
-
-  return rv;
+    return s.toDouble(ok);
 }
-
 } // namespace MusELib
 

--- a/src/libs/string/hex_float.cpp
+++ b/src/libs/string/hex_float.cpp
@@ -40,7 +40,14 @@ QString museStringFromDouble(double v)
 
 double museStringToDouble(const QString &s, bool *ok)
 {
-    return s.toDouble(ok);
+    std::stringstream ss;
+    double value;
+    size_t end;
+    ss.imbue(std::locale("C"));
+    ss << s.toStdString();
+    value = std::stod(ss.str(), &end);
+    *ok = (s.size() == end);
+    return value;
 }
 } // namespace MusELib
 


### PR DESCRIPTION
Goals
* Improve portability (in mingw there were problems with locale_t)
* Make code clearlier