### PR TITLE
Fixed and enhanced Edirol SD-90 IDF

### DIFF
--- a/src/share/instruments/Edirol-SD90.idf
+++ b/src/share/instruments/Edirol-SD90.idf
@@ -1,1155 +1,907 @@
-<?xml version="1.0"?>
-<muse version="1.0">
-  <MidiInstrument name="Edirol SD-90 StudioCanvas">
-    <PatchGroup name="SD90 Classical Capital Tones">
-      <Patch name="Piano 1" hbank="96" lbank="0" prog="0" />
-      <Patch name="Piano 2" hbank="96" lbank="0" prog="1" />
-      <Patch name="Piano 3" hbank="96" lbank="0" prog="2" />
-      <Patch name="Honky-tonk" hbank="96" lbank="0" prog="3" />
-      <Patch name="E.Piano 1" hbank="96" lbank="0" prog="4" />
-      <Patch name="E.Piano 2" hbank="96" lbank="0" prog="5" />
-      <Patch name="Harpsichord" hbank="96" lbank="0" prog="6" />
-      <Patch name="Clav" hbank="96" lbank="0" prog="7" />
-      <Patch name="Celesta" hbank="96" lbank="0" prog="8" />
-      <Patch name="Glockenspiel" hbank="96" lbank="0" prog="9" />
-      <Patch name="Music Box" hbank="96" lbank="0" prog="10" />
-      <Patch name="Vibraphone" hbank="96" lbank="0" prog="11" />
-      <Patch name="Marimba" hbank="96" lbank="0" prog="12" />
-      <Patch name="Xylophone" hbank="96" lbank="0" prog="13" />
-      <Patch name="Tubular-bell" hbank="96" lbank="0" prog="14" />
-      <Patch name="Santur" hbank="96" lbank="0" prog="15" />
-      <Patch name="Organ 1" hbank="96" lbank="0" prog="16" />
-      <Patch name="Organ 2" hbank="96" lbank="0" prog="17" />
-      <Patch name="Organ 3" hbank="96" lbank="0" prog="18" />
-      <Patch name="Church 1" hbank="96" lbank="0" prog="19" />
-      <Patch name="Reed Organ" hbank="96" lbank="0" prog="20" />
-      <Patch name="Accordion F" hbank="96" lbank="0" prog="21" />
-      <Patch name="Harmonica" hbank="96" lbank="0" prog="22" />
-      <Patch name="Bandneon" hbank="96" lbank="0" prog="23" />
-      <Patch name="Nylon Gt" hbank="96" lbank="0" prog="24" />
-      <Patch name="Steel-str.Gt" hbank="96" lbank="0" prog="25" />
-      <Patch name="Jazz Gt" hbank="96" lbank="0" prog="26" />
-      <Patch name="Clean Rear" hbank="96" lbank="0" prog="27" />
-      <Patch name="Muted Gt" hbank="96" lbank="0" prog="28" />
-      <Patch name="Overdrive Gt" hbank="96" lbank="0" prog="29" />
-      <Patch name="DistortionGt" hbank="96" lbank="0" prog="30" />
-      <Patch name="Gt.Harmonics" hbank="96" lbank="0" prog="31" />
-      <Patch name="Acoustic Bs" hbank="96" lbank="0" prog="32" />
-      <Patch name="Fingered Bs" hbank="96" lbank="0" prog="33" />
-      <Patch name="Picked Bass" hbank="96" lbank="0" prog="34" />
-      <Patch name="Fretless Bs" hbank="96" lbank="0" prog="35" />
-      <Patch name="Slap Bass 1" hbank="96" lbank="0" prog="36" />
-      <Patch name="Slap Bass 2" hbank="96" lbank="0" prog="37" />
-      <Patch name="Synth Bass 1" hbank="96" lbank="0" prog="38" />
-      <Patch name="Synth Bass 2" hbank="96" lbank="0" prog="39" />
-      <Patch name="Violin" hbank="96" lbank="0" prog="40" />
-      <Patch name="Viola" hbank="96" lbank="0" prog="41" />
-      <Patch name="Cello" hbank="96" lbank="0" prog="42" />
-      <Patch name="Contrabass" hbank="96" lbank="0" prog="43" />
-      <Patch name="Tremolo Str" hbank="96" lbank="0" prog="44" />
-      <Patch name="Pizzicato" hbank="96" lbank="0" prog="45" />
-      <Patch name="Harp" hbank="96" lbank="0" prog="46" />
-      <Patch name="Timpani" hbank="96" lbank="0" prog="47" />
-      <Patch name="Strings" hbank="96" lbank="0" prog="48" />
-      <Patch name="Slow Strings" hbank="96" lbank="0" prog="49" />
-      <Patch name="Syn.Strings1" hbank="96" lbank="0" prog="50" />
-      <Patch name="Syn.Strings2" hbank="96" lbank="0" prog="51" />
-      <Patch name="Choir Aahs" hbank="96" lbank="0" prog="52" />
-      <Patch name="Voice Oohs" hbank="96" lbank="0" prog="53" />
-      <Patch name="SynVox" hbank="96" lbank="0" prog="54" />
-      <Patch name="Orchestrahit" hbank="96" lbank="0" prog="55" />
-      <Patch name="Trumpet" hbank="96" lbank="0" prog="56" />
-      <Patch name="Trombone" hbank="96" lbank="0" prog="57" />
-      <Patch name="Tuba" hbank="96" lbank="0" prog="58" />
-      <Patch name="MuteTrumpet" hbank="96" lbank="0" prog="59" />
-      <Patch name="French Horns" hbank="96" lbank="0" prog="60" />
-      <Patch name="Brass 1" hbank="96" lbank="0" prog="61" />
-      <Patch name="SynthBrass 1" hbank="96" lbank="0" prog="62" />
-      <Patch name="SynthBrass 2" hbank="96" lbank="0" prog="63" />
-      <Patch name="Soprano Sax" hbank="96" lbank="0" prog="64" />
-      <Patch name="Alto Sax" hbank="96" lbank="0" prog="65" />
-      <Patch name="Tenor Sax" hbank="96" lbank="0" prog="66" />
-      <Patch name="Bariton Sax" hbank="96" lbank="0" prog="67" />
-      <Patch name="Oboe" hbank="96" lbank="0" prog="68" />
-      <Patch name="EnglishHorn" hbank="96" lbank="0" prog="69" />
-      <Patch name="Bassoon" hbank="96" lbank="0" prog="70" />
-      <Patch name="Clarinet" hbank="96" lbank="0" prog="71" />
-      <Patch name="Piccolo" hbank="96" lbank="0" prog="72" />
-      <Patch name="Flute" hbank="96" lbank="0" prog="73" />
-      <Patch name="Recorder" hbank="96" lbank="0" prog="74" />
-      <Patch name="Pan Flute" hbank="96" lbank="0" prog="75" />
-      <Patch name="Bottle Blow" hbank="96" lbank="0" prog="76" />
-      <Patch name="Shakuhachi" hbank="96" lbank="0" prog="77" />
-      <Patch name="Whistle" hbank="96" lbank="0" prog="78" />
-      <Patch name="Ocarina" hbank="96" lbank="0" prog="79" />
-      <Patch name="Square Wave" hbank="96" lbank="0" prog="80" />
-      <Patch name="Saw Wave" hbank="96" lbank="0" prog="81" />
-      <Patch name="Syn.Calliope" hbank="96" lbank="0" prog="82" />
-      <Patch name="Chiffer Lead" hbank="96" lbank="0" prog="83" />
-      <Patch name="Charang" hbank="96" lbank="0" prog="84" />
-      <Patch name="Solo Vox" hbank="96" lbank="0" prog="85" />
-      <Patch name="5th SawWave" hbank="96" lbank="0" prog="86" />
-      <Patch name="Bass &amp; Lead" hbank="96" lbank="0" prog="87" />
-      <Patch name="Fantasia" hbank="96" lbank="0" prog="88" />
-      <Patch name="Warm Pad" hbank="96" lbank="0" prog="89" />
-      <Patch name="Polysynth" hbank="96" lbank="0" prog="90" />
-      <Patch name="SpaceVoice" hbank="96" lbank="0" prog="91" />
-      <Patch name="BowedGlass" hbank="96" lbank="0" prog="92" />
-      <Patch name="Metal Pad" hbank="96" lbank="0" prog="93" />
-      <Patch name="Halo Pad" hbank="96" lbank="0" prog="94" />
-      <Patch name="Sweep Pad" hbank="96" lbank="0" prog="95" />
-      <Patch name="Ice Rain" hbank="96" lbank="0" prog="96" />
-      <Patch name="Soundtrack" hbank="96" lbank="0" prog="97" />
-      <Patch name="Crystal" hbank="96" lbank="0" prog="98" />
-      <Patch name="Atmosphere" hbank="96" lbank="0" prog="99" />
-      <Patch name="Brightness" hbank="96" lbank="0" prog="100" />
-      <Patch name="Goblin" hbank="96" lbank="0" prog="101" />
-      <Patch name="Echo Drops" hbank="96" lbank="0" prog="102" />
-      <Patch name="Star Theme" hbank="96" lbank="0" prog="103" />
-      <Patch name="Sitar" hbank="96" lbank="0" prog="104" />
-      <Patch name="Banjo" hbank="96" lbank="0" prog="105" />
-      <Patch name="Shamisen" hbank="96" lbank="0" prog="106" />
-      <Patch name="Koto" hbank="96" lbank="0" prog="107" />
-      <Patch name="Kalimba" hbank="96" lbank="0" prog="108" />
-      <Patch name="Bag Pipe" hbank="96" lbank="0" prog="109" />
-      <Patch name="Fiddle" hbank="96" lbank="0" prog="110" />
-      <Patch name="Shanai" hbank="96" lbank="0" prog="111" />
+<?xml version='1.0' encoding='utf-8'?>
+<muse version="2.1">
+  <MidiInstrument name="Edirol SD-90">
+    <SysEx name="Native On">
+      <data>41 10 00 48 12 00 00 00 00 00 00</data>
+    </SysEx>
+    <Init>
+      <event tick="0" type="2" datalen="11">41 10 00 48 12 00 00 00 00 00 00</event>
+    </Init>
+    <PatchGroup name="Piano">
+      <Patch name="Piano 1 Cls" hbank="96" lbank="0" prog="0" />
+      <Patch name="Piano 1w Cls" hbank="96" lbank="1" prog="0" />
+      <Patch name="Piano 1d Cls" hbank="96" lbank="2" prog="0" />
+      <Patch name="Ac.Piano Ctm" hbank="97" lbank="0" prog="0" />
+      <Patch name="Ac.Piano w Ctm" hbank="97" lbank="1" prog="0" />
+      <Patch name="Mild Piano Ctm" hbank="97" lbank="2" prog="0" />
+      <Patch name="St.Piano 1 Solo" hbank="98" lbank="0" prog="0" />
+      <Patch name="St.Piano 1w Solo" hbank="98" lbank="1" prog="0" />
+      <Patch name="European Pf Solo" hbank="98" lbank="2" prog="0" />
+      <Patch name="SD Piano Enh" hbank="99" lbank="0" prog="0" />
+      <Patch name="SD Piano w Enh" hbank="99" lbank="1" prog="0" />
+      <Patch name="Classic Pf Enh" hbank="99" lbank="2" prog="0" />
+      <Patch name="Piano 2 Cls" hbank="96" lbank="0" prog="1" />
+      <Patch name="Piano 2w Cls" hbank="96" lbank="1" prog="1" />
+      <Patch name="Rock Piano Ctm" hbank="97" lbank="0" prog="1" />
+      <Patch name="Rock Piano w Ctm" hbank="97" lbank="1" prog="1" />
+      <Patch name="St.Piano 2 Solo" hbank="98" lbank="0" prog="1" />
+      <Patch name="St.Piano 2w Solo" hbank="98" lbank="1" prog="1" />
+      <Patch name="Enh.Piano 2 Enh" hbank="99" lbank="0" prog="1" />
+      <Patch name="Enh.Piano 2w Enh" hbank="99" lbank="1" prog="1" />
+      <Patch name="Piano 3 Cls" hbank="96" lbank="0" prog="2" />
+      <Patch name="Piano 3w Cls" hbank="96" lbank="1" prog="2" />
+      <Patch name="E.Grand Pf Ctm" hbank="97" lbank="0" prog="2" />
+      <Patch name="E.Grand Pf w Ctm" hbank="97" lbank="1" prog="2" />
+      <Patch name="SA Piano Solo" hbank="98" lbank="0" prog="2" />
+      <Patch name="SA Piano w Solo" hbank="98" lbank="1" prog="2" />
+      <Patch name="Enh.E Grand Enh" hbank="99" lbank="0" prog="2" />
+      <Patch name="Enh.E Grandw Enh" hbank="99" lbank="1" prog="2" />
+      <Patch name="Honky-tonk Cls" hbank="96" lbank="0" prog="3" />
+      <Patch name="Honky-tonk w Cls" hbank="96" lbank="1" prog="3" />
+      <Patch name="Old Honky Ctm" hbank="97" lbank="0" prog="3" />
+      <Patch name="Old Honky w Ctm" hbank="97" lbank="1" prog="3" />
+      <Patch name="St.Honky Solo" hbank="98" lbank="0" prog="3" />
+      <Patch name="St.Honky w Solo" hbank="98" lbank="1" prog="3" />
+      <Patch name="Brite Honky Enh" hbank="99" lbank="0" prog="3" />
+      <Patch name="Brite Honkyw Enh" hbank="99" lbank="1" prog="3" />
+      <Patch name="E.Piano 1 Cls" hbank="96" lbank="0" prog="4" />
+      <Patch name="Detuned EP1 Cls" hbank="96" lbank="1" prog="4" />
+      <Patch name="Dyno Rhodes Cls" hbank="96" lbank="2" prog="4" />
+      <Patch name="60's E.Piano Cls" hbank="96" lbank="3" prog="4" />
+      <Patch name="Soft Rhodes Ctm" hbank="97" lbank="0" prog="4" />
+      <Patch name="Fat Rhodes Ctm" hbank="97" lbank="1" prog="4" />
+      <Patch name="Rhodes Wide Ctm" hbank="97" lbank="2" prog="4" />
+      <Patch name="Wurly Soft Ctm" hbank="97" lbank="3" prog="4" />
+      <Patch name="Tremo Rhodes Solo" hbank="98" lbank="0" prog="4" />
+      <Patch name="Sweet Tynes Solo" hbank="98" lbank="1" prog="4" />
+      <Patch name="Tremo Dyno Solo" hbank="98" lbank="2" prog="4" />
+      <Patch name="Tremo Wurly Solo" hbank="98" lbank="3" prog="4" />
+      <Patch name="Stage 73 Enh" hbank="99" lbank="0" prog="4" />
+      <Patch name="NY Rhodes Enh" hbank="99" lbank="1" prog="4" />
+      <Patch name="Phase Dyno Enh" hbank="99" lbank="2" prog="4" />
+      <Patch name="Whirly Enh" hbank="99" lbank="3" prog="4" />
+      <Patch name="E.Piano 2 Cls" hbank="96" lbank="0" prog="5" />
+      <Patch name="Detuned EP2 Cls" hbank="96" lbank="1" prog="5" />
+      <Patch name="E.Piano 2v Cls" hbank="96" lbank="2" prog="5" />
+      <Patch name="EP Legend Cls" hbank="96" lbank="3" prog="5" />
+      <Patch name="EP Phase Cls" hbank="96" lbank="4" prog="5" />
+      <Patch name="FM E.Piano Ctm" hbank="97" lbank="0" prog="5" />
+      <Patch name="Soft FM EP Ctm" hbank="97" lbank="1" prog="5" />
+      <Patch name="SA E.Piano Ctm" hbank="97" lbank="2" prog="5" />
+      <Patch name="EP Legend 2 Ctm" hbank="97" lbank="3" prog="5" />
+      <Patch name="EP Phase 2 Ctm" hbank="97" lbank="4" prog="5" />
+      <Patch name="FM Hard EP Solo" hbank="98" lbank="0" prog="5" />
+      <Patch name="Brite FM EP Solo" hbank="98" lbank="1" prog="5" />
+      <Patch name="Brite FM EP2 Solo" hbank="98" lbank="2" prog="5" />
+      <Patch name="EP Legend 3 Solo" hbank="98" lbank="3" prog="5" />
+      <Patch name="EP Phase 3 Solo" hbank="98" lbank="4" prog="5" />
+      <Patch name="Chorus EP Enh" hbank="99" lbank="0" prog="5" />
+      <Patch name="Phase FM EP Enh" hbank="99" lbank="1" prog="5" />
+      <Patch name="Wah FM EP Enh" hbank="99" lbank="2" prog="5" />
+      <Patch name="Enh.Legend Enh" hbank="99" lbank="3" prog="5" />
+      <Patch name="Phasing EP Enh" hbank="99" lbank="4" prog="5" />
+      <Patch name="Harpsichord Cls" hbank="96" lbank="0" prog="6" />
+      <Patch name="Coupl hps Cls" hbank="96" lbank="1" prog="6" />
+      <Patch name="Harpsi w Cls" hbank="96" lbank="2" prog="6" />
+      <Patch name="Harpsi o Cls" hbank="96" lbank="3" prog="6" />
+      <Patch name="Harpsi 2 Ctm" hbank="97" lbank="0" prog="6" />
+      <Patch name="Coupl hps 2 Ctm" hbank="97" lbank="1" prog="6" />
+      <Patch name="Harpsi 2 w Ctm" hbank="97" lbank="2" prog="6" />
+      <Patch name="Harpsi 2 o Ctm" hbank="97" lbank="3" prog="6" />
+      <Patch name="St.Harpsichd Solo" hbank="98" lbank="0" prog="6" />
+      <Patch name="St.Coupl hps Solo" hbank="98" lbank="1" prog="6" />
+      <Patch name="St.Harpsi w Solo" hbank="98" lbank="2" prog="6" />
+      <Patch name="St.Harpsi o Solo" hbank="98" lbank="3" prog="6" />
+      <Patch name="Enh.Harpsi Enh" hbank="99" lbank="0" prog="6" />
+      <Patch name="Enh.Coupl hp Enh" hbank="99" lbank="1" prog="6" />
+      <Patch name="Enh.Harpsi w Enh" hbank="99" lbank="2" prog="6" />
+      <Patch name="Enh.Harpsi o Enh" hbank="99" lbank="3" prog="6" />
+      <Patch name="Clav Cls" hbank="96" lbank="0" prog="7" />
+      <Patch name="Pulse Clav Cls" hbank="96" lbank="1" prog="7" />
+      <Patch name="Atack Clav 1 Ctm" hbank="97" lbank="0" prog="7" />
+      <Patch name="AnalogClav 1 Ctm" hbank="97" lbank="1" prog="7" />
+      <Patch name="Atack Clav 2 Solo" hbank="98" lbank="0" prog="7" />
+      <Patch name="AnalogClav 2 Solo" hbank="98" lbank="1" prog="7" />
+      <Patch name="Comp Clav Enh" hbank="99" lbank="0" prog="7" />
+      <Patch name="Wah Ana.Clav Enh" hbank="99" lbank="1" prog="7" />
+    </PatchGroup>
+    <PatchGroup name="Chromatic Percussion">
+      <Patch name="Celesta Cls" hbank="96" lbank="0" prog="8" />
+      <Patch name="Celesta 2 Ctm" hbank="97" lbank="0" prog="8" />
+      <Patch name="St.Celesta Solo" hbank="98" lbank="0" prog="8" />
+      <Patch name="SpaceCelesta Enh" hbank="99" lbank="0" prog="8" />
+      <Patch name="Glockenspiel Cls" hbank="96" lbank="0" prog="9" />
+      <Patch name="Glocken 2 Ctm" hbank="97" lbank="0" prog="9" />
+      <Patch name="St.Glocken Solo" hbank="98" lbank="0" prog="9" />
+      <Patch name="Trem.Glocken Enh" hbank="99" lbank="0" prog="9" />
+      <Patch name="Music Box Cls" hbank="96" lbank="0" prog="10" />
+      <Patch name="Music Box 2 Ctm" hbank="97" lbank="0" prog="10" />
+      <Patch name="St.Music Box Solo" hbank="98" lbank="0" prog="10" />
+      <Patch name="Panning Box Enh" hbank="99" lbank="0" prog="10" />
+      <Patch name="Vibraphone Cls" hbank="96" lbank="0" prog="11" />
+      <Patch name="Vibraphone w Cls" hbank="96" lbank="1" prog="11" />
+      <Patch name="Vibraphone 2 Ctm" hbank="97" lbank="0" prog="11" />
+      <Patch name="Vibraphone2w Ctm" hbank="97" lbank="1" prog="11" />
+      <Patch name="St.Vibra Solo" hbank="98" lbank="0" prog="11" />
+      <Patch name="St.Vibra w Solo" hbank="98" lbank="1" prog="11" />
+      <Patch name="Trem.Vibra Enh" hbank="99" lbank="0" prog="11" />
+      <Patch name="Trem.Vibra w Enh" hbank="99" lbank="1" prog="11" />
+      <Patch name="Marimba Cls" hbank="96" lbank="0" prog="12" />
+      <Patch name="Marimba w Cls" hbank="96" lbank="1" prog="12" />
+      <Patch name="Marimba 2 Ctm" hbank="97" lbank="0" prog="12" />
+      <Patch name="Marimba 2 w Ctm" hbank="97" lbank="1" prog="12" />
+      <Patch name="St.Marimba Solo" hbank="98" lbank="0" prog="12" />
+      <Patch name="St.Marimba w Solo" hbank="98" lbank="1" prog="12" />
+      <Patch name="Enh.Marimba Enh" hbank="99" lbank="0" prog="12" />
+      <Patch name="Enh.Marimbaw Enh" hbank="99" lbank="1" prog="12" />
+      <Patch name="Xylophone Cls" hbank="96" lbank="0" prog="13" />
+      <Patch name="Xylophone 2 Ctm" hbank="97" lbank="0" prog="13" />
+      <Patch name="St.Xylophone Solo" hbank="98" lbank="0" prog="13" />
+      <Patch name="Enh.Xylophon Enh" hbank="99" lbank="0" prog="13" />
+      <Patch name="Tubular-bell Cls" hbank="96" lbank="0" prog="14" />
+      <Patch name="Church Bell Cls" hbank="96" lbank="1" prog="14" />
+      <Patch name="Carillon Cls" hbank="96" lbank="2" prog="14" />
+      <Patch name="Tubular-bel2 Ctm" hbank="97" lbank="0" prog="14" />
+      <Patch name="Church Bell2 Ctm" hbank="97" lbank="1" prog="14" />
+      <Patch name="Carillon 2 Ctm" hbank="97" lbank="2" prog="14" />
+      <Patch name="St.Tubular Solo" hbank="98" lbank="0" prog="14" />
+      <Patch name="St.Church Solo" hbank="98" lbank="1" prog="14" />
+      <Patch name="St.Carillon Solo" hbank="98" lbank="2" prog="14" />
+      <Patch name="Trem.Tubula Enh" hbank="99" lbank="0" prog="14" />
+      <Patch name="Echo Church Enh" hbank="99" lbank="1" prog="14" />
+      <Patch name="Trm.Carillon Enh" hbank="99" lbank="2" prog="14" />
+      <Patch name="Santur Cls" hbank="96" lbank="0" prog="15" />
+      <Patch name="Santur 2 Ctm" hbank="97" lbank="0" prog="15" />
+      <Patch name="St.Santur Solo" hbank="98" lbank="0" prog="15" />
+      <Patch name="Enh.Santur Enh" hbank="99" lbank="0" prog="15" />
+    </PatchGroup>
+    <PatchGroup name="Organ">
+      <Patch name="Organ 1 Cls" hbank="96" lbank="0" prog="16" />
+      <Patch name="Detuned Or1 Cls" hbank="96" lbank="1" prog="16" />
+      <Patch name="Organ 60 Cls" hbank="96" lbank="2" prog="16" />
+      <Patch name="Organ 4 Cls" hbank="96" lbank="3" prog="16" />
+      <Patch name="Perky Ctm" hbank="97" lbank="0" prog="16" />
+      <Patch name="Ballad B Ctm" hbank="97" lbank="1" prog="16" />
+      <Patch name="Happy 60s Ctm" hbank="97" lbank="2" prog="16" />
+      <Patch name="Tone Wheel Ctm" hbank="97" lbank="3" prog="16" />
+      <Patch name="Roller Solo" hbank="98" lbank="0" prog="16" />
+      <Patch name="Rocker Solo" hbank="98" lbank="1" prog="16" />
+      <Patch name="Soft60'Organ Solo" hbank="98" lbank="2" prog="16" />
+      <Patch name="Full Stops Solo" hbank="98" lbank="3" prog="16" />
+      <Patch name="Perky Spin Enh" hbank="99" lbank="0" prog="16" />
+      <Patch name="Gospel Spin Enh" hbank="99" lbank="1" prog="16" />
+      <Patch name="96 Year Enh" hbank="99" lbank="2" prog="16" />
+      <Patch name="Tone Wh.Solo Enh" hbank="99" lbank="3" prog="16" />
+      <Patch name="Organ 2 Cls" hbank="96" lbank="0" prog="17" />
+      <Patch name="Detuned Or2 Cls" hbank="96" lbank="1" prog="17" />
+      <Patch name="Organ 5 Cls" hbank="96" lbank="2" prog="17" />
+      <Patch name="Jazz Organ 1 Ctm" hbank="97" lbank="0" prog="17" />
+      <Patch name="Perc.Organ 1 Ctm" hbank="97" lbank="1" prog="17" />
+      <Patch name="Dist.JzOrg 1 Ctm" hbank="97" lbank="2" prog="17" />
+      <Patch name="Jazz Organ 2 Solo" hbank="98" lbank="0" prog="17" />
+      <Patch name="Perc.Organ 2 Solo" hbank="98" lbank="1" prog="17" />
+      <Patch name="Dist.JzOrg 2 Solo" hbank="98" lbank="2" prog="17" />
+      <Patch name="Jazzy Spin Enh" hbank="99" lbank="0" prog="17" />
+      <Patch name="Jazzy Spin 2 Enh" hbank="99" lbank="1" prog="17" />
+      <Patch name="Jazzy Spin 3 Enh" hbank="99" lbank="2" prog="17" />
+      <Patch name="Organ 3 Cls" hbank="96" lbank="0" prog="18" />
+      <Patch name="Organ 3 fast Ctm" hbank="97" lbank="0" prog="18" />
+      <Patch name="Rock Organ Solo" hbank="98" lbank="0" prog="18" />
+      <Patch name="Rocker Spin Enh" hbank="99" lbank="0" prog="18" />
+      <Patch name="Church 1 Cls" hbank="96" lbank="0" prog="19" />
+      <Patch name="Church 2 Cls" hbank="96" lbank="1" prog="19" />
+      <Patch name="Church 3 Cls" hbank="96" lbank="2" prog="19" />
+      <Patch name="Pipe Organ 1 Ctm" hbank="97" lbank="0" prog="19" />
+      <Patch name="LargeChurch1 Ctm" hbank="97" lbank="1" prog="19" />
+      <Patch name="SmallChurch1 Ctm" hbank="97" lbank="2" prog="19" />
+      <Patch name="Pipe Organ 2 Solo" hbank="98" lbank="0" prog="19" />
+      <Patch name="LargeChurch2 Solo" hbank="98" lbank="1" prog="19" />
+      <Patch name="SmallChurch2 Solo" hbank="98" lbank="2" prog="19" />
+      <Patch name="Amb.Church Enh" hbank="99" lbank="0" prog="19" />
+      <Patch name="Amb.Church 2 Enh" hbank="99" lbank="1" prog="19" />
+      <Patch name="Amb.Church 3 Enh" hbank="99" lbank="2" prog="19" />
+      <Patch name="Reed Organ Cls" hbank="96" lbank="0" prog="20" />
+      <Patch name="Puff Organ Cls" hbank="96" lbank="1" prog="20" />
+      <Patch name="Reed Organ 2 Ctm" hbank="97" lbank="0" prog="20" />
+      <Patch name="Organ Flute Ctm" hbank="97" lbank="1" prog="20" />
+      <Patch name="Reed Organ 3 Solo" hbank="98" lbank="0" prog="20" />
+      <Patch name="Theater Solo" hbank="98" lbank="1" prog="20" />
+      <Patch name="Old Reed Org Enh" hbank="99" lbank="0" prog="20" />
+      <Patch name="Enh.Theater Enh" hbank="99" lbank="1" prog="20" />
+      <Patch name="Accordion F Cls" hbank="96" lbank="0" prog="21" />
+      <Patch name="Accordion I Cls" hbank="96" lbank="1" prog="21" />
+      <Patch name="French Acc Ctm" hbank="97" lbank="0" prog="21" />
+      <Patch name="It Muset Ctm" hbank="97" lbank="1" prog="21" />
+      <Patch name="St.FrenchAcc Solo" hbank="98" lbank="0" prog="21" />
+      <Patch name="St.It Muset Solo" hbank="98" lbank="1" prog="21" />
+      <Patch name="Enh.French Enh" hbank="99" lbank="0" prog="21" />
+      <Patch name="Enh.ItMuset Enh" hbank="99" lbank="1" prog="21" />
+      <Patch name="Harmonica Cls" hbank="96" lbank="0" prog="22" />
+      <Patch name="Harmonica 2 Ctm" hbank="97" lbank="0" prog="22" />
+      <Patch name="St.Harmonica Solo" hbank="98" lbank="0" prog="22" />
+      <Patch name="Ld.Harmonica Enh" hbank="99" lbank="0" prog="22" />
+      <Patch name="Bandneon Cls" hbank="96" lbank="0" prog="23" />
+      <Patch name="Bandneon 1 Ctm" hbank="97" lbank="0" prog="23" />
+      <Patch name="St.Bandneon Solo" hbank="98" lbank="0" prog="23" />
+      <Patch name="Enh.Bandneon Enh" hbank="99" lbank="0" prog="23" />
+    </PatchGroup>
+    <PatchGroup name="Guitar">
+      <Patch name="Nylon Gt Cls" hbank="96" lbank="0" prog="24" />
+      <Patch name="Ukulele Cls" hbank="96" lbank="1" prog="24" />
+      <Patch name="Nylon o Cls" hbank="96" lbank="2" prog="24" />
+      <Patch name="Nylon Gt.2 Cls" hbank="96" lbank="3" prog="24" />
+      <Patch name="Nylon Gt 2 Ctm" hbank="97" lbank="0" prog="24" />
+      <Patch name="Ukulele 2 Ctm" hbank="97" lbank="1" prog="24" />
+      <Patch name="Nylon 2 o Ctm" hbank="97" lbank="2" prog="24" />
+      <Patch name="Hard Gut Gt Ctm" hbank="97" lbank="3" prog="24" />
+      <Patch name="Nylon Gt 3 Solo" hbank="98" lbank="0" prog="24" />
+      <Patch name="Ukulele 3 Solo" hbank="98" lbank="1" prog="24" />
+      <Patch name="Nylon 3 o Solo" hbank="98" lbank="2" prog="24" />
+      <Patch name="Hard Gut Gt2 Solo" hbank="98" lbank="3" prog="24" />
+      <Patch name="Enh.Nylon Gt Enh" hbank="99" lbank="0" prog="24" />
+      <Patch name="Enh.Ukulele Enh" hbank="99" lbank="1" prog="24" />
+      <Patch name="Enh.Nylon o Enh" hbank="99" lbank="2" prog="24" />
+      <Patch name="Enh.Gut Gt Enh" hbank="99" lbank="3" prog="24" />
+      <Patch name="Steel-str.Gt Cls" hbank="96" lbank="0" prog="25" />
+      <Patch name="12-Str.Gt Cls" hbank="96" lbank="1" prog="25" />
+      <Patch name="Mandolin Cls" hbank="96" lbank="2" prog="25" />
+      <Patch name="Steel+Body Cls" hbank="96" lbank="3" prog="25" />
+      <Patch name="OV Steel Gt Ctm" hbank="97" lbank="0" prog="25" />
+      <Patch name="12-Str.Gt 2 Ctm" hbank="97" lbank="1" prog="25" />
+      <Patch name="Mandolin 2 Ctm" hbank="97" lbank="2" prog="25" />
+      <Patch name="Steel+Body 2 Ctm" hbank="97" lbank="3" prog="25" />
+      <Patch name="SteelStr.Gt2 Solo" hbank="98" lbank="0" prog="25" />
+      <Patch name="12-Str.Gt 3 Solo" hbank="98" lbank="1" prog="25" />
+      <Patch name="Mandolin 3 Solo" hbank="98" lbank="2" prog="25" />
+      <Patch name="Steel+Body 3 Solo" hbank="98" lbank="3" prog="25" />
+      <Patch name="Comp OVSteel Enh" hbank="99" lbank="0" prog="25" />
+      <Patch name="3D 12-Str.Gt Enh" hbank="99" lbank="1" prog="25" />
+      <Patch name="Enh.Mandolin Enh" hbank="99" lbank="2" prog="25" />
+      <Patch name="DelayedSteel Enh" hbank="99" lbank="3" prog="25" />
+      <Patch name="Jazz Gt Cls" hbank="96" lbank="0" prog="26" />
+      <Patch name="Pedal Steel Cls" hbank="96" lbank="1" prog="26" />
+      <Patch name="Jazz Gt 2 Ctm" hbank="97" lbank="0" prog="26" />
+      <Patch name="Pedal Steel2 Ctm" hbank="97" lbank="1" prog="26" />
+      <Patch name="Jazz Gt 3 Solo" hbank="98" lbank="0" prog="26" />
+      <Patch name="Pedal Steel3 Solo" hbank="98" lbank="1" prog="26" />
+      <Patch name="Lead Jazz Gt Enh" hbank="99" lbank="0" prog="26" />
+      <Patch name="Hawaian Gt Enh" hbank="99" lbank="1" prog="26" />
+      <Patch name="Clean Rear Cls" hbank="96" lbank="0" prog="27" />
+      <Patch name="Clean Half Cls" hbank="96" lbank="1" prog="27" />
+      <Patch name="Mid Tone Gt Cls" hbank="96" lbank="2" prog="27" />
+      <Patch name="TC Rear Ctm" hbank="97" lbank="0" prog="27" />
+      <Patch name="TC Front Ctm" hbank="97" lbank="1" prog="27" />
+      <Patch name="TC Front 2 Ctm" hbank="97" lbank="2" prog="27" />
+      <Patch name="Strat2 Rear Solo" hbank="98" lbank="0" prog="27" />
+      <Patch name="Chorus Clean Solo" hbank="98" lbank="1" prog="27" />
+      <Patch name="335 Solo" hbank="98" lbank="2" prog="27" />
+      <Patch name="Old Clean Gt Enh" hbank="99" lbank="0" prog="27" />
+      <Patch name="Jazz Chorus Enh" hbank="99" lbank="1" prog="27" />
+      <Patch name="335 Drive Enh" hbank="99" lbank="2" prog="27" />
+      <Patch name="Muted Gt Cls" hbank="96" lbank="0" prog="28" />
+      <Patch name="Funk Gt Cls" hbank="96" lbank="1" prog="28" />
+      <Patch name="Funk Gt 2 Cls" hbank="96" lbank="2" prog="28" />
+      <Patch name="Jazz Man Cls" hbank="96" lbank="3" prog="28" />
+      <Patch name="TC Mute Gt Ctm" hbank="97" lbank="0" prog="28" />
+      <Patch name="FunkGt Slap Ctm" hbank="97" lbank="1" prog="28" />
+      <Patch name="Funk Pop Ctm" hbank="97" lbank="2" prog="28" />
+      <Patch name="Mute Jazz Gt Ctm" hbank="97" lbank="3" prog="28" />
+      <Patch name="TC Mute Gt 2 Solo" hbank="98" lbank="0" prog="28" />
+      <Patch name="FunkGt.Slap2 Solo" hbank="98" lbank="1" prog="28" />
+      <Patch name="Funk Pop 2 Solo" hbank="98" lbank="2" prog="28" />
+      <Patch name="Slap Jazz Gt Solo" hbank="98" lbank="3" prog="28" />
+      <Patch name="Comp Mute Gt Enh" hbank="99" lbank="0" prog="28" />
+      <Patch name="Enh.Funk Gt Enh" hbank="99" lbank="1" prog="28" />
+      <Patch name="Wah Funk Pop Enh" hbank="99" lbank="2" prog="28" />
+      <Patch name="Solo Jazz Gt Enh" hbank="99" lbank="3" prog="28" />
+      <Patch name="Overdrive Gt Cls" hbank="96" lbank="0" prog="29" />
+      <Patch name="Gt.Pinch Cls" hbank="96" lbank="1" prog="29" />
+      <Patch name="Atk Drive Gt Ctm" hbank="97" lbank="0" prog="29" />
+      <Patch name="Gt.Pinch 2 Ctm" hbank="97" lbank="1" prog="29" />
+      <Patch name="OverdriveGt2 Solo" hbank="98" lbank="0" prog="29" />
+      <Patch name="Gt.Pinch 3 Solo" hbank="98" lbank="1" prog="29" />
+      <Patch name="TC Lead Gt Enh" hbank="99" lbank="0" prog="29" />
+      <Patch name="Gt.PinchLead Enh" hbank="99" lbank="1" prog="29" />
+      <Patch name="DistortionGt Cls" hbank="96" lbank="0" prog="30" />
+      <Patch name="Feedback Gt Cls" hbank="96" lbank="1" prog="30" />
+      <Patch name="DistRythm Gt Cls" hbank="96" lbank="2" prog="30" />
+      <Patch name="Atk Dist Gt Ctm" hbank="97" lbank="0" prog="30" />
+      <Patch name="FeedbackGt 2 Ctm" hbank="97" lbank="1" prog="30" />
+      <Patch name="Muted Dist Ctm" hbank="97" lbank="2" prog="30" />
+      <Patch name="Dist.Gt 2 Solo" hbank="98" lbank="0" prog="30" />
+      <Patch name="Feedback OD Solo" hbank="98" lbank="1" prog="30" />
+      <Patch name="Muted Dist 2 Solo" hbank="98" lbank="2" prog="30" />
+      <Patch name="Heavy DistGt Enh" hbank="99" lbank="0" prog="30" />
+      <Patch name="Feedbacker Enh" hbank="99" lbank="1" prog="30" />
+      <Patch name="Muted OD Enh" hbank="99" lbank="2" prog="30" />
+      <Patch name="Gt.Harmonics Cls" hbank="96" lbank="0" prog="31" />
+      <Patch name="Gt.Feedback Cls" hbank="96" lbank="1" prog="31" />
+      <Patch name="Gt.Harm 2 Ctm" hbank="97" lbank="0" prog="31" />
+      <Patch name="FeedbackOct Ctm" hbank="97" lbank="1" prog="31" />
+      <Patch name="Gt.OctHarm Solo" hbank="98" lbank="0" prog="31" />
+      <Patch name="FeedbackHarm Solo" hbank="98" lbank="1" prog="31" />
+      <Patch name="Amp.Harm Enh" hbank="99" lbank="0" prog="31" />
+      <Patch name="Amp.FeedBack Enh" hbank="99" lbank="1" prog="31" />
+    </PatchGroup>
+    <PatchGroup name="Bass">
+      <Patch name="Acoustic Bs Cls" hbank="96" lbank="0" prog="32" />
+      <Patch name="Rockabilly Ctm" hbank="97" lbank="0" prog="32" />
+      <Patch name="Fat Aco.Bass Solo" hbank="98" lbank="0" prog="32" />
+      <Patch name="Enh.Aco Bass Enh" hbank="99" lbank="0" prog="32" />
+      <Patch name="Fingered Bs Cls" hbank="96" lbank="0" prog="33" />
+      <Patch name="FingerJ.Bass Cls" hbank="96" lbank="1" prog="33" />
+      <Patch name="Fingered Bs2 Ctm" hbank="97" lbank="0" prog="33" />
+      <Patch name="FingerP.Bass Ctm" hbank="97" lbank="1" prog="33" />
+      <Patch name="Jazz Bass Solo" hbank="98" lbank="0" prog="33" />
+      <Patch name="Finger Slap Solo" hbank="98" lbank="1" prog="33" />
+      <Patch name="Pre Bass Enh" hbank="99" lbank="0" prog="33" />
+      <Patch name="Comp Finger Enh" hbank="99" lbank="1" prog="33" />
+      <Patch name="Picked Bass Cls" hbank="96" lbank="0" prog="34" />
+      <Patch name="Picked Jz Bs Ctm" hbank="97" lbank="0" prog="34" />
+      <Patch name="Picking Bass Solo" hbank="98" lbank="0" prog="34" />
+      <Patch name="Rock Bass Enh" hbank="99" lbank="0" prog="34" />
+      <Patch name="Fretless Bs Cls" hbank="96" lbank="0" prog="35" />
+      <Patch name="Fretless Bs2 Ctm" hbank="97" lbank="0" prog="35" />
+      <Patch name="PhaseFrtless Solo" hbank="98" lbank="0" prog="35" />
+      <Patch name="Cho.Fretless Enh" hbank="99" lbank="0" prog="35" />
+      <Patch name="Slap Bass 1 Cls" hbank="96" lbank="0" prog="36" />
+      <Patch name="Slap Pop 1 Ctm" hbank="97" lbank="0" prog="36" />
+      <Patch name="Jazz Slap Solo" hbank="98" lbank="0" prog="36" />
+      <Patch name="Phase Slap Enh" hbank="99" lbank="0" prog="36" />
+      <Patch name="Slap Bass 2 Cls" hbank="96" lbank="0" prog="37" />
+      <Patch name="Funky Slap Ctm" hbank="97" lbank="0" prog="37" />
+      <Patch name="Slap Pop 2 Solo" hbank="98" lbank="0" prog="37" />
+      <Patch name="Enh.Slap Pop Enh" hbank="99" lbank="0" prog="37" />
+      <Patch name="Synth Bass 1 Cls" hbank="96" lbank="0" prog="38" />
+      <Patch name="SynthBass101 Cls" hbank="96" lbank="1" prog="38" />
+      <Patch name="Acid Bass Cls" hbank="96" lbank="2" prog="38" />
+      <Patch name="Clavi Bass Cls" hbank="96" lbank="3" prog="38" />
+      <Patch name="Hammer Cls" hbank="96" lbank="4" prog="38" />
+      <Patch name="MG303 Bass Ctm" hbank="97" lbank="0" prog="38" />
+      <Patch name="MG Bass Ctm" hbank="97" lbank="1" prog="38" />
+      <Patch name="MG Acid Bass Ctm" hbank="97" lbank="2" prog="38" />
+      <Patch name="Clavi Bass 2 Ctm" hbank="97" lbank="3" prog="38" />
+      <Patch name="OB Hammer Ctm" hbank="97" lbank="4" prog="38" />
+      <Patch name="Fat Syn.Bass Solo" hbank="98" lbank="0" prog="38" />
+      <Patch name="SynthSaw Bs Solo" hbank="98" lbank="1" prog="38" />
+      <Patch name="AcidBs Dirty Solo" hbank="98" lbank="2" prog="38" />
+      <Patch name="Clavi Bass 3 Solo" hbank="98" lbank="3" prog="38" />
+      <Patch name="MG Hammer Solo" hbank="98" lbank="4" prog="38" />
+      <Patch name="Dist303 Bass Enh" hbank="99" lbank="0" prog="38" />
+      <Patch name="P.Shift Bass Enh" hbank="99" lbank="1" prog="38" />
+      <Patch name="Acid Dist Bs Enh" hbank="99" lbank="2" prog="38" />
+      <Patch name="PhaseClaviBs Enh" hbank="99" lbank="3" prog="38" />
+      <Patch name="Enh.Hammer Enh" hbank="99" lbank="4" prog="38" />
+      <Patch name="Synth Bass 2 Cls" hbank="96" lbank="0" prog="39" />
+      <Patch name="Beef FM Bs Cls" hbank="96" lbank="1" prog="39" />
+      <Patch name="Rubber Bass Cls" hbank="96" lbank="2" prog="39" />
+      <Patch name="Attack Pulse Cls" hbank="96" lbank="3" prog="39" />
+      <Patch name="Seq101 Bass Ctm" hbank="97" lbank="0" prog="39" />
+      <Patch name="Beef Slap Bs Ctm" hbank="97" lbank="1" prog="39" />
+      <Patch name="Rubber Bass2 Ctm" hbank="97" lbank="2" prog="39" />
+      <Patch name="Attack Saw Ctm" hbank="97" lbank="3" prog="39" />
+      <Patch name="Sq SynthBass Solo" hbank="98" lbank="0" prog="39" />
+      <Patch name="Beef Saw Bs Solo" hbank="98" lbank="1" prog="39" />
+      <Patch name="JpSaw Rubber Solo" hbank="98" lbank="2" prog="39" />
+      <Patch name="Attack MG Bs Solo" hbank="98" lbank="3" prog="39" />
+      <Patch name="PhaseSq Bass Enh" hbank="99" lbank="0" prog="39" />
+      <Patch name="Enh.Beef Bs Enh" hbank="99" lbank="1" prog="39" />
+      <Patch name="Fat JpSaw Bs Enh" hbank="99" lbank="2" prog="39" />
+      <Patch name="Enh.MG Bass Enh" hbank="99" lbank="3" prog="39" />
+    </PatchGroup>
+    <PatchGroup name="Strings">
+      <Patch name="Violin Cls" hbank="96" lbank="0" prog="40" />
+      <Patch name="Slow Violin Cls" hbank="96" lbank="1" prog="40" />
+      <Patch name="Violin vib Ctm" hbank="97" lbank="0" prog="40" />
+      <Patch name="Slow Vln vib Ctm" hbank="97" lbank="1" prog="40" />
+      <Patch name="Violin 2 vib Solo" hbank="98" lbank="0" prog="40" />
+      <Patch name="SlowVln2 vib Solo" hbank="98" lbank="1" prog="40" />
+      <Patch name="Enh.Violin Enh" hbank="99" lbank="0" prog="40" />
+      <Patch name="Enh.Slow Vln Enh" hbank="99" lbank="1" prog="40" />
+      <Patch name="Viola Cls" hbank="96" lbank="0" prog="41" />
+      <Patch name="Viola vib Ctm" hbank="97" lbank="0" prog="41" />
+      <Patch name="Viola2 vib Solo" hbank="98" lbank="0" prog="41" />
+      <Patch name="Enh.Viola Enh" hbank="99" lbank="0" prog="41" />
+      <Patch name="Cello Cls" hbank="96" lbank="0" prog="42" />
+      <Patch name="Cello vib Ctm" hbank="97" lbank="0" prog="42" />
+      <Patch name="Cello2 vib Solo" hbank="98" lbank="0" prog="42" />
+      <Patch name="Enh.Cello Enh" hbank="99" lbank="0" prog="42" />
+      <Patch name="Contrabass Cls" hbank="96" lbank="0" prog="43" />
+      <Patch name="Cb vib Ctm" hbank="97" lbank="0" prog="43" />
+      <Patch name="Cb2 vib Solo" hbank="98" lbank="0" prog="43" />
+      <Patch name="Enh.Cb Enh" hbank="99" lbank="0" prog="43" />
+      <Patch name="Tremolo Str Cls" hbank="96" lbank="0" prog="44" />
+      <Patch name="Tremolo Str2 Ctm" hbank="97" lbank="0" prog="44" />
+      <Patch name="St.Trem Str Solo" hbank="98" lbank="0" prog="44" />
+      <Patch name="St.Trem Str2 Enh" hbank="99" lbank="0" prog="44" />
+      <Patch name="Pizzicato Cls" hbank="96" lbank="0" prog="45" />
+      <Patch name="Pizzicato 2 Ctm" hbank="97" lbank="0" prog="45" />
+      <Patch name="St.Pizzicato Solo" hbank="98" lbank="0" prog="45" />
+      <Patch name="Chorus Pizz Enh" hbank="99" lbank="0" prog="45" />
+      <Patch name="Harp Cls" hbank="96" lbank="0" prog="46" />
+      <Patch name="Yangqin Cls" hbank="96" lbank="1" prog="46" />
+      <Patch name="Harp 2 Ctm" hbank="97" lbank="0" prog="46" />
+      <Patch name="Yangqin 2 Ctm" hbank="97" lbank="1" prog="46" />
+      <Patch name="St.Harp Solo" hbank="98" lbank="0" prog="46" />
+      <Patch name="St.Yangqin Solo" hbank="98" lbank="1" prog="46" />
+      <Patch name="Chorus Harp Enh" hbank="99" lbank="0" prog="46" />
+      <Patch name="Enh.Yangqin Enh" hbank="99" lbank="1" prog="46" />
+      <Patch name="Timpani Cls" hbank="96" lbank="0" prog="47" />
+      <Patch name="Timpani 2 Ctm" hbank="97" lbank="0" prog="47" />
+      <Patch name="St.Timpani Solo" hbank="98" lbank="0" prog="47" />
+      <Patch name="Enh.Timpani Enh" hbank="99" lbank="0" prog="47" />
+    </PatchGroup>
+    <PatchGroup name="Ensemble">
+      <Patch name="Strings Cls" hbank="96" lbank="0" prog="48" />
+      <Patch name="Orchestra Cls" hbank="96" lbank="1" prog="48" />
+      <Patch name="60'Strings Cls" hbank="96" lbank="2" prog="48" />
+      <Patch name="Strings 2 Ctm" hbank="97" lbank="0" prog="48" />
+      <Patch name="Orchestra 2 Ctm" hbank="97" lbank="1" prog="48" />
+      <Patch name="Oct.Strings Ctm" hbank="97" lbank="2" prog="48" />
+      <Patch name="St.Strings Solo" hbank="98" lbank="0" prog="48" />
+      <Patch name="St.Orchestra Solo" hbank="98" lbank="1" prog="48" />
+      <Patch name="St.OctStr 1 Solo" hbank="98" lbank="2" prog="48" />
+      <Patch name="St.Strings 2 Enh" hbank="99" lbank="0" prog="48" />
+      <Patch name="St.Orchestr2 Enh" hbank="99" lbank="1" prog="48" />
+      <Patch name="St.OctStr 2 Enh" hbank="99" lbank="2" prog="48" />
+      <Patch name="Slow Strings Cls" hbank="96" lbank="0" prog="49" />
+      <Patch name="SlowStrings2 Ctm" hbank="97" lbank="0" prog="49" />
+      <Patch name="St.Slow Str Solo" hbank="98" lbank="0" prog="49" />
+      <Patch name="St.Slow Str2 Enh" hbank="99" lbank="0" prog="49" />
+      <Patch name="Syn.Strings1 Cls" hbank="96" lbank="0" prog="50" />
+      <Patch name="Syn.Strings3 Cls" hbank="96" lbank="1" prog="50" />
+      <Patch name="BriteSyn.Str Ctm" hbank="97" lbank="0" prog="50" />
+      <Patch name="Oct.SynStr 1 Ctm" hbank="97" lbank="1" prog="50" />
+      <Patch name="StackSyn.Str Solo" hbank="98" lbank="0" prog="50" />
+      <Patch name="Oct.SynStr 2 Solo" hbank="98" lbank="1" prog="50" />
+      <Patch name="JP Strings Enh" hbank="99" lbank="0" prog="50" />
+      <Patch name="PhaseSyn.Str Enh" hbank="99" lbank="1" prog="50" />
+      <Patch name="Syn.Strings2 Cls" hbank="96" lbank="0" prog="51" />
+      <Patch name="Warm SynStr1 Ctm" hbank="97" lbank="0" prog="51" />
+      <Patch name="Warm SynStr2 Solo" hbank="98" lbank="0" prog="51" />
+      <Patch name="OB Strings Enh" hbank="99" lbank="0" prog="51" />
+      <Patch name="Choir Aahs Cls" hbank="96" lbank="0" prog="52" />
+      <Patch name="Choir Aahs 2 Cls" hbank="96" lbank="1" prog="52" />
+      <Patch name="Large Choir Ctm" hbank="97" lbank="0" prog="52" />
+      <Patch name="Small Choir Ctm" hbank="97" lbank="1" prog="52" />
+      <Patch name="St.ChoirAahs Solo" hbank="98" lbank="0" prog="52" />
+      <Patch name="St.Sm Choir Solo" hbank="98" lbank="1" prog="52" />
+      <Patch name="Rich Choir Enh" hbank="99" lbank="0" prog="52" />
+      <Patch name="St.Sm Choir2 Enh" hbank="99" lbank="1" prog="52" />
+      <Patch name="Voice Oohs Cls" hbank="96" lbank="0" prog="53" />
+      <Patch name="Hamming Cls" hbank="96" lbank="1" prog="53" />
+      <Patch name="Voice Oohs 2 Ctm" hbank="97" lbank="0" prog="53" />
+      <Patch name="Hamming 2 Ctm" hbank="97" lbank="1" prog="53" />
+      <Patch name="St.Vox Oohs Solo" hbank="98" lbank="0" prog="53" />
+      <Patch name="St.Hamming Solo" hbank="98" lbank="1" prog="53" />
+      <Patch name="Enh.Vox Oohs Enh" hbank="99" lbank="0" prog="53" />
+      <Patch name="Enh.Hamming Enh" hbank="99" lbank="1" prog="53" />
+      <Patch name="SynVox Cls" hbank="96" lbank="0" prog="54" />
+      <Patch name="Ana Voice Cls" hbank="96" lbank="1" prog="54" />
+      <Patch name="SynVox 2 Ctm" hbank="97" lbank="0" prog="54" />
+      <Patch name="Ana Voice 2 Ctm" hbank="97" lbank="1" prog="54" />
+      <Patch name="St.SynVox Solo" hbank="98" lbank="0" prog="54" />
+      <Patch name="Ana Voice 3 Solo" hbank="98" lbank="1" prog="54" />
+      <Patch name="Phase SynVox Enh" hbank="99" lbank="0" prog="54" />
+      <Patch name="Lead Ana.Vox Enh" hbank="99" lbank="1" prog="54" />
+      <Patch name="Orchestrahit Cls" hbank="96" lbank="0" prog="55" />
+      <Patch name="Bass Hit Cls" hbank="96" lbank="1" prog="55" />
+      <Patch name="6th Hit Cls" hbank="96" lbank="2" prog="55" />
+      <Patch name="Euro Hit Cls" hbank="96" lbank="3" prog="55" />
+      <Patch name="Orc Hit 2 Ctm" hbank="97" lbank="0" prog="55" />
+      <Patch name="Bass Hit 2 Ctm" hbank="97" lbank="1" prog="55" />
+      <Patch name="6th Hit 2 Ctm" hbank="97" lbank="2" prog="55" />
+      <Patch name="Euro Hit 2 Ctm" hbank="97" lbank="3" prog="55" />
+      <Patch name="St.Orc Hit Solo" hbank="98" lbank="0" prog="55" />
+      <Patch name="St.Bass Hit Solo" hbank="98" lbank="1" prog="55" />
+      <Patch name="St.6th Hit Solo" hbank="98" lbank="2" prog="55" />
+      <Patch name="St.Euro Hit Solo" hbank="98" lbank="3" prog="55" />
+      <Patch name="Enh.Orc Hit Enh" hbank="99" lbank="0" prog="55" />
+      <Patch name="PhaseBassHit Enh" hbank="99" lbank="1" prog="55" />
+      <Patch name="Dly.6th Hit Enh" hbank="99" lbank="2" prog="55" />
+      <Patch name="Dly.Euro Hit Enh" hbank="99" lbank="3" prog="55" />
+    </PatchGroup>
+    <PatchGroup name="Brass">
+      <Patch name="Trumpet Cls" hbank="96" lbank="0" prog="56" />
+      <Patch name="Dark Trumpet Cls" hbank="96" lbank="1" prog="56" />
+      <Patch name="Solo Trumpet Ctm" hbank="97" lbank="0" prog="56" />
+      <Patch name="Mild Trumpet Ctm" hbank="97" lbank="1" prog="56" />
+      <Patch name="Romantic Tp Solo" hbank="98" lbank="0" prog="56" />
+      <Patch name="Tp.Dark vib Solo" hbank="98" lbank="1" prog="56" />
+      <Patch name="Enh.Trumpet Enh" hbank="99" lbank="0" prog="56" />
+      <Patch name="Warm Trumpet Enh" hbank="99" lbank="1" prog="56" />
+      <Patch name="Trombone Cls" hbank="96" lbank="0" prog="57" />
+      <Patch name="Trombone 2 Cls" hbank="96" lbank="1" prog="57" />
+      <Patch name="Brite Bone Cls" hbank="96" lbank="2" prog="57" />
+      <Patch name="Solo Bone Ctm" hbank="97" lbank="0" prog="57" />
+      <Patch name="Solo Bone 2 Ctm" hbank="97" lbank="1" prog="57" />
+      <Patch name="Brite Bone 2 Ctm" hbank="97" lbank="2" prog="57" />
+      <Patch name="Trombone vib Solo" hbank="98" lbank="0" prog="57" />
+      <Patch name="Trombone2vib Solo" hbank="98" lbank="1" prog="57" />
+      <Patch name="Br.Bone vib Solo" hbank="98" lbank="2" prog="57" />
+      <Patch name="Enh.Trombone Enh" hbank="99" lbank="0" prog="57" />
+      <Patch name="Enh.Bone 2 Enh" hbank="99" lbank="1" prog="57" />
+      <Patch name="Enh.Br Bone Enh" hbank="99" lbank="2" prog="57" />
+      <Patch name="Tuba Cls" hbank="96" lbank="0" prog="58" />
+      <Patch name="Tuba 2 Ctm" hbank="97" lbank="0" prog="58" />
+      <Patch name="Tuba vib Solo" hbank="98" lbank="0" prog="58" />
+      <Patch name="Chorus Tuba Enh" hbank="99" lbank="0" prog="58" />
+      <Patch name="MuteTrumpet Cls" hbank="96" lbank="0" prog="59" />
+      <Patch name="MuteTrumpet2 Cls" hbank="96" lbank="1" prog="59" />
+      <Patch name="MuteTrumpet2 Ctm" hbank="97" lbank="0" prog="59" />
+      <Patch name="Harmon Mute Ctm" hbank="97" lbank="1" prog="59" />
+      <Patch name="Solo MutedTp Solo" hbank="98" lbank="0" prog="59" />
+      <Patch name="Harmon Mute2 Solo" hbank="98" lbank="1" prog="59" />
+      <Patch name="Enh.Muted Tp Enh" hbank="99" lbank="0" prog="59" />
+      <Patch name="Enh.MutedTp2 Enh" hbank="99" lbank="1" prog="59" />
+      <Patch name="French Horns Cls" hbank="96" lbank="0" prog="60" />
+      <Patch name="Fr.Horn Cls" hbank="96" lbank="1" prog="60" />
+      <Patch name="FrenchHorns2 Ctm" hbank="97" lbank="0" prog="60" />
+      <Patch name="MildFr.Horns Ctm" hbank="97" lbank="1" prog="60" />
+      <Patch name="St.Fr Horns Solo" hbank="98" lbank="0" prog="60" />
+      <Patch name="St.Fr Horns2 Solo" hbank="98" lbank="1" prog="60" />
+      <Patch name="Enh.StFrHorn Enh" hbank="99" lbank="0" prog="60" />
+      <Patch name="Warm Horns Enh" hbank="99" lbank="1" prog="60" />
+      <Patch name="Brass 1 Cls" hbank="96" lbank="0" prog="61" />
+      <Patch name="Brass 2 Cls" hbank="96" lbank="1" prog="61" />
+      <Patch name="Brass FF Ctm" hbank="97" lbank="0" prog="61" />
+      <Patch name="BrassSection Ctm" hbank="97" lbank="1" prog="61" />
+      <Patch name="St.Brass Solo" hbank="98" lbank="0" prog="61" />
+      <Patch name="St.Brass 2 Solo" hbank="98" lbank="1" prog="61" />
+      <Patch name="St.Big Brass Enh" hbank="99" lbank="0" prog="61" />
+      <Patch name="Enh.Brs Sect Enh" hbank="99" lbank="1" prog="61" />
+      <Patch name="SynthBrass 1 Cls" hbank="96" lbank="0" prog="62" />
+      <Patch name="SynthBrass 3 Cls" hbank="96" lbank="1" prog="62" />
+      <Patch name="Oct.SynBrass Cls" hbank="96" lbank="2" prog="62" />
+      <Patch name="Jump Brass Cls" hbank="96" lbank="3" prog="62" />
+      <Patch name="JP Syn.Brass Ctm" hbank="97" lbank="0" prog="62" />
+      <Patch name="JPSyn.Brass2 Ctm" hbank="97" lbank="1" prog="62" />
+      <Patch name="OctSynBrass2 Ctm" hbank="97" lbank="2" prog="62" />
+      <Patch name="80's Brass Ctm" hbank="97" lbank="3" prog="62" />
+      <Patch name="Hyper Brass Solo" hbank="98" lbank="0" prog="62" />
+      <Patch name="Stack Brass Solo" hbank="98" lbank="1" prog="62" />
+      <Patch name="OctSynBrass3 Solo" hbank="98" lbank="2" prog="62" />
+      <Patch name="SuperSaw Brs Solo" hbank="98" lbank="3" prog="62" />
+      <Patch name="SuperJP Brs1 Enh" hbank="99" lbank="0" prog="62" />
+      <Patch name="Lead Brass Enh" hbank="99" lbank="1" prog="62" />
+      <Patch name="Phase OctBrs Enh" hbank="99" lbank="2" prog="62" />
+      <Patch name="SuperJP Brs2 Enh" hbank="99" lbank="3" prog="62" />
+      <Patch name="SynthBrass 2 Cls" hbank="96" lbank="0" prog="63" />
+      <Patch name="SynthBrass 4 Cls" hbank="96" lbank="1" prog="63" />
+      <Patch name="Velo Brass Cls" hbank="96" lbank="2" prog="63" />
+      <Patch name="MG Syn.Horn Ctm" hbank="97" lbank="0" prog="63" />
+      <Patch name="OB Syn.Horn Ctm" hbank="97" lbank="1" prog="63" />
+      <Patch name="CS Syn.Brass Ctm" hbank="97" lbank="2" prog="63" />
+      <Patch name="Warm SynHorn Solo" hbank="98" lbank="0" prog="63" />
+      <Patch name="Rich SynHorn Solo" hbank="98" lbank="1" prog="63" />
+      <Patch name="P5 Syn.Brass Solo" hbank="98" lbank="2" prog="63" />
+      <Patch name="WarmSynHorn2 Enh" hbank="99" lbank="0" prog="63" />
+      <Patch name="Phase Horn Enh" hbank="99" lbank="1" prog="63" />
+      <Patch name="Fat Pro Bras Enh" hbank="99" lbank="2" prog="63" />
+    </PatchGroup>
+    <PatchGroup name="Reed">
+      <Patch name="Soprano Sax Cls" hbank="96" lbank="0" prog="64" />
+      <Patch name="Soprano Sax2 Ctm" hbank="97" lbank="0" prog="64" />
+      <Patch name="Sop.Sax vib Solo" hbank="98" lbank="0" prog="64" />
+      <Patch name="Enh.Sop Sax Enh" hbank="99" lbank="0" prog="64" />
+      <Patch name="Alto Sax Cls" hbank="96" lbank="0" prog="65" />
+      <Patch name="Breathy Alto Ctm" hbank="97" lbank="0" prog="65" />
+      <Patch name="AltoSoft vib Solo" hbank="98" lbank="0" prog="65" />
+      <Patch name="Enh.Alto Sax Enh" hbank="99" lbank="0" prog="65" />
+      <Patch name="Tenor Sax Cls" hbank="96" lbank="0" prog="66" />
+      <Patch name="BreathyTenor Ctm" hbank="97" lbank="0" prog="66" />
+      <Patch name="Blow Tenor Solo" hbank="98" lbank="0" prog="66" />
+      <Patch name="Enh.TenorSax Enh" hbank="99" lbank="0" prog="66" />
+      <Patch name="Bariton Sax Cls" hbank="96" lbank="0" prog="67" />
+      <Patch name="Barely Bari Ctm" hbank="97" lbank="0" prog="67" />
+      <Patch name="Bari.Sax vib Solo" hbank="98" lbank="0" prog="67" />
+      <Patch name="Enh.Bari Sax Enh" hbank="99" lbank="0" prog="67" />
+      <Patch name="Oboe Cls" hbank="96" lbank="0" prog="68" />
+      <Patch name="Brite Oboe Ctm" hbank="97" lbank="0" prog="68" />
+      <Patch name="Classic Oboe Solo" hbank="98" lbank="0" prog="68" />
+      <Patch name="Enh.Oboe Enh" hbank="99" lbank="0" prog="68" />
+      <Patch name="EnglishHorn Cls" hbank="96" lbank="0" prog="69" />
+      <Patch name="EnglishHorn2 Ctm" hbank="97" lbank="0" prog="69" />
+      <Patch name="E.Horn vib Solo" hbank="98" lbank="0" prog="69" />
+      <Patch name="Enh.E Horn Enh" hbank="99" lbank="0" prog="69" />
+      <Patch name="Bassoon Cls" hbank="96" lbank="0" prog="70" />
+      <Patch name="Bassoon 2 Ctm" hbank="97" lbank="0" prog="70" />
+      <Patch name="Bassoon vib Solo" hbank="98" lbank="0" prog="70" />
+      <Patch name="Enh.Bassoon Enh" hbank="99" lbank="0" prog="70" />
+      <Patch name="Clarinet Cls" hbank="96" lbank="0" prog="71" />
+      <Patch name="Br.Clarinet Ctm" hbank="97" lbank="0" prog="71" />
+      <Patch name="JazzClarinet Solo" hbank="98" lbank="0" prog="71" />
+      <Patch name="Jz.Clarinet2 Enh" hbank="99" lbank="0" prog="71" />
+    </PatchGroup>
+    <PatchGroup name="Pipe">
+      <Patch name="Piccolo Cls" hbank="96" lbank="0" prog="72" />
+      <Patch name="Piccolo 2 Ctm" hbank="97" lbank="0" prog="72" />
+      <Patch name="Piccolo vib Solo" hbank="98" lbank="0" prog="72" />
+      <Patch name="Enh.Piccolo Enh" hbank="99" lbank="0" prog="72" />
+      <Patch name="Flute Cls" hbank="96" lbank="0" prog="73" />
+      <Patch name="Flute 2 Ctm" hbank="97" lbank="0" prog="73" />
+      <Patch name="Flute vib Solo" hbank="98" lbank="0" prog="73" />
+      <Patch name="Enh.Flute Enh" hbank="99" lbank="0" prog="73" />
+      <Patch name="Recorder Cls" hbank="96" lbank="0" prog="74" />
+      <Patch name="Recorder 2 Ctm" hbank="97" lbank="0" prog="74" />
+      <Patch name="Recorder vib Solo" hbank="98" lbank="0" prog="74" />
+      <Patch name="Enh.Recorder Enh" hbank="99" lbank="0" prog="74" />
+      <Patch name="Pan Flute Cls" hbank="96" lbank="0" prog="75" />
+      <Patch name="Pan Flute 2 Ctm" hbank="97" lbank="0" prog="75" />
+      <Patch name="PanFlute vib Solo" hbank="98" lbank="0" prog="75" />
+      <Patch name="Cho.PanFlute Enh" hbank="99" lbank="0" prog="75" />
+      <Patch name="Bottle Blow Cls" hbank="96" lbank="0" prog="76" />
+      <Patch name="Bottle Blow2 Ctm" hbank="97" lbank="0" prog="76" />
+      <Patch name="Bottle vib Solo" hbank="98" lbank="0" prog="76" />
+      <Patch name="Phase Bottle Enh" hbank="99" lbank="0" prog="76" />
+      <Patch name="Shakuhachi Cls" hbank="96" lbank="0" prog="77" />
+      <Patch name="Shakuhachi 2 Ctm" hbank="97" lbank="0" prog="77" />
+      <Patch name="Shaku.vib Solo" hbank="98" lbank="0" prog="77" />
+      <Patch name="Delay Shaku Enh" hbank="99" lbank="0" prog="77" />
+      <Patch name="Whistle Cls" hbank="96" lbank="0" prog="78" />
+      <Patch name="Whistle 2 Ctm" hbank="97" lbank="0" prog="78" />
+      <Patch name="Whistle vib Solo" hbank="98" lbank="0" prog="78" />
+      <Patch name="DelayWhistle Enh" hbank="99" lbank="0" prog="78" />
+      <Patch name="Ocarina Cls" hbank="96" lbank="0" prog="79" />
+      <Patch name="Ocarina 2 Ctm" hbank="97" lbank="0" prog="79" />
+      <Patch name="Ocarina vib Solo" hbank="98" lbank="0" prog="79" />
+      <Patch name="DelayOcarina Enh" hbank="99" lbank="0" prog="79" />
+    </PatchGroup>
+    <PatchGroup name="Synth Lead">
+      <Patch name="Square Wave Cls" hbank="96" lbank="0" prog="80" />
+      <Patch name="Square Cls" hbank="96" lbank="1" prog="80" />
+      <Patch name="Sine Wave Cls" hbank="96" lbank="2" prog="80" />
+      <Patch name="MG Square Ctm" hbank="97" lbank="0" prog="80" />
+      <Patch name="Fat Square Ctm" hbank="97" lbank="1" prog="80" />
+      <Patch name="2600 Sine Ctm" hbank="97" lbank="2" prog="80" />
+      <Patch name="OB Square Solo" hbank="98" lbank="0" prog="80" />
+      <Patch name="Fat Square2 Solo" hbank="98" lbank="1" prog="80" />
+      <Patch name="2600 Sine 2 Solo" hbank="98" lbank="2" prog="80" />
+      <Patch name="OBSquareLead Enh" hbank="99" lbank="0" prog="80" />
+      <Patch name="Phase Square Enh" hbank="99" lbank="1" prog="80" />
+      <Patch name="Sine Lead Enh" hbank="99" lbank="2" prog="80" />
+      <Patch name="Saw Wave Cls" hbank="96" lbank="0" prog="81" />
+      <Patch name="Saw Cls" hbank="96" lbank="1" prog="81" />
+      <Patch name="Doctor Solo Cls" hbank="96" lbank="2" prog="81" />
+      <Patch name="Natural Lead Cls" hbank="96" lbank="3" prog="81" />
+      <Patch name="SequencedSaw Cls" hbank="96" lbank="4" prog="81" />
+      <Patch name="JP Saw Wave Ctm" hbank="97" lbank="0" prog="81" />
+      <Patch name="MG Saw Ctm" hbank="97" lbank="1" prog="81" />
+      <Patch name="Fat Saw Solo Ctm" hbank="97" lbank="2" prog="81" />
+      <Patch name="P5 Saw Lead Ctm" hbank="97" lbank="3" prog="81" />
+      <Patch name="MG Sequence Ctm" hbank="97" lbank="4" prog="81" />
+      <Patch name="Oct.JP Saw Solo" hbank="98" lbank="0" prog="81" />
+      <Patch name="Hybrit Saw Solo" hbank="98" lbank="1" prog="81" />
+      <Patch name="Hybrit Solo Solo" hbank="98" lbank="2" prog="81" />
+      <Patch name="MG Saw Lead Solo" hbank="98" lbank="3" prog="81" />
+      <Patch name="DelaySeqence Solo" hbank="98" lbank="4" prog="81" />
+      <Patch name="KeySync Saw Enh" hbank="99" lbank="0" prog="81" />
+      <Patch name="Flanging Saw Enh" hbank="99" lbank="1" prog="81" />
+      <Patch name="Doctor Lead Enh" hbank="99" lbank="2" prog="81" />
+      <Patch name="Fat Saw Lead Enh" hbank="99" lbank="3" prog="81" />
+      <Patch name="PhaseSeqence Enh" hbank="99" lbank="4" prog="81" />
+      <Patch name="Syn.Calliope Cls" hbank="96" lbank="0" prog="82" />
+      <Patch name="SynCalliope2 Ctm" hbank="97" lbank="0" prog="82" />
+      <Patch name="SynCalliope3 Solo" hbank="98" lbank="0" prog="82" />
+      <Patch name="LeadCalliope Enh" hbank="99" lbank="0" prog="82" />
+      <Patch name="Chiffer Lead Cls" hbank="96" lbank="0" prog="83" />
+      <Patch name="ChifferLead2 Ctm" hbank="97" lbank="0" prog="83" />
+      <Patch name="ChifferLead3 Solo" hbank="98" lbank="0" prog="83" />
+      <Patch name="Chiffers Enh" hbank="99" lbank="0" prog="83" />
+      <Patch name="Charang Cls" hbank="96" lbank="0" prog="84" />
+      <Patch name="Wire Lead Cls" hbank="96" lbank="1" prog="84" />
+      <Patch name="Charang 2 Ctm" hbank="97" lbank="0" prog="84" />
+      <Patch name="Wire Lead 2 Ctm" hbank="97" lbank="1" prog="84" />
+      <Patch name="Charang 3 Solo" hbank="98" lbank="0" prog="84" />
+      <Patch name="Wire Lead 3 Solo" hbank="98" lbank="1" prog="84" />
+      <Patch name="Charang Lead Enh" hbank="99" lbank="0" prog="84" />
+      <Patch name="Phase Wire Enh" hbank="99" lbank="1" prog="84" />
+      <Patch name="Solo Vox Cls" hbank="96" lbank="0" prog="85" />
+      <Patch name="Solo Vox 2 Ctm" hbank="97" lbank="0" prog="85" />
+      <Patch name="Solo Vox 3 Solo" hbank="98" lbank="0" prog="85" />
+      <Patch name="SoloVox Lead Enh" hbank="99" lbank="0" prog="85" />
+      <Patch name="5th SawWave Cls" hbank="96" lbank="0" prog="86" />
+      <Patch name="5th SawWave2 Ctm" hbank="97" lbank="0" prog="86" />
+      <Patch name="5th SawWave3 Solo" hbank="98" lbank="0" prog="86" />
+      <Patch name="Flanging 5th Enh" hbank="99" lbank="0" prog="86" />
+      <Patch name="Bass &amp; Lead Cls" hbank="96" lbank="0" prog="87" />
+      <Patch name="DelayedLead Cls" hbank="96" lbank="1" prog="87" />
+      <Patch name="Bass &amp; Lead2 Ctm" hbank="97" lbank="0" prog="87" />
+      <Patch name="DelayedLead2 Ctm" hbank="97" lbank="1" prog="87" />
+      <Patch name="Bass &amp; Lead3 Solo" hbank="98" lbank="0" prog="87" />
+      <Patch name="DelayedLead3 Solo" hbank="98" lbank="1" prog="87" />
+      <Patch name="Phase BsLead Enh" hbank="99" lbank="0" prog="87" />
+      <Patch name="Suffle Lead Enh" hbank="99" lbank="1" prog="87" />
+    </PatchGroup>
+    <PatchGroup name="Synth Pad">
+      <Patch name="Fantasia Cls" hbank="96" lbank="0" prog="88" />
+      <Patch name="Fantasia 2 Ctm" hbank="97" lbank="0" prog="88" />
+      <Patch name="Fantasia 3 Solo" hbank="98" lbank="0" prog="88" />
+      <Patch name="New Fantasia Enh" hbank="99" lbank="0" prog="88" />
+      <Patch name="Warm Pad Cls" hbank="96" lbank="0" prog="89" />
+      <Patch name="Sine Pad Cls" hbank="96" lbank="1" prog="89" />
+      <Patch name="Warm Pad 2 Ctm" hbank="97" lbank="0" prog="89" />
+      <Patch name="Sine Pad 2 Ctm" hbank="97" lbank="1" prog="89" />
+      <Patch name="Warm Pad 3 Solo" hbank="98" lbank="0" prog="89" />
+      <Patch name="Sine Pad 3 Solo" hbank="98" lbank="1" prog="89" />
+      <Patch name="Phase Pad Enh" hbank="99" lbank="0" prog="89" />
+      <Patch name="Chorus Sine Enh" hbank="99" lbank="1" prog="89" />
+      <Patch name="Polysynth Cls" hbank="96" lbank="0" prog="90" />
+      <Patch name="Polysynth 2 Ctm" hbank="97" lbank="0" prog="90" />
+      <Patch name="Polysynth 3 Solo" hbank="98" lbank="0" prog="90" />
+      <Patch name="KeySyncSynth Enh" hbank="99" lbank="0" prog="90" />
+      <Patch name="SpaceVoice Cls" hbank="96" lbank="0" prog="91" />
+      <Patch name="Itopia Cls" hbank="96" lbank="1" prog="91" />
+      <Patch name="SpaceVoice 2 Ctm" hbank="97" lbank="0" prog="91" />
+      <Patch name="Itopia 2 Ctm" hbank="97" lbank="1" prog="91" />
+      <Patch name="SpaceVoice 3 Solo" hbank="98" lbank="0" prog="91" />
+      <Patch name="Itopia 3 Solo" hbank="98" lbank="1" prog="91" />
+      <Patch name="Phase Voice Enh" hbank="99" lbank="0" prog="91" />
+      <Patch name="Pan Itopia Enh" hbank="99" lbank="1" prog="91" />
+      <Patch name="BowedGlass Cls" hbank="96" lbank="0" prog="92" />
+      <Patch name="BowedGlass 2 Ctm" hbank="97" lbank="0" prog="92" />
+      <Patch name="BowedGlass 3 Solo" hbank="98" lbank="0" prog="92" />
+      <Patch name="Ring Glass Enh" hbank="99" lbank="0" prog="92" />
+      <Patch name="Metal Pad Cls" hbank="96" lbank="0" prog="93" />
+      <Patch name="Metal Pad 2 Ctm" hbank="97" lbank="0" prog="93" />
+      <Patch name="Metal Pad 3 Solo" hbank="98" lbank="0" prog="93" />
+      <Patch name="Space Pad Enh" hbank="99" lbank="0" prog="93" />
+      <Patch name="Halo Pad Cls" hbank="96" lbank="0" prog="94" />
+      <Patch name="Halo Pad 2 Ctm" hbank="97" lbank="0" prog="94" />
+      <Patch name="Halo Pad 3 Solo" hbank="98" lbank="0" prog="94" />
+      <Patch name="Phase Halo Enh" hbank="99" lbank="0" prog="94" />
+      <Patch name="Sweep Pad Cls" hbank="96" lbank="0" prog="95" />
+      <Patch name="Sweep Pad 2 Ctm" hbank="97" lbank="0" prog="95" />
+      <Patch name="Sweep Pad 3 Solo" hbank="98" lbank="0" prog="95" />
+      <Patch name="Flanging Pad Enh" hbank="99" lbank="0" prog="95" />
+    </PatchGroup>
+    <PatchGroup name="Synth SFX">
+      <Patch name="Ice Rain Cls" hbank="96" lbank="0" prog="96" />
+      <Patch name="Ice Rain 2 Ctm" hbank="97" lbank="0" prog="96" />
+      <Patch name="Ice Rain 3 Solo" hbank="98" lbank="0" prog="96" />
+      <Patch name="Reverse Rain Enh" hbank="99" lbank="0" prog="96" />
+      <Patch name="Soundtrack Cls" hbank="96" lbank="0" prog="97" />
+      <Patch name="Soundtrack 2 Ctm" hbank="97" lbank="0" prog="97" />
+      <Patch name="Soundtrack 3 Solo" hbank="98" lbank="0" prog="97" />
+      <Patch name="Phase Track Enh" hbank="99" lbank="0" prog="97" />
+      <Patch name="Crystal Cls" hbank="96" lbank="0" prog="98" />
+      <Patch name="Syn Mallet Cls" hbank="96" lbank="1" prog="98" />
+      <Patch name="Crystal 2 Ctm" hbank="97" lbank="0" prog="98" />
+      <Patch name="Syn Mallet 2 Ctm" hbank="97" lbank="1" prog="98" />
+      <Patch name="Crystal 3 Solo" hbank="98" lbank="0" prog="98" />
+      <Patch name="Syn Mallet 3 Solo" hbank="98" lbank="1" prog="98" />
+      <Patch name="3D Crystal Enh" hbank="99" lbank="0" prog="98" />
+      <Patch name="Phase Mallet Enh" hbank="99" lbank="1" prog="98" />
+      <Patch name="Atmosphere Cls" hbank="96" lbank="0" prog="99" />
+      <Patch name="Atmosphere 2 Ctm" hbank="97" lbank="0" prog="99" />
+      <Patch name="Atmosphere 3 Solo" hbank="98" lbank="0" prog="99" />
+      <Patch name="Pan Atmos Enh" hbank="99" lbank="0" prog="99" />
+      <Patch name="Brightness Cls" hbank="96" lbank="0" prog="100" />
+      <Patch name="Brightness 2 Ctm" hbank="97" lbank="0" prog="100" />
+      <Patch name="Brightness 3 Solo" hbank="98" lbank="0" prog="100" />
+      <Patch name="Bright Star Enh" hbank="99" lbank="0" prog="100" />
+      <Patch name="Goblin Cls" hbank="96" lbank="0" prog="101" />
+      <Patch name="Goblin 2 Ctm" hbank="97" lbank="0" prog="101" />
+      <Patch name="Goblin 3 Solo" hbank="98" lbank="0" prog="101" />
+      <Patch name="Rev Goblin Enh" hbank="99" lbank="0" prog="101" />
+      <Patch name="Echo Drops Cls" hbank="96" lbank="0" prog="102" />
+      <Patch name="Echo Bell Cls" hbank="96" lbank="1" prog="102" />
+      <Patch name="Echo Pan Cls" hbank="96" lbank="2" prog="102" />
+      <Patch name="Echo Drops 2 Ctm" hbank="97" lbank="0" prog="102" />
+      <Patch name="Echo Bell 2 Ctm" hbank="97" lbank="1" prog="102" />
+      <Patch name="Echo Pan 2 Ctm" hbank="97" lbank="2" prog="102" />
+      <Patch name="Echo Drops 3 Solo" hbank="98" lbank="0" prog="102" />
+      <Patch name="Echo Bell 3 Solo" hbank="98" lbank="1" prog="102" />
+      <Patch name="Echo Pan 3 Solo" hbank="98" lbank="2" prog="102" />
+      <Patch name="Delay Drops Enh" hbank="99" lbank="0" prog="102" />
+      <Patch name="Delay Bell Enh" hbank="99" lbank="1" prog="102" />
+      <Patch name="Delay Pan Enh" hbank="99" lbank="2" prog="102" />
+      <Patch name="Star Theme Cls" hbank="96" lbank="0" prog="103" />
+      <Patch name="Star Theme 2 Ctm" hbank="97" lbank="0" prog="103" />
+      <Patch name="Star Theme 3 Solo" hbank="98" lbank="0" prog="103" />
+      <Patch name="Phase Theme Enh" hbank="99" lbank="0" prog="103" />
+    </PatchGroup>
+    <PatchGroup name="Ethnic">
+      <Patch name="Sitar Cls" hbank="96" lbank="0" prog="104" />
+      <Patch name="Sitar 2 Cls" hbank="96" lbank="1" prog="104" />
+      <Patch name="Atk Sitar Ctm" hbank="97" lbank="0" prog="104" />
+      <Patch name="Atk Sitar 2 Ctm" hbank="97" lbank="1" prog="104" />
+      <Patch name="St.Sitar Solo" hbank="98" lbank="0" prog="104" />
+      <Patch name="St.Sitar 2 Solo" hbank="98" lbank="1" prog="104" />
+      <Patch name="Enh.Sitar Enh" hbank="99" lbank="0" prog="104" />
+      <Patch name="FantasySitar Enh" hbank="99" lbank="1" prog="104" />
+      <Patch name="Banjo Cls" hbank="96" lbank="0" prog="105" />
+      <Patch name="Banjo 2 Ctm" hbank="97" lbank="0" prog="105" />
+      <Patch name="St.Banjo Solo" hbank="98" lbank="0" prog="105" />
+      <Patch name="St.Banjo 2 Enh" hbank="99" lbank="0" prog="105" />
+      <Patch name="Shamisen Cls" hbank="96" lbank="0" prog="106" />
+      <Patch name="Shamisen 2 Ctm" hbank="97" lbank="0" prog="106" />
+      <Patch name="St.Shamisen Solo" hbank="98" lbank="0" prog="106" />
+      <Patch name="St.Shamisen2 Enh" hbank="99" lbank="0" prog="106" />
+      <Patch name="Koto Cls" hbank="96" lbank="0" prog="107" />
+      <Patch name="Taisho Koto Cls" hbank="96" lbank="1" prog="107" />
+      <Patch name="Koto 2 Ctm" hbank="97" lbank="0" prog="107" />
+      <Patch name="Taisho Koto2 Ctm" hbank="97" lbank="1" prog="107" />
+      <Patch name="St.Koto Solo" hbank="98" lbank="0" prog="107" />
+      <Patch name="St.T Koto Solo" hbank="98" lbank="1" prog="107" />
+      <Patch name="St.Koto 2 Enh" hbank="99" lbank="0" prog="107" />
+      <Patch name="St.T Koto 2 Enh" hbank="99" lbank="1" prog="107" />
+      <Patch name="Kalimba Cls" hbank="96" lbank="0" prog="108" />
+      <Patch name="Kalimba 2 Ctm" hbank="97" lbank="0" prog="108" />
+      <Patch name="St.Kalimba Solo" hbank="98" lbank="0" prog="108" />
+      <Patch name="Trem.Kalimba Enh" hbank="99" lbank="0" prog="108" />
+      <Patch name="Bag Pipe Cls" hbank="96" lbank="0" prog="109" />
+      <Patch name="Bag Pipe 2 Ctm" hbank="97" lbank="0" prog="109" />
+      <Patch name="St.Bag Pipe Solo" hbank="98" lbank="0" prog="109" />
+      <Patch name="Enh.Bag Pipe Enh" hbank="99" lbank="0" prog="109" />
+      <Patch name="Fiddle Cls" hbank="96" lbank="0" prog="110" />
+      <Patch name="Fiddle vib Ctm" hbank="97" lbank="0" prog="110" />
+      <Patch name="Fiddle 2 vib Solo" hbank="98" lbank="0" prog="110" />
+      <Patch name="Enh.Fiddle Enh" hbank="99" lbank="0" prog="110" />
+      <Patch name="Shanai Cls" hbank="96" lbank="0" prog="111" />
+      <Patch name="Shanai 2 Ctm" hbank="97" lbank="0" prog="111" />
+      <Patch name="St.Shanai Solo" hbank="98" lbank="0" prog="111" />
+      <Patch name="Enh.Shanai Enh" hbank="99" lbank="0" prog="111" />
+    </PatchGroup>
+    <PatchGroup name="Percussive">
       <Patch name="Tinkle Bell" hbank="96" lbank="0" prog="112" />
       <Patch name="Agogo" hbank="96" lbank="0" prog="113" />
       <Patch name="Steel Drums" hbank="96" lbank="0" prog="114" />
       <Patch name="Woodblock" hbank="96" lbank="0" prog="115" />
+      <Patch name="Castanet" hbank="96" lbank="1" prog="115" />
       <Patch name="Taiko" hbank="96" lbank="0" prog="116" />
+      <Patch name="Concert BD" hbank="96" lbank="1" prog="116" />
       <Patch name="Melo.Tom 1" hbank="96" lbank="0" prog="117" />
+      <Patch name="Melo.Tom 2" hbank="96" lbank="1" prog="117" />
       <Patch name="Synth Drum" hbank="96" lbank="0" prog="118" />
+      <Patch name="808 tom" hbank="96" lbank="1" prog="118" />
+      <Patch name="Elec Perc" hbank="96" lbank="2" prog="118" />
       <Patch name="Reverse Cym" hbank="96" lbank="0" prog="119" />
+    </PatchGroup>
+    <PatchGroup name="SFX">
       <Patch name="GtFret Noise" hbank="96" lbank="0" prog="120" />
+      <Patch name="Gt.Cut Noise" hbank="96" lbank="1" prog="120" />
+      <Patch name="Slap_St.Bass" hbank="96" lbank="2" prog="120" />
       <Patch name="Breath Noise" hbank="96" lbank="0" prog="121" />
+      <Patch name="Fl.Key Click" hbank="96" lbank="1" prog="121" />
       <Patch name="Seashore" hbank="96" lbank="0" prog="122" />
+      <Patch name="Rain" hbank="96" lbank="1" prog="122" />
+      <Patch name="Thunder" hbank="96" lbank="2" prog="122" />
+      <Patch name="Wind" hbank="96" lbank="3" prog="122" />
+      <Patch name="Stream" hbank="96" lbank="4" prog="122" />
+      <Patch name="Bubble" hbank="96" lbank="5" prog="122" />
       <Patch name="Bird Tweet" hbank="96" lbank="0" prog="123" />
+      <Patch name="Dog" hbank="96" lbank="1" prog="123" />
+      <Patch name="Horse Gallop" hbank="96" lbank="2" prog="123" />
+      <Patch name="Bird Tweet 2" hbank="96" lbank="3" prog="123" />
       <Patch name="Telephone" hbank="96" lbank="0" prog="124" />
+      <Patch name="Telephone 2" hbank="96" lbank="1" prog="124" />
+      <Patch name="Door Creak" hbank="96" lbank="2" prog="124" />
+      <Patch name="Door" hbank="96" lbank="3" prog="124" />
+      <Patch name="Scratch" hbank="96" lbank="4" prog="124" />
+      <Patch name="Wind Chimes" hbank="96" lbank="5" prog="124" />
       <Patch name="Helicopter" hbank="96" lbank="0" prog="125" />
+      <Patch name="Car-Engine" hbank="96" lbank="1" prog="125" />
+      <Patch name="Car-Stop" hbank="96" lbank="2" prog="125" />
+      <Patch name="Car-Pass" hbank="96" lbank="3" prog="125" />
+      <Patch name="Car-Crash" hbank="96" lbank="4" prog="125" />
+      <Patch name="Siren" hbank="96" lbank="5" prog="125" />
+      <Patch name="Train" hbank="96" lbank="6" prog="125" />
+      <Patch name="Jetplane" hbank="96" lbank="7" prog="125" />
+      <Patch name="Starship" hbank="96" lbank="8" prog="125" />
+      <Patch name="Burst Noise" hbank="96" lbank="9" prog="125" />
       <Patch name="Applause" hbank="96" lbank="0" prog="126" />
+      <Patch name="Laughing" hbank="96" lbank="1" prog="126" />
+      <Patch name="Screaming" hbank="96" lbank="2" prog="126" />
+      <Patch name="Punch" hbank="96" lbank="3" prog="126" />
+      <Patch name="Heart Beat" hbank="96" lbank="4" prog="126" />
+      <Patch name="Footsteps" hbank="96" lbank="5" prog="126" />
       <Patch name="Gunshot" hbank="96" lbank="0" prog="127" />
+      <Patch name="Machine Gun" hbank="96" lbank="1" prog="127" />
+      <Patch name="Lasergun" hbank="96" lbank="2" prog="127" />
+      <Patch name="Explosion" hbank="96" lbank="3" prog="127" />
     </PatchGroup>
-    <PatchGroup name="SD90 Classical Var #01">
-      <Patch name="Piano 1w" hbank="96" lbank="0" prog="0" />
-      <Patch name="Piano 2w" hbank="96" lbank="0" prog="1" />
-      <Patch name="Piano 3w" hbank="96" lbank="0" prog="2" />
-      <Patch name="Honky-tonk w" hbank="96" lbank="0" prog="3" />
-      <Patch name="Detuned EP1" hbank="96" lbank="0" prog="4" />
-      <Patch name="Detuned EP2" hbank="96" lbank="0" prog="5" />
-      <Patch name="Coupl hps" hbank="96" lbank="0" prog="6" />
-      <Patch name="Pulse Clav" hbank="96" lbank="0" prog="7" />
-      <Patch name="Vibraphone w" hbank="96" lbank="0" prog="11" />
-      <Patch name="Marimba w" hbank="96" lbank="0" prog="12" />
-      <Patch name="Church Bell" hbank="96" lbank="0" prog="14" />
-      <Patch name="Detuned Or1" hbank="96" lbank="0" prog="16" />
-      <Patch name="Detuned Or2" hbank="96" lbank="0" prog="17" />
-      <Patch name="Church 2" hbank="96" lbank="0" prog="19" />
-      <Patch name="Puff Organ" hbank="96" lbank="0" prog="20" />
-      <Patch name="Accordion I" hbank="96" lbank="0" prog="21" />
-      <Patch name="Ukulele" hbank="96" lbank="0" prog="24" />
-      <Patch name="12-Str.Gt" hbank="96" lbank="0" prog="25" />
-      <Patch name="Pedal Steel" hbank="96" lbank="0" prog="26" />
-      <Patch name="Clean Half" hbank="96" lbank="0" prog="27" />
-      <Patch name="Funk Gt" hbank="96" lbank="0" prog="28" />
-      <Patch name="Gt.Pinch" hbank="96" lbank="0" prog="29" />
-      <Patch name="Feedback Gt" hbank="96" lbank="0" prog="30" />
-      <Patch name="Gt.Feedback" hbank="96" lbank="0" prog="31" />
-      <Patch name="FingerJ.Bass" hbank="96" lbank="0" prog="33" />
-      <Patch name="SynthBass101" hbank="96" lbank="0" prog="38" />
-      <Patch name="Beef FM Bs" hbank="96" lbank="0" prog="39" />
-      <Patch name="Slow Violin" hbank="96" lbank="0" prog="40" />
-      <Patch name="Yangqin" hbank="96" lbank="0" prog="46" />
-      <Patch name="Orchestra" hbank="96" lbank="0" prog="48" />
-      <Patch name="Syn.Strings3" hbank="96" lbank="0" prog="50" />
-      <Patch name="Choir Aahs 2" hbank="96" lbank="0" prog="52" />
-      <Patch name="Hamming" hbank="96" lbank="0" prog="53" />
-      <Patch name="Ana Voice" hbank="96" lbank="0" prog="54" />
-      <Patch name="Bass Hit" hbank="96" lbank="0" prog="55" />
-      <Patch name="Dark Trumpet" hbank="96" lbank="0" prog="56" />
-      <Patch name="Trombone 2" hbank="96" lbank="0" prog="57" />
-      <Patch name="MuteTrumpet2" hbank="96" lbank="0" prog="59" />
-      <Patch name="Fr.Horn" hbank="96" lbank="0" prog="60" />
-      <Patch name="Brass 2" hbank="96" lbank="0" prog="61" />
-      <Patch name="SynthBrass 3" hbank="96" lbank="0" prog="62" />
-      <Patch name="SynthBrass 4" hbank="96" lbank="0" prog="63" />
-      <Patch name="Square" hbank="96" lbank="0" prog="80" />
-      <Patch name="Saw" hbank="96" lbank="0" prog="81" />
-      <Patch name="Wire Lead" hbank="96" lbank="0" prog="84" />
-      <Patch name="DelayedLead" hbank="96" lbank="0" prog="87" />
-      <Patch name="Sine Pad" hbank="96" lbank="0" prog="89" />
-      <Patch name="Itopia" hbank="96" lbank="0" prog="91" />
-      <Patch name="Syn Mallet" hbank="96" lbank="0" prog="98" />
-      <Patch name="Echo Bell" hbank="96" lbank="0" prog="102" />
-      <Patch name="Sitar 2" hbank="96" lbank="0" prog="104" />
-      <Patch name="Taisho Koto" hbank="96" lbank="0" prog="107" />
-      <Patch name="Castanet" hbank="96" lbank="0" prog="115" />
-      <Patch name="Concert BD" hbank="96" lbank="0" prog="116" />
-      <Patch name="Melo.Tom 2" hbank="96" lbank="0" prog="117" />
-      <Patch name="808 tom" hbank="96" lbank="0" prog="118" />
-      <Patch name="Gt.Cut Noise" hbank="96" lbank="0" prog="120" />
-      <Patch name="Fl.Key Click" hbank="96" lbank="0" prog="121" />
-      <Patch name="Rain" hbank="96" lbank="0" prog="122" />
-      <Patch name="Dog" hbank="96" lbank="0" prog="123" />
-      <Patch name="Telephone 2" hbank="96" lbank="0" prog="124" />
-      <Patch name="Car-Engine" hbank="96" lbank="0" prog="125" />
-      <Patch name="Laughing" hbank="96" lbank="0" prog="126" />
-      <Patch name="Machine Gun" hbank="96" lbank="0" prog="127" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Classical Var #02">
-      <Patch name="Piano 1d" hbank="96" lbank="0" prog="0" />
-      <Patch name="Dyno Rhodes" hbank="96" lbank="0" prog="4" />
-      <Patch name="E.Piano 2v" hbank="96" lbank="0" prog="5" />
-      <Patch name="Harpsi w" hbank="96" lbank="0" prog="6" />
-      <Patch name="Carillon" hbank="96" lbank="0" prog="14" />
-      <Patch name="Organ 60" hbank="96" lbank="0" prog="16" />
-      <Patch name="Organ 5" hbank="96" lbank="0" prog="17" />
-      <Patch name="Church 3" hbank="96" lbank="0" prog="19" />
-      <Patch name="Nylon o" hbank="96" lbank="0" prog="24" />
-      <Patch name="Mandolin" hbank="96" lbank="0" prog="25" />
-      <Patch name="Mid Tone Gt" hbank="96" lbank="0" prog="27" />
-      <Patch name="Funk Gt 2" hbank="96" lbank="0" prog="28" />
-      <Patch name="DistRythm Gt" hbank="96" lbank="0" prog="30" />
-      <Patch name="Acid Bass" hbank="96" lbank="0" prog="38" />
-      <Patch name="Rubber Bass" hbank="96" lbank="0" prog="39" />
-      <Patch name="60&apos;Strings" hbank="96" lbank="0" prog="48" />
-      <Patch name="6th Hit" hbank="96" lbank="0" prog="55" />
-      <Patch name="Brite Bone" hbank="96" lbank="0" prog="57" />
-      <Patch name="Oct.SynBrass" hbank="96" lbank="0" prog="62" />
-      <Patch name="Velo Brass" hbank="96" lbank="0" prog="63" />
-      <Patch name="Sine Wave" hbank="96" lbank="0" prog="80" />
-      <Patch name="Doctor Solo" hbank="96" lbank="0" prog="81" />
-      <Patch name="Echo Pan" hbank="96" lbank="0" prog="102" />
-      <Patch name="Elec Perc" hbank="96" lbank="0" prog="118" />
-      <Patch name="Slap_St.Bass" hbank="96" lbank="0" prog="120" />
-      <Patch name="Thunder" hbank="96" lbank="0" prog="122" />
-      <Patch name="Horse Gallop" hbank="96" lbank="0" prog="123" />
-      <Patch name="Door Creak" hbank="96" lbank="0" prog="124" />
-      <Patch name="Car-Stop" hbank="96" lbank="0" prog="125" />
-      <Patch name="Screaming" hbank="96" lbank="0" prog="126" />
-      <Patch name="Lasergun" hbank="96" lbank="0" prog="127" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Classical Var #03">
-      <Patch name="60&apos;s E.Piano" hbank="96" lbank="0" prog="4" />
-      <Patch name="EP Legend" hbank="96" lbank="0" prog="5" />
-      <Patch name="Harpsi o" hbank="96" lbank="0" prog="6" />
-      <Patch name="Organ 4" hbank="96" lbank="0" prog="16" />
-      <Patch name="Nylon Gt.2" hbank="96" lbank="0" prog="24" />
-      <Patch name="Steel+Body" hbank="96" lbank="0" prog="25" />
-      <Patch name="Jazz Man" hbank="96" lbank="0" prog="28" />
-      <Patch name="Clavi Bass" hbank="96" lbank="0" prog="38" />
-      <Patch name="Attack Pulse" hbank="96" lbank="0" prog="39" />
-      <Patch name="Euro Hit" hbank="96" lbank="0" prog="55" />
-      <Patch name="Jump Brass" hbank="96" lbank="0" prog="62" />
-      <Patch name="Natural Lead" hbank="96" lbank="0" prog="81" />
-      <Patch name="Wind" hbank="96" lbank="0" prog="122" />
-      <Patch name="Bird Tweet 2" hbank="96" lbank="0" prog="123" />
-      <Patch name="Door" hbank="96" lbank="0" prog="124" />
-      <Patch name="Car-Pass" hbank="96" lbank="0" prog="125" />
-      <Patch name="Punch" hbank="96" lbank="0" prog="126" />
-      <Patch name="Explosion" hbank="96" lbank="0" prog="127" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Classical Var #04">
-      <Patch name="EP Phase" hbank="96" lbank="0" prog="5" />
-      <Patch name="Hammer" hbank="96" lbank="0" prog="38" />
-      <Patch name="SequencedSaw" hbank="96" lbank="0" prog="81" />
-      <Patch name="Stream" hbank="96" lbank="0" prog="122" />
-      <Patch name="Scratch" hbank="96" lbank="0" prog="124" />
-      <Patch name="Car-Crash" hbank="96" lbank="0" prog="125" />
-      <Patch name="Heart Beat" hbank="96" lbank="0" prog="126" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Classical Var #05">
-      <Patch name="Bubble" hbank="96" lbank="0" prog="122" />
-      <Patch name="Wind Chimes" hbank="96" lbank="0" prog="124" />
-      <Patch name="Siren" hbank="96" lbank="0" prog="125" />
-      <Patch name="Footsteps" hbank="96" lbank="0" prog="126" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Classical Var #06">
-      <Patch name="Train" hbank="96" lbank="0" prog="125" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Classical Var #07">
-      <Patch name="Jetplane" hbank="96" lbank="0" prog="125" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Classical Var #08">
-      <Patch name="Starship" hbank="96" lbank="0" prog="125" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Classical Var #09">
-      <Patch name="Burst Noise" hbank="96" lbank="0" prog="125" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Classical Drums">
-      <Patch name="Standard Set" hbank="104" prog="0" drum="1" />
-      <Patch name="Room Set" hbank="104" lbank="0" prog="8" drum="1" />
-      <Patch name="Power Set" hbank="104" lbank="0" prog="16" drum="1" />
-      <Patch name="Electric Set" hbank="104" lbank="0" prog="24" drum="1" />
-      <Patch name="Analog Set" hbank="104" lbank="0" prog="25" drum="1" />
-      <Patch name="Jazz Set" hbank="104" lbank="0" prog="32" drum="1" />
-      <Patch name="Brush Set" hbank="104" lbank="0" prog="40" drum="1" />
-      <Patch name="OrchestraSet" hbank="104" lbank="0" prog="48" drum="1" />
-      <Patch name="SFX Set" hbank="104" lbank="0" prog="56" drum="1" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Contemporary Capital Tones">
-      <Patch name="Ac.Piano" hbank="97" lbank="0" prog="0" />
-      <Patch name="Rock Piano" hbank="97" lbank="0" prog="1" />
-      <Patch name="E.Grand Pf" hbank="97" lbank="0" prog="2" />
-      <Patch name="Old Honky" hbank="97" lbank="0" prog="3" />
-      <Patch name="Soft Rhodes" hbank="97" lbank="0" prog="4" />
-      <Patch name="FM E.Piano" hbank="97" lbank="0" prog="5" />
-      <Patch name="Harpsi 2" hbank="97" lbank="0" prog="6" />
-      <Patch name="Atack Clav 1" hbank="97" lbank="0" prog="7" />
-      <Patch name="Celesta 2" hbank="97" lbank="0" prog="8" />
-      <Patch name="Glocken 2" hbank="97" lbank="0" prog="9" />
-      <Patch name="Music Box 2" hbank="97" lbank="0" prog="10" />
-      <Patch name="Vibraphone 2" hbank="97" lbank="0" prog="11" />
-      <Patch name="Marimba 2" hbank="97" lbank="0" prog="12" />
-      <Patch name="Xylophone 2" hbank="97" lbank="0" prog="13" />
-      <Patch name="Tubular-bel2" hbank="97" lbank="0" prog="14" />
-      <Patch name="Santur 2" hbank="97" lbank="0" prog="15" />
-      <Patch name="Perky" hbank="97" lbank="0" prog="16" />
-      <Patch name="Jazz Organ 1" hbank="97" lbank="0" prog="17" />
-      <Patch name="Organ 3 fast" hbank="97" lbank="0" prog="18" />
-      <Patch name="Pipe Organ 1" hbank="97" lbank="0" prog="19" />
-      <Patch name="Reed Organ 2" hbank="97" lbank="0" prog="20" />
-      <Patch name="French Acc" hbank="97" lbank="0" prog="21" />
-      <Patch name="Harmonica 2" hbank="97" lbank="0" prog="22" />
-      <Patch name="Bandneon 1" hbank="97" lbank="0" prog="23" />
-      <Patch name="Nylon Gt 2" hbank="97" lbank="0" prog="24" />
-      <Patch name="OV Steel Gt" hbank="97" lbank="0" prog="25" />
-      <Patch name="Jazz Gt 2" hbank="97" lbank="0" prog="26" />
-      <Patch name="TC Rear" hbank="97" lbank="0" prog="27" />
-      <Patch name="TC Mute Gt" hbank="97" lbank="0" prog="28" />
-      <Patch name="Atk Drive Gt" hbank="97" lbank="0" prog="29" />
-      <Patch name="Atk Dist Gt" hbank="97" lbank="0" prog="30" />
-      <Patch name="Gt.Harm 2" hbank="97" lbank="0" prog="31" />
-      <Patch name="Rockabilly" hbank="97" lbank="0" prog="32" />
-      <Patch name="Fingered Bs2" hbank="97" lbank="0" prog="33" />
-      <Patch name="Picked Jz Bs" hbank="97" lbank="0" prog="34" />
-      <Patch name="Fretless Bs2" hbank="97" lbank="0" prog="35" />
-      <Patch name="Slap Pop 1" hbank="97" lbank="0" prog="36" />
-      <Patch name="Funky Slap" hbank="97" lbank="0" prog="37" />
-      <Patch name="MG303 Bass" hbank="97" lbank="0" prog="38" />
-      <Patch name="Seq101 Bass" hbank="97" lbank="0" prog="39" />
-      <Patch name="Violin vib" hbank="97" lbank="0" prog="40" />
-      <Patch name="Viola vib" hbank="97" lbank="0" prog="41" />
-      <Patch name="Cello vib" hbank="97" lbank="0" prog="42" />
-      <Patch name="Cb vib" hbank="97" lbank="0" prog="43" />
-      <Patch name="Tremolo Str2" hbank="97" lbank="0" prog="44" />
-      <Patch name="Pizzicato 2" hbank="97" lbank="0" prog="45" />
-      <Patch name="Harp 2" hbank="97" lbank="0" prog="46" />
-      <Patch name="Timpani 2" hbank="97" lbank="0" prog="47" />
-      <Patch name="Strings 2" hbank="97" lbank="0" prog="48" />
-      <Patch name="SlowStrings2" hbank="97" lbank="0" prog="49" />
-      <Patch name="BriteSyn.Str" hbank="97" lbank="0" prog="50" />
-      <Patch name="Warm SynStr1" hbank="97" lbank="0" prog="51" />
-      <Patch name="Large Choir" hbank="97" lbank="0" prog="52" />
-      <Patch name="Voice Oohs 2" hbank="97" lbank="0" prog="53" />
-      <Patch name="SynVox 2" hbank="97" lbank="0" prog="54" />
-      <Patch name="Orc Hit 2" hbank="97" lbank="0" prog="55" />
-      <Patch name="Solo Trumpet" hbank="97" lbank="0" prog="56" />
-      <Patch name="Solo Bone" hbank="97" lbank="0" prog="57" />
-      <Patch name="Tuba 2" hbank="97" lbank="0" prog="58" />
-      <Patch name="MuteTrumpet2" hbank="97" lbank="0" prog="59" />
-      <Patch name="FrenchHorns2" hbank="97" lbank="0" prog="60" />
-      <Patch name="Brass FF" hbank="97" lbank="0" prog="61" />
-      <Patch name="JP Syn.Brass" hbank="97" lbank="0" prog="62" />
-      <Patch name="MG Syn.Horn" hbank="97" lbank="0" prog="63" />
-      <Patch name="Soprano Sax2" hbank="97" lbank="0" prog="64" />
-      <Patch name="Breathy Alto" hbank="97" lbank="0" prog="65" />
-      <Patch name="BreathyTenor" hbank="97" lbank="0" prog="66" />
-      <Patch name="Barely Bari" hbank="97" lbank="0" prog="67" />
-      <Patch name="Brite Oboe" hbank="97" lbank="0" prog="68" />
-      <Patch name="EnglishHorn2" hbank="97" lbank="0" prog="69" />
-      <Patch name="Bassoon 2" hbank="97" lbank="0" prog="70" />
-      <Patch name="Br.Clarinet" hbank="97" lbank="0" prog="71" />
-      <Patch name="Piccolo 2" hbank="97" lbank="0" prog="72" />
-      <Patch name="Flute 2" hbank="97" lbank="0" prog="73" />
-      <Patch name="Recorder 2" hbank="97" lbank="0" prog="74" />
-      <Patch name="Pan Flute 2" hbank="97" lbank="0" prog="75" />
-      <Patch name="Bottle Blow2" hbank="97" lbank="0" prog="76" />
-      <Patch name="Shakuhachi 2" hbank="97" lbank="0" prog="77" />
-      <Patch name="Whistle 2" hbank="97" lbank="0" prog="78" />
-      <Patch name="Ocarina 2" hbank="97" lbank="0" prog="79" />
-      <Patch name="MG Square" hbank="97" lbank="0" prog="80" />
-      <Patch name="JP Saw Wave" hbank="97" lbank="0" prog="81" />
-      <Patch name="SynCalliope2" hbank="97" lbank="0" prog="82" />
-      <Patch name="ChifferLead2" hbank="97" lbank="0" prog="83" />
-      <Patch name="Charang 2" hbank="97" lbank="0" prog="84" />
-      <Patch name="Solo Vox 2" hbank="97" lbank="0" prog="85" />
-      <Patch name="5th SawWave2" hbank="97" lbank="0" prog="86" />
-      <Patch name="Bass &amp; Lead2" hbank="97" lbank="0" prog="87" />
-      <Patch name="Fantasia 2" hbank="97" lbank="0" prog="88" />
-      <Patch name="Warm Pad 2" hbank="97" lbank="0" prog="89" />
-      <Patch name="Polysynth 2" hbank="97" lbank="0" prog="90" />
-      <Patch name="SpaceVoice 2" hbank="97" lbank="0" prog="91" />
-      <Patch name="BowedGlass 2" hbank="97" lbank="0" prog="92" />
-      <Patch name="Metal Pad 2" hbank="97" lbank="0" prog="93" />
-      <Patch name="Halo Pad 2" hbank="97" lbank="0" prog="94" />
-      <Patch name="Sweep Pad 2" hbank="97" lbank="0" prog="95" />
-      <Patch name="Ice Rain 2" hbank="97" lbank="0" prog="96" />
-      <Patch name="Soundtrack 2" hbank="97" lbank="0" prog="97" />
-      <Patch name="Crystal 2" hbank="97" lbank="0" prog="98" />
-      <Patch name="Atmosphere 2" hbank="97" lbank="0" prog="99" />
-      <Patch name="Brightness 2" hbank="97" lbank="0" prog="100" />
-      <Patch name="Goblin 2" hbank="97" lbank="0" prog="101" />
-      <Patch name="Echo Drops 2" hbank="97" lbank="0" prog="102" />
-      <Patch name="Star Theme 2" hbank="97" lbank="0" prog="103" />
-      <Patch name="Atk Sitar" hbank="97" lbank="0" prog="104" />
-      <Patch name="Banjo 2" hbank="97" lbank="0" prog="105" />
-      <Patch name="Shamisen 2" hbank="97" lbank="0" prog="106" />
-      <Patch name="Koto 2" hbank="97" lbank="0" prog="107" />
-      <Patch name="Kalimba 2" hbank="97" lbank="0" prog="108" />
-      <Patch name="Bag Pipe 2" hbank="97" lbank="0" prog="109" />
-      <Patch name="Fiddle vib" hbank="97" lbank="0" prog="110" />
-      <Patch name="Shanai 2" hbank="97" lbank="0" prog="111" />
-      <Patch name="Tinkle Bell" hbank="97" lbank="0" prog="112" />
-      <Patch name="Agogo" hbank="97" lbank="0" prog="113" />
-      <Patch name="Steel Drums" hbank="97" lbank="0" prog="114" />
-      <Patch name="Woodblock" hbank="97" lbank="0" prog="115" />
-      <Patch name="Taiko" hbank="97" lbank="0" prog="116" />
-      <Patch name="Melo.Tom 1" hbank="97" lbank="0" prog="117" />
-      <Patch name="Synth Drum" hbank="97" lbank="0" prog="118" />
-      <Patch name="Reverse Cym" hbank="97" lbank="0" prog="119" />
-      <Patch name="GtFret Noise" hbank="97" lbank="0" prog="120" />
-      <Patch name="Breath Noise" hbank="97" lbank="0" prog="121" />
-      <Patch name="Seashore" hbank="97" lbank="0" prog="122" />
-      <Patch name="Bird Tweet" hbank="97" lbank="0" prog="123" />
-      <Patch name="Telephone" hbank="97" lbank="0" prog="124" />
-      <Patch name="Helicopter" hbank="97" lbank="0" prog="125" />
-      <Patch name="Applause" hbank="97" lbank="0" prog="126" />
-      <Patch name="Gunshot" hbank="97" lbank="0" prog="127" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Contemporary Var #01">
-      <Patch name="Ac.Piano w" hbank="97" lbank="0" prog="0" />
-      <Patch name="Rock Piano w" hbank="97" lbank="0" prog="1" />
-      <Patch name="E.Grand Pf w" hbank="97" lbank="0" prog="2" />
-      <Patch name="Old Honky w" hbank="97" lbank="0" prog="3" />
-      <Patch name="Fat Rhodes" hbank="97" lbank="0" prog="4" />
-      <Patch name="Soft FM EP" hbank="97" lbank="0" prog="5" />
-      <Patch name="Coupl hps 2" hbank="97" lbank="0" prog="6" />
-      <Patch name="AnalogClav 1" hbank="97" lbank="0" prog="7" />
-      <Patch name="Vibraphone2w" hbank="97" lbank="0" prog="11" />
-      <Patch name="Marimba 2 w" hbank="97" lbank="0" prog="12" />
-      <Patch name="Church Bell2" hbank="97" lbank="0" prog="14" />
-      <Patch name="Ballad B" hbank="97" lbank="0" prog="16" />
-      <Patch name="Perc.Organ 1" hbank="97" lbank="0" prog="17" />
-      <Patch name="LargeChurch1" hbank="97" lbank="0" prog="19" />
-      <Patch name="Organ Flute" hbank="97" lbank="0" prog="20" />
-      <Patch name="It Muset" hbank="97" lbank="0" prog="21" />
-      <Patch name="Ukulele 2" hbank="97" lbank="0" prog="24" />
-      <Patch name="12-Str.Gt 2" hbank="97" lbank="0" prog="25" />
-      <Patch name="Pedal Steel2" hbank="97" lbank="0" prog="26" />
-      <Patch name="TC Front" hbank="97" lbank="0" prog="27" />
-      <Patch name="FunkGt Slap" hbank="97" lbank="0" prog="28" />
-      <Patch name="Gt.Pinch 2" hbank="97" lbank="0" prog="29" />
-      <Patch name="FeedbackGt 2" hbank="97" lbank="0" prog="30" />
-      <Patch name="FeedbackOct" hbank="97" lbank="0" prog="31" />
-      <Patch name="FingerP.Bass" hbank="97" lbank="0" prog="33" />
-      <Patch name="MG Bass" hbank="97" lbank="0" prog="38" />
-      <Patch name="Beef Slap Bs" hbank="97" lbank="0" prog="39" />
-      <Patch name="Slow Vln vib" hbank="97" lbank="0" prog="40" />
-      <Patch name="Yangqin 2" hbank="97" lbank="0" prog="46" />
-      <Patch name="Orchestra 2" hbank="97" lbank="0" prog="48" />
-      <Patch name="Oct.SynStr 1" hbank="97" lbank="0" prog="50" />
-      <Patch name="Small Choir" hbank="97" lbank="0" prog="52" />
-      <Patch name="Hamming 2" hbank="97" lbank="0" prog="53" />
-      <Patch name="Ana Voice 2" hbank="97" lbank="0" prog="54" />
-      <Patch name="Bass Hit 2" hbank="97" lbank="0" prog="55" />
-      <Patch name="Mild Trumpet" hbank="97" lbank="0" prog="56" />
-      <Patch name="Solo Bone 2" hbank="97" lbank="0" prog="57" />
-      <Patch name="Harmon Mute" hbank="97" lbank="0" prog="59" />
-      <Patch name="MildFr.Horns" hbank="97" lbank="0" prog="60" />
-      <Patch name="BrassSection" hbank="97" lbank="0" prog="61" />
-      <Patch name="JPSyn.Brass2" hbank="97" lbank="0" prog="62" />
-      <Patch name="OB Syn.Horn" hbank="97" lbank="0" prog="63" />
-      <Patch name="Fat Square" hbank="97" lbank="0" prog="80" />
-      <Patch name="MG Saw" hbank="97" lbank="0" prog="81" />
-      <Patch name="Wire Lead 2" hbank="97" lbank="0" prog="84" />
-      <Patch name="DelayedLead2" hbank="97" lbank="0" prog="87" />
-      <Patch name="Sine Pad 2" hbank="97" lbank="0" prog="89" />
-      <Patch name="Itopia 2" hbank="97" lbank="0" prog="91" />
-      <Patch name="Syn Mallet 2" hbank="97" lbank="0" prog="98" />
-      <Patch name="Echo Bell 2" hbank="97" lbank="0" prog="102" />
-      <Patch name="Atk Sitar 2" hbank="97" lbank="0" prog="104" />
-      <Patch name="Taisho Koto2" hbank="97" lbank="0" prog="107" />
-      <Patch name="Castanet" hbank="97" lbank="0" prog="115" />
-      <Patch name="Concert BD" hbank="97" lbank="0" prog="116" />
-      <Patch name="Melo.Tom 2" hbank="97" lbank="0" prog="117" />
-      <Patch name="808 tom" hbank="97" lbank="0" prog="118" />
-      <Patch name="Gt.Cut Noise" hbank="97" lbank="0" prog="120" />
-      <Patch name="Fl.Key Click" hbank="97" lbank="0" prog="121" />
-      <Patch name="Rain" hbank="97" lbank="0" prog="122" />
-      <Patch name="Dog" hbank="97" lbank="0" prog="123" />
-      <Patch name="Telephone 2" hbank="97" lbank="0" prog="124" />
-      <Patch name="Car-Engine" hbank="97" lbank="0" prog="125" />
-      <Patch name="Laughing" hbank="97" lbank="0" prog="126" />
-      <Patch name="Machine Gun" hbank="97" lbank="0" prog="127" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Contemporary Var #02">
-      <Patch name="Mild Piano" hbank="97" lbank="0" prog="0" />
-      <Patch name="Rhodes Wide" hbank="97" lbank="0" prog="4" />
-      <Patch name="SA E.Piano" hbank="97" lbank="0" prog="5" />
-      <Patch name="Harpsi 2 w" hbank="97" lbank="0" prog="6" />
-      <Patch name="Carillon 2" hbank="97" lbank="0" prog="14" />
-      <Patch name="Happy 60s" hbank="97" lbank="0" prog="16" />
-      <Patch name="Dist.JzOrg 1" hbank="97" lbank="0" prog="17" />
-      <Patch name="SmallChurch1" hbank="97" lbank="0" prog="19" />
-      <Patch name="Nylon 2 o" hbank="97" lbank="0" prog="24" />
-      <Patch name="Mandolin 2" hbank="97" lbank="0" prog="25" />
-      <Patch name="TC Front 2" hbank="97" lbank="0" prog="27" />
-      <Patch name="Funk Pop" hbank="97" lbank="0" prog="28" />
-      <Patch name="Muted Dist" hbank="97" lbank="0" prog="30" />
-      <Patch name="MG Acid Bass" hbank="97" lbank="0" prog="38" />
-      <Patch name="Rubber Bass2" hbank="97" lbank="0" prog="39" />
-      <Patch name="Oct.Strings" hbank="97" lbank="0" prog="48" />
-      <Patch name="6th Hit 2" hbank="97" lbank="0" prog="55" />
-      <Patch name="Brite Bone 2" hbank="97" lbank="0" prog="57" />
-      <Patch name="OctSynBrass2" hbank="97" lbank="0" prog="62" />
-      <Patch name="CS Syn.Brass" hbank="97" lbank="0" prog="63" />
-      <Patch name="2600 Sine" hbank="97" lbank="0" prog="80" />
-      <Patch name="Fat Saw Solo" hbank="97" lbank="0" prog="81" />
-      <Patch name="Echo Pan 2" hbank="97" lbank="0" prog="102" />
-      <Patch name="Elec Perc" hbank="97" lbank="0" prog="118" />
-      <Patch name="Slap_St.Bass" hbank="97" lbank="0" prog="120" />
-      <Patch name="Thunder" hbank="97" lbank="0" prog="122" />
-      <Patch name="Horse Gallop" hbank="97" lbank="0" prog="123" />
-      <Patch name="Door Creak" hbank="97" lbank="0" prog="124" />
-      <Patch name="Car-Stop" hbank="97" lbank="0" prog="125" />
-      <Patch name="Screaming" hbank="97" lbank="0" prog="126" />
-      <Patch name="Lasergun" hbank="97" lbank="0" prog="127" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Contemporary Var #03">
-      <Patch name="Wurly Soft" hbank="97" lbank="0" prog="4" />
-      <Patch name="EP Legend 2" hbank="97" lbank="0" prog="5" />
-      <Patch name="Harpsi 2 o" hbank="97" lbank="0" prog="6" />
-      <Patch name="Tone Wheel" hbank="97" lbank="0" prog="16" />
-      <Patch name="Hard Gut Gt" hbank="97" lbank="0" prog="24" />
-      <Patch name="Steel+Body 2" hbank="97" lbank="0" prog="25" />
-      <Patch name="Mute Jazz Gt" hbank="97" lbank="0" prog="28" />
-      <Patch name="Clavi Bass 2" hbank="97" lbank="0" prog="38" />
-      <Patch name="Attack Saw" hbank="97" lbank="0" prog="39" />
-      <Patch name="Euro Hit 2" hbank="97" lbank="0" prog="55" />
-      <Patch name="80&apos;s Brass" hbank="97" lbank="0" prog="62" />
-      <Patch name="P5 Saw Lead" hbank="97" lbank="0" prog="81" />
-      <Patch name="Wind" hbank="97" lbank="0" prog="122" />
-      <Patch name="Bird Tweet 2" hbank="97" lbank="0" prog="123" />
-      <Patch name="Door" hbank="97" lbank="0" prog="124" />
-      <Patch name="Car-Pass" hbank="97" lbank="0" prog="125" />
-      <Patch name="Punch" hbank="97" lbank="0" prog="126" />
-      <Patch name="Explosion" hbank="97" lbank="0" prog="127" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Contemporary Var #04">
-      <Patch name="EP Phase 2" hbank="97" lbank="0" prog="5" />
-      <Patch name="OB Hammer" hbank="97" lbank="0" prog="38" />
-      <Patch name="MG Sequence" hbank="97" lbank="0" prog="81" />
-      <Patch name="Stream" hbank="97" lbank="0" prog="122" />
-      <Patch name="Scratch" hbank="97" lbank="0" prog="124" />
-      <Patch name="Car-Crash" hbank="97" lbank="0" prog="125" />
-      <Patch name="Heart Beat" hbank="97" lbank="0" prog="126" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Contemporary Var #05">
-      <Patch name="Bubble" hbank="97" lbank="0" prog="122" />
-      <Patch name="Wind Chimes" hbank="97" lbank="0" prog="124" />
-      <Patch name="Siren" hbank="97" lbank="0" prog="125" />
-      <Patch name="Footsteps" hbank="97" lbank="0" prog="126" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Contemporary Var #06">
-      <Patch name="Train" hbank="97" lbank="0" prog="125" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Contemporary Var #07">
-      <Patch name="Jetplane" hbank="97" lbank="0" prog="125" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Contemporary Var #08">
-      <Patch name="Starship" hbank="97" lbank="0" prog="125" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Contemporary Var #09">
-      <Patch name="Burst Noise" hbank="97" lbank="0" prog="125" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Contemporary Drums">
-      <Patch name="StandardSet2" hbank="105" lbank="0" prog="0" drum="1" />
-      <Patch name="Room Set 2" hbank="105" lbank="0" prog="8" drum="1" />
-      <Patch name="Power Set 2" hbank="105" lbank="0" prog="16" drum="1" />
-      <Patch name="Dance Set" hbank="105" lbank="0" prog="24" drum="1" />
-      <Patch name="Rave Set" hbank="105" lbank="0" prog="25" drum="1" />
-      <Patch name="Jazz Set 2" hbank="105" lbank="0" prog="32" drum="1" />
-      <Patch name="Brush Set 2" hbank="105" lbank="0" prog="40" drum="1" />
-      <Patch name="OrchestraSet" hbank="105" lbank="0" prog="48" drum="1" />
-      <Patch name="SFX Set" hbank="105" lbank="0" prog="56" drum="1" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Solo Capital Tones">
-      <Patch name="St.Piano 1" hbank="98" lbank="0" prog="0" />
-      <Patch name="St.Piano 2" hbank="98" lbank="0" prog="1" />
-      <Patch name="SA Piano" hbank="98" lbank="0" prog="2" />
-      <Patch name="St.Honky" hbank="98" lbank="0" prog="3" />
-      <Patch name="Tremo Rhodes" hbank="98" lbank="0" prog="4" />
-      <Patch name="FM Hard EP" hbank="98" lbank="0" prog="5" />
-      <Patch name="St.Harpsichd" hbank="98" lbank="0" prog="6" />
-      <Patch name="Atack Clav 2" hbank="98" lbank="0" prog="7" />
-      <Patch name="St.Celesta" hbank="98" lbank="0" prog="8" />
-      <Patch name="St.Glocken" hbank="98" lbank="0" prog="9" />
-      <Patch name="St.Music Box" hbank="98" lbank="0" prog="10" />
-      <Patch name="St.Vibra" hbank="98" lbank="0" prog="11" />
-      <Patch name="St.Marimba" hbank="98" lbank="0" prog="12" />
-      <Patch name="St.Xylophone" hbank="98" lbank="0" prog="13" />
-      <Patch name="St.Tubular" hbank="98" lbank="0" prog="14" />
-      <Patch name="St.Santur" hbank="98" lbank="0" prog="15" />
-      <Patch name="Roller" hbank="98" lbank="0" prog="16" />
-      <Patch name="Jazz Organ 2" hbank="98" lbank="0" prog="17" />
-      <Patch name="Rock Organ" hbank="98" lbank="0" prog="18" />
-      <Patch name="Pipe Organ 2" hbank="98" lbank="0" prog="19" />
-      <Patch name="Reed Organ 3" hbank="98" lbank="0" prog="20" />
-      <Patch name="St.FrenchAcc" hbank="98" lbank="0" prog="21" />
-      <Patch name="St.Harmonica" hbank="98" lbank="0" prog="22" />
-      <Patch name="St.Bandneon" hbank="98" lbank="0" prog="23" />
-      <Patch name="Nylon Gt 3" hbank="98" lbank="0" prog="24" />
-      <Patch name="SteelStr.Gt2" hbank="98" lbank="0" prog="25" />
-      <Patch name="Jazz Gt 3" hbank="98" lbank="0" prog="26" />
-      <Patch name="Strat2 Rear" hbank="98" lbank="0" prog="27" />
-      <Patch name="TC Mute Gt 2" hbank="98" lbank="0" prog="28" />
-      <Patch name="OverdriveGt2" hbank="98" lbank="0" prog="29" />
-      <Patch name="Dist.Gt 2" hbank="98" lbank="0" prog="30" />
-      <Patch name="Gt.OctHarm" hbank="98" lbank="0" prog="31" />
-      <Patch name="Fat Aco.Bass" hbank="98" lbank="0" prog="32" />
-      <Patch name="Jazz Bass" hbank="98" lbank="0" prog="33" />
-      <Patch name="Picking Bass" hbank="98" lbank="0" prog="34" />
-      <Patch name="PhaseFrtless" hbank="98" lbank="0" prog="35" />
-      <Patch name="Jazz Slap" hbank="98" lbank="0" prog="36" />
-      <Patch name="Slap Pop 2" hbank="98" lbank="0" prog="37" />
-      <Patch name="Fat Syn.Bass" hbank="98" lbank="0" prog="38" />
-      <Patch name="Sq SynthBass" hbank="98" lbank="0" prog="39" />
-      <Patch name="Violin 2 vib" hbank="98" lbank="0" prog="40" />
-      <Patch name="Viola2 vib" hbank="98" lbank="0" prog="41" />
-      <Patch name="Cello2 vib" hbank="98" lbank="0" prog="42" />
-      <Patch name="Cb2 vib" hbank="98" lbank="0" prog="43" />
-      <Patch name="St.Trem Str" hbank="98" lbank="0" prog="44" />
-      <Patch name="St.Pizzicato" hbank="98" lbank="0" prog="45" />
-      <Patch name="St.Harp" hbank="98" lbank="0" prog="46" />
-      <Patch name="St.Timpani" hbank="98" lbank="0" prog="47" />
-      <Patch name="St.Strings" hbank="98" lbank="0" prog="48" />
-      <Patch name="St.Slow Str" hbank="98" lbank="0" prog="49" />
-      <Patch name="StackSyn.Str" hbank="98" lbank="0" prog="50" />
-      <Patch name="Warm SynStr2" hbank="98" lbank="0" prog="51" />
-      <Patch name="St.ChoirAahs" hbank="98" lbank="0" prog="52" />
-      <Patch name="St.Vox Oohs" hbank="98" lbank="0" prog="53" />
-      <Patch name="St.SynVox" hbank="98" lbank="0" prog="54" />
-      <Patch name="St.Orc Hit" hbank="98" lbank="0" prog="55" />
-      <Patch name="Romantic Tp" hbank="98" lbank="0" prog="56" />
-      <Patch name="Trombone vib" hbank="98" lbank="0" prog="57" />
-      <Patch name="Tuba vib" hbank="98" lbank="0" prog="58" />
-      <Patch name="Solo MutedTp" hbank="98" lbank="0" prog="59" />
-      <Patch name="St.Fr Horns" hbank="98" lbank="0" prog="60" />
-      <Patch name="St.Brass" hbank="98" lbank="0" prog="61" />
-      <Patch name="Hyper Brass" hbank="98" lbank="0" prog="62" />
-      <Patch name="Warm SynHorn" hbank="98" lbank="0" prog="63" />
-      <Patch name="Sop.Sax vib" hbank="98" lbank="0" prog="64" />
-      <Patch name="AltoSoft vib" hbank="98" lbank="0" prog="65" />
-      <Patch name="Blow Tenor" hbank="98" lbank="0" prog="66" />
-      <Patch name="Bari.Sax vib" hbank="98" lbank="0" prog="67" />
-      <Patch name="Classic Oboe" hbank="98" lbank="0" prog="68" />
-      <Patch name="E.Horn vib" hbank="98" lbank="0" prog="69" />
-      <Patch name="Bassoon vib" hbank="98" lbank="0" prog="70" />
-      <Patch name="JazzClarinet" hbank="98" lbank="0" prog="71" />
-      <Patch name="Piccolo vib" hbank="98" lbank="0" prog="72" />
-      <Patch name="Flute vib" hbank="98" lbank="0" prog="73" />
-      <Patch name="Recorder vib" hbank="98" lbank="0" prog="74" />
-      <Patch name="PanFlute vib" hbank="98" lbank="0" prog="75" />
-      <Patch name="Bottle vib" hbank="98" lbank="0" prog="76" />
-      <Patch name="Shaku.vib" hbank="98" lbank="0" prog="77" />
-      <Patch name="Whistle vib" hbank="98" lbank="0" prog="78" />
-      <Patch name="Ocarina vib" hbank="98" lbank="0" prog="79" />
-      <Patch name="OB Square" hbank="98" lbank="0" prog="80" />
-      <Patch name="Oct.JP Saw" hbank="98" lbank="0" prog="81" />
-      <Patch name="SynCalliope3" hbank="98" lbank="0" prog="82" />
-      <Patch name="ChifferLead3" hbank="98" lbank="0" prog="83" />
-      <Patch name="Charang 3" hbank="98" lbank="0" prog="84" />
-      <Patch name="Solo Vox 3" hbank="98" lbank="0" prog="85" />
-      <Patch name="5th SawWave3" hbank="98" lbank="0" prog="86" />
-      <Patch name="Bass &amp; Lead3" hbank="98" lbank="0" prog="87" />
-      <Patch name="Fantasia 3" hbank="98" lbank="0" prog="88" />
-      <Patch name="Warm Pad 3" hbank="98" lbank="0" prog="89" />
-      <Patch name="Polysynth 3" hbank="98" lbank="0" prog="90" />
-      <Patch name="SpaceVoice 3" hbank="98" lbank="0" prog="91" />
-      <Patch name="BowedGlass 3" hbank="98" lbank="0" prog="92" />
-      <Patch name="Metal Pad 3" hbank="98" lbank="0" prog="93" />
-      <Patch name="Halo Pad 3" hbank="98" lbank="0" prog="94" />
-      <Patch name="Sweep Pad 3" hbank="98" lbank="0" prog="95" />
-      <Patch name="Ice Rain 3" hbank="98" lbank="0" prog="96" />
-      <Patch name="Soundtrack 3" hbank="98" lbank="0" prog="97" />
-      <Patch name="Crystal 3" hbank="98" lbank="0" prog="98" />
-      <Patch name="Atmosphere 3" hbank="98" lbank="0" prog="99" />
-      <Patch name="Brightness 3" hbank="98" lbank="0" prog="100" />
-      <Patch name="Goblin 3" hbank="98" lbank="0" prog="101" />
-      <Patch name="Echo Drops 3" hbank="98" lbank="0" prog="102" />
-      <Patch name="Star Theme 3" hbank="98" lbank="0" prog="103" />
-      <Patch name="St.Sitar" hbank="98" lbank="0" prog="104" />
-      <Patch name="St.Banjo" hbank="98" lbank="0" prog="105" />
-      <Patch name="St.Shamisen" hbank="98" lbank="0" prog="106" />
-      <Patch name="St.Koto" hbank="98" lbank="0" prog="107" />
-      <Patch name="St.Kalimba" hbank="98" lbank="0" prog="108" />
-      <Patch name="St.Bag Pipe" hbank="98" lbank="0" prog="109" />
-      <Patch name="Fiddle 2 vib" hbank="98" lbank="0" prog="110" />
-      <Patch name="St.Shanai" hbank="98" lbank="0" prog="111" />
-      <Patch name="Tinkle Bell" hbank="98" lbank="0" prog="112" />
-      <Patch name="Agogo" hbank="98" lbank="0" prog="113" />
-      <Patch name="Steel Drums" hbank="98" lbank="0" prog="114" />
-      <Patch name="Woodblock" hbank="98" lbank="0" prog="115" />
-      <Patch name="Taiko" hbank="98" lbank="0" prog="116" />
-      <Patch name="Melo.Tom 1" hbank="98" lbank="0" prog="117" />
-      <Patch name="Synth Drum" hbank="98" lbank="0" prog="118" />
-      <Patch name="Reverse Cym" hbank="98" lbank="0" prog="119" />
-      <Patch name="GtFret Noise" hbank="98" lbank="0" prog="120" />
-      <Patch name="Breath Noise" hbank="98" lbank="0" prog="121" />
-      <Patch name="Seashore" hbank="98" lbank="0" prog="122" />
-      <Patch name="Bird Tweet" hbank="98" lbank="0" prog="123" />
-      <Patch name="Telephone" hbank="98" lbank="0" prog="124" />
-      <Patch name="Helicopter" hbank="98" lbank="0" prog="125" />
-      <Patch name="Applause" hbank="98" lbank="0" prog="126" />
-      <Patch name="Gunshot" hbank="98" lbank="0" prog="127" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Solo Var #01">
-      <Patch name="St.Piano 1w" hbank="98" lbank="0" prog="0" />
-      <Patch name="St.Piano 2w" hbank="98" lbank="0" prog="1" />
-      <Patch name="SA Piano w" hbank="98" lbank="0" prog="2" />
-      <Patch name="St.Honky w" hbank="98" lbank="0" prog="3" />
-      <Patch name="Sweet Tynes" hbank="98" lbank="0" prog="4" />
-      <Patch name="Brite FM EP" hbank="98" lbank="0" prog="5" />
-      <Patch name="St.Coupl hps" hbank="98" lbank="0" prog="6" />
-      <Patch name="AnalogClav 2" hbank="98" lbank="0" prog="7" />
-      <Patch name="St.Vibra w" hbank="98" lbank="0" prog="11" />
-      <Patch name="St.Marimba w" hbank="98" lbank="0" prog="12" />
-      <Patch name="St.Church" hbank="98" lbank="0" prog="14" />
-      <Patch name="Rocker" hbank="98" lbank="0" prog="16" />
-      <Patch name="Perc.Organ 2" hbank="98" lbank="0" prog="17" />
-      <Patch name="LargeChurch2" hbank="98" lbank="0" prog="19" />
-      <Patch name="Theater" hbank="98" lbank="0" prog="20" />
-      <Patch name="St.It Muset" hbank="98" lbank="0" prog="21" />
-      <Patch name="Ukulele 3" hbank="98" lbank="0" prog="24" />
-      <Patch name="12-Str.Gt 3" hbank="98" lbank="0" prog="25" />
-      <Patch name="Pedal Steel3" hbank="98" lbank="0" prog="26" />
-      <Patch name="Chorus Clean" hbank="98" lbank="0" prog="27" />
-      <Patch name="FunkGt.Slap2" hbank="98" lbank="0" prog="28" />
-      <Patch name="Gt.Pinch 3" hbank="98" lbank="0" prog="29" />
-      <Patch name="Feedback OD" hbank="98" lbank="0" prog="30" />
-      <Patch name="FeedbackHarm" hbank="98" lbank="0" prog="31" />
-      <Patch name="Finger Slap" hbank="98" lbank="0" prog="33" />
-      <Patch name="SynthSaw Bs" hbank="98" lbank="0" prog="38" />
-      <Patch name="Beef Saw Bs" hbank="98" lbank="0" prog="39" />
-      <Patch name="SlowVln2 vib" hbank="98" lbank="0" prog="40" />
-      <Patch name="St.Yangqin" hbank="98" lbank="0" prog="46" />
-      <Patch name="St.Orchestra" hbank="98" lbank="0" prog="48" />
-      <Patch name="Oct.SynStr 2" hbank="98" lbank="0" prog="50" />
-      <Patch name="St.Sm Choir" hbank="98" lbank="0" prog="52" />
-      <Patch name="St.Hamming" hbank="98" lbank="0" prog="53" />
-      <Patch name="Ana Voice 3" hbank="98" lbank="0" prog="54" />
-      <Patch name="St.Bass Hit" hbank="98" lbank="0" prog="55" />
-      <Patch name="Tp.Dark vib" hbank="98" lbank="0" prog="56" />
-      <Patch name="Trombone2vib" hbank="98" lbank="0" prog="57" />
-      <Patch name="Harmon Mute2" hbank="98" lbank="0" prog="59" />
-      <Patch name="St.Fr Horns2" hbank="98" lbank="0" prog="60" />
-      <Patch name="St.Brass 2" hbank="98" lbank="0" prog="61" />
-      <Patch name="Stack Brass" hbank="98" lbank="0" prog="62" />
-      <Patch name="Rich SynHorn" hbank="98" lbank="0" prog="63" />
-      <Patch name="Fat Square2" hbank="98" lbank="0" prog="80" />
-      <Patch name="Hybrid Saw" hbank="98" lbank="0" prog="81" />
-      <Patch name="Wire Lead 3" hbank="98" lbank="0" prog="84" />
-      <Patch name="DelayedLead3" hbank="98" lbank="0" prog="87" />
-      <Patch name="Sine Pad 3" hbank="98" lbank="0" prog="89" />
-      <Patch name="Itopia 3" hbank="98" lbank="0" prog="91" />
-      <Patch name="Syn Mallet 3" hbank="98" lbank="0" prog="98" />
-      <Patch name="Echo Bell 3" hbank="98" lbank="0" prog="102" />
-      <Patch name="St.Sitar 2" hbank="98" lbank="0" prog="104" />
-      <Patch name="St.T Koto" hbank="98" lbank="0" prog="107" />
-      <Patch name="Castanet" hbank="98" lbank="0" prog="115" />
-      <Patch name="Concert BD" hbank="98" lbank="0" prog="116" />
-      <Patch name="Melo.Tom 2" hbank="98" lbank="0" prog="117" />
-      <Patch name="808 tom" hbank="98" lbank="0" prog="118" />
-      <Patch name="Gt.Cut Noise" hbank="98" lbank="0" prog="120" />
-      <Patch name="Fl.Key Click" hbank="98" lbank="0" prog="121" />
-      <Patch name="Rain" hbank="98" lbank="0" prog="122" />
-      <Patch name="Dog" hbank="98" lbank="0" prog="123" />
-      <Patch name="Telephone 2" hbank="98" lbank="0" prog="124" />
-      <Patch name="Car-Engine" hbank="98" lbank="0" prog="125" />
-      <Patch name="Laughing" hbank="98" lbank="0" prog="126" />
-      <Patch name="Machine Gun" hbank="98" lbank="0" prog="127" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Solo Var #02">
-      <Patch name="European Pf" hbank="98" lbank="0" prog="0" />
-      <Patch name="Tremo Dyno" hbank="98" lbank="0" prog="4" />
-      <Patch name="Brite FM EP2" hbank="98" lbank="0" prog="5" />
-      <Patch name="St.Harpsi w" hbank="98" lbank="0" prog="6" />
-      <Patch name="St.Carillon" hbank="98" lbank="0" prog="14" />
-      <Patch name="Soft60&apos;Organ" hbank="98" lbank="0" prog="16" />
-      <Patch name="Dist.JzOrg 2" hbank="98" lbank="0" prog="17" />
-      <Patch name="SmallChurch2" hbank="98" lbank="0" prog="19" />
-      <Patch name="Nylon 3 o" hbank="98" lbank="0" prog="24" />
-      <Patch name="Mandolin 3" hbank="98" lbank="0" prog="25" />
-      <Patch name="335" hbank="98" lbank="0" prog="27" />
-      <Patch name="Funk Pop 2" hbank="98" lbank="0" prog="28" />
-      <Patch name="Muted Dist 2" hbank="98" lbank="0" prog="30" />
-      <Patch name="AcidBs Dirty" hbank="98" lbank="0" prog="38" />
-      <Patch name="JpSaw Rubber" hbank="98" lbank="0" prog="39" />
-      <Patch name="St.OctStr 1" hbank="98" lbank="0" prog="48" />
-      <Patch name="St.6th Hit" hbank="98" lbank="0" prog="55" />
-      <Patch name="Br.Bone vib" hbank="98" lbank="0" prog="57" />
-      <Patch name="OctSynBrass3" hbank="98" lbank="0" prog="62" />
-      <Patch name="P5 Syn.Brass" hbank="98" lbank="0" prog="63" />
-      <Patch name="2600 Sine 2" hbank="98" lbank="0" prog="80" />
-      <Patch name="Hybrid Solo" hbank="98" lbank="0" prog="81" />
-      <Patch name="Echo Pan 3" hbank="98" lbank="0" prog="102" />
-      <Patch name="Elec Perc" hbank="98" lbank="0" prog="118" />
-      <Patch name="Slap_St.Bass" hbank="98" lbank="0" prog="120" />
-      <Patch name="Thunder" hbank="98" lbank="0" prog="122" />
-      <Patch name="Horse Gallop" hbank="98" lbank="0" prog="123" />
-      <Patch name="Door Creak" hbank="98" lbank="0" prog="124" />
-      <Patch name="Car-Stop" hbank="98" lbank="0" prog="125" />
-      <Patch name="Screaming" hbank="98" lbank="0" prog="126" />
-      <Patch name="Lasergun" hbank="98" lbank="0" prog="127" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Solo Var #03">
-      <Patch name="Tremo Wurly" hbank="98" lbank="0" prog="4" />
-      <Patch name="EP Legend 3" hbank="98" lbank="0" prog="5" />
-      <Patch name="St.Harpsi o" hbank="98" lbank="0" prog="6" />
-      <Patch name="Full Stops" hbank="98" lbank="0" prog="16" />
-      <Patch name="Hard Gut Gt2" hbank="98" lbank="0" prog="24" />
-      <Patch name="Steel+Body 3" hbank="98" lbank="0" prog="25" />
-      <Patch name="Slap Jazz Gt" hbank="98" lbank="0" prog="28" />
-      <Patch name="Clavi Bass 3" hbank="98" lbank="0" prog="38" />
-      <Patch name="Attack MG Bs" hbank="98" lbank="0" prog="39" />
-      <Patch name="St.Euro Hit" hbank="98" lbank="0" prog="55" />
-      <Patch name="SuperSaw Brs" hbank="98" lbank="0" prog="62" />
-      <Patch name="MG Saw Lead" hbank="98" lbank="0" prog="81" />
-      <Patch name="Wind" hbank="98" lbank="0" prog="122" />
-      <Patch name="Bird Tweet 2" hbank="98" lbank="0" prog="123" />
-      <Patch name="Door" hbank="98" lbank="0" prog="124" />
-      <Patch name="Car-Pass" hbank="98" lbank="0" prog="125" />
-      <Patch name="Punch" hbank="98" lbank="0" prog="126" />
-      <Patch name="Explosion" hbank="98" lbank="0" prog="127" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Solo Var #04">
-      <Patch name="EP Phase 3" hbank="98" lbank="0" prog="5" />
-      <Patch name="MG Hammer" hbank="98" lbank="0" prog="38" />
-      <Patch name="DelaySeqence" hbank="98" lbank="0" prog="81" />
-      <Patch name="Stream" hbank="98" lbank="0" prog="122" />
-      <Patch name="Scratch" hbank="98" lbank="0" prog="124" />
-      <Patch name="Car-Crash" hbank="98" lbank="0" prog="125" />
-      <Patch name="Heart Beat" hbank="98" lbank="0" prog="126" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Solo Var #05">
-      <Patch name="Bubble" hbank="98" lbank="0" prog="122" />
-      <Patch name="Wind Chimes" hbank="98" lbank="0" prog="124" />
-      <Patch name="Siren" hbank="98" lbank="0" prog="125" />
-      <Patch name="Footsteps" hbank="98" lbank="0" prog="126" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Solo Var #06">
-      <Patch name="Train" hbank="98" lbank="0" prog="125" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Solo Var #07">
-      <Patch name="Jetplane" hbank="98" lbank="0" prog="125" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Solo Var #08">
-      <Patch name="Starship" hbank="98" lbank="0" prog="125" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Solo Var #09">
-      <Patch name="Burst Noise" hbank="98" lbank="0" prog="125" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Solo Drums">
-      <Patch name="St.Standard" hbank="106" lbank="0" prog="0" drum="1" />
-      <Patch name="St.Room" hbank="106" lbank="0" prog="8" drum="1" />
-      <Patch name="St.Power" hbank="106" lbank="0" prog="16" drum="1" />
-      <Patch name="Rust Set" hbank="106" lbank="0" prog="24" drum="1" />
-      <Patch name="Analog2 Set" hbank="106" lbank="0" prog="25" drum="1" />
-      <Patch name="St.Jazz" hbank="106" lbank="0" prog="32" drum="1" />
-      <Patch name="St.Brush" hbank="106" lbank="0" prog="40" drum="1" />
-      <Patch name="OrchestraSet" hbank="106" lbank="0" prog="48" drum="1" />
-      <Patch name="SFX Set" hbank="106" lbank="0" prog="56" drum="1" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Enhanced Capital Tones">
-      <Patch name="SD Piano" hbank="99" lbank="0" prog="0" />
-      <Patch name="Enh.Piano 2" hbank="99" lbank="0" prog="1" />
-      <Patch name="Enh.E Grand" hbank="99" lbank="0" prog="2" />
-      <Patch name="Brite Honky" hbank="99" lbank="0" prog="3" />
-      <Patch name="Stage 73" hbank="99" lbank="0" prog="4" />
-      <Patch name="Chorus EP" hbank="99" lbank="0" prog="5" />
-      <Patch name="Enh.Harpsi" hbank="99" lbank="0" prog="6" />
-      <Patch name="Comp Clav" hbank="99" lbank="0" prog="7" />
-      <Patch name="SpaceCelesta" hbank="99" lbank="0" prog="8" />
-      <Patch name="Trem.Glocken" hbank="99" lbank="0" prog="9" />
-      <Patch name="Panning Box" hbank="99" lbank="0" prog="10" />
-      <Patch name="Trem.Vibra" hbank="99" lbank="0" prog="11" />
-      <Patch name="Enh.Marimba" hbank="99" lbank="0" prog="12" />
-      <Patch name="Enh.Xylophon" hbank="99" lbank="0" prog="13" />
-      <Patch name="Trem.Tubula" hbank="99" lbank="0" prog="14" />
-      <Patch name="Enh.Santur" hbank="99" lbank="0" prog="15" />
-      <Patch name="Perky Spin" hbank="99" lbank="0" prog="16" />
-      <Patch name="Jazzy Spin" hbank="99" lbank="0" prog="17" />
-      <Patch name="Rocker Spin" hbank="99" lbank="0" prog="18" />
-      <Patch name="Amb.Church" hbank="99" lbank="0" prog="19" />
-      <Patch name="Old Reed Org" hbank="99" lbank="0" prog="20" />
-      <Patch name="Enh.French" hbank="99" lbank="0" prog="21" />
-      <Patch name="Ld.Harmonica" hbank="99" lbank="0" prog="22" />
-      <Patch name="Enh.Bandneon" hbank="99" lbank="0" prog="23" />
-      <Patch name="Enh.Nylon Gt" hbank="99" lbank="0" prog="24" />
-      <Patch name="Comp OVSteel" hbank="99" lbank="0" prog="25" />
-      <Patch name="Lead Jazz Gt" hbank="99" lbank="0" prog="26" />
-      <Patch name="Old Clean Gt" hbank="99" lbank="0" prog="27" />
-      <Patch name="Comp Mute Gt" hbank="99" lbank="0" prog="28" />
-      <Patch name="TC Lead Gt" hbank="99" lbank="0" prog="29" />
-      <Patch name="Heavy DistGt" hbank="99" lbank="0" prog="30" />
-      <Patch name="Amp.Harm" hbank="99" lbank="0" prog="31" />
-      <Patch name="Enh.Aco Bass" hbank="99" lbank="0" prog="32" />
-      <Patch name="Pre Bass" hbank="99" lbank="0" prog="33" />
-      <Patch name="Rock Bass" hbank="99" lbank="0" prog="34" />
-      <Patch name="Cho.Fretless" hbank="99" lbank="0" prog="35" />
-      <Patch name="Phase Slap" hbank="99" lbank="0" prog="36" />
-      <Patch name="Enh.Slap Pop" hbank="99" lbank="0" prog="37" />
-      <Patch name="Dist303 Bass" hbank="99" lbank="0" prog="38" />
-      <Patch name="PhaseSq Bass" hbank="99" lbank="0" prog="39" />
-      <Patch name="Enh.Violin" hbank="99" lbank="0" prog="40" />
-      <Patch name="Enh.Viola" hbank="99" lbank="0" prog="41" />
-      <Patch name="Enh.Cello" hbank="99" lbank="0" prog="42" />
-      <Patch name="Enh.Cb" hbank="99" lbank="0" prog="43" />
-      <Patch name="St.Trem Str2" hbank="99" lbank="0" prog="44" />
-      <Patch name="Chorus Pizz" hbank="99" lbank="0" prog="45" />
-      <Patch name="Chorus Harp" hbank="99" lbank="0" prog="46" />
-      <Patch name="Enh.Timpani" hbank="99" lbank="0" prog="47" />
-      <Patch name="St.Strings 2" hbank="99" lbank="0" prog="48" />
-      <Patch name="St.Slow Str2" hbank="99" lbank="0" prog="49" />
-      <Patch name="JP Strings" hbank="99" lbank="0" prog="50" />
-      <Patch name="OB Strings" hbank="99" lbank="0" prog="51" />
-      <Patch name="Rich Choir" hbank="99" lbank="0" prog="52" />
-      <Patch name="Enh.Vox Oohs" hbank="99" lbank="0" prog="53" />
-      <Patch name="Phase SynVox" hbank="99" lbank="0" prog="54" />
-      <Patch name="Enh.Orc Hit" hbank="99" lbank="0" prog="55" />
-      <Patch name="Enh.Trumpet" hbank="99" lbank="0" prog="56" />
-      <Patch name="Enh.Trombone" hbank="99" lbank="0" prog="57" />
-      <Patch name="Chorus Tuba" hbank="99" lbank="0" prog="58" />
-      <Patch name="Enh.Muted Tp" hbank="99" lbank="0" prog="59" />
-      <Patch name="Enh.StFrHorn" hbank="99" lbank="0" prog="60" />
-      <Patch name="St.Big Brass" hbank="99" lbank="0" prog="61" />
-      <Patch name="SuperJP Brs1" hbank="99" lbank="0" prog="62" />
-      <Patch name="WarmSynHorn2" hbank="99" lbank="0" prog="63" />
-      <Patch name="Enh.Sop Sax" hbank="99" lbank="0" prog="64" />
-      <Patch name="Enh.Alto Sax" hbank="99" lbank="0" prog="65" />
-      <Patch name="Enh.TenorSax" hbank="99" lbank="0" prog="66" />
-      <Patch name="Enh.Bari Sax" hbank="99" lbank="0" prog="67" />
-      <Patch name="Enh.Oboe" hbank="99" lbank="0" prog="68" />
-      <Patch name="Enh.E Horn" hbank="99" lbank="0" prog="69" />
-      <Patch name="Enh.Bassoon" hbank="99" lbank="0" prog="70" />
-      <Patch name="Jz.Clarinet2" hbank="99" lbank="0" prog="71" />
-      <Patch name="Enh.Piccolo" hbank="99" lbank="0" prog="72" />
-      <Patch name="Enh.Flute" hbank="99" lbank="0" prog="73" />
-      <Patch name="Enh.Recorder" hbank="99" lbank="0" prog="74" />
-      <Patch name="Cho.PanFlute" hbank="99" lbank="0" prog="75" />
-      <Patch name="Phase Bottle" hbank="99" lbank="0" prog="76" />
-      <Patch name="Delay Shaku" hbank="99" lbank="0" prog="77" />
-      <Patch name="DelayWhistle" hbank="99" lbank="0" prog="78" />
-      <Patch name="DelayOcarina" hbank="99" lbank="0" prog="79" />
-      <Patch name="OBSquareLead" hbank="99" lbank="0" prog="80" />
-      <Patch name="KeySync Saw" hbank="99" lbank="0" prog="81" />
-      <Patch name="LeadCalliope" hbank="99" lbank="0" prog="82" />
-      <Patch name="Chiffers" hbank="99" lbank="0" prog="83" />
-      <Patch name="Charang Lead" hbank="99" lbank="0" prog="84" />
-      <Patch name="SoloVox Lead" hbank="99" lbank="0" prog="85" />
-      <Patch name="Flanging 5th" hbank="99" lbank="0" prog="86" />
-      <Patch name="Phase BsLead" hbank="99" lbank="0" prog="87" />
-      <Patch name="New Fantasia" hbank="99" lbank="0" prog="88" />
-      <Patch name="Phase Pad" hbank="99" lbank="0" prog="89" />
-      <Patch name="KeySyncSynth" hbank="99" lbank="0" prog="90" />
-      <Patch name="Phase Voice" hbank="99" lbank="0" prog="91" />
-      <Patch name="Ring Glass" hbank="99" lbank="0" prog="92" />
-      <Patch name="Space Pad" hbank="99" lbank="0" prog="93" />
-      <Patch name="Phase Halo" hbank="99" lbank="0" prog="94" />
-      <Patch name="Flanging Pad" hbank="99" lbank="0" prog="95" />
-      <Patch name="Reverse Rain" hbank="99" lbank="0" prog="96" />
-      <Patch name="Phase Track" hbank="99" lbank="0" prog="97" />
-      <Patch name="3D Crystal" hbank="99" lbank="0" prog="98" />
-      <Patch name="Pan Atmos" hbank="99" lbank="0" prog="99" />
-      <Patch name="Bright Star" hbank="99" lbank="0" prog="100" />
-      <Patch name="Rev Goblin" hbank="99" lbank="0" prog="101" />
-      <Patch name="Delay Drops" hbank="99" lbank="0" prog="102" />
-      <Patch name="Phase Theme" hbank="99" lbank="0" prog="103" />
-      <Patch name="Enh.Sitar" hbank="99" lbank="0" prog="104" />
-      <Patch name="St.Banjo 2" hbank="99" lbank="0" prog="105" />
-      <Patch name="St.Shamisen2" hbank="99" lbank="0" prog="106" />
-      <Patch name="St.Koto 2" hbank="99" lbank="0" prog="107" />
-      <Patch name="Trem.Kalimba" hbank="99" lbank="0" prog="108" />
-      <Patch name="Enh.Bag Pipe" hbank="99" lbank="0" prog="109" />
-      <Patch name="Enh.Fiddle" hbank="99" lbank="0" prog="110" />
-      <Patch name="Enh.Shanai" hbank="99" lbank="0" prog="111" />
-      <Patch name="Tinkle Bell" hbank="99" lbank="0" prog="112" />
-      <Patch name="Agogo" hbank="99" lbank="0" prog="113" />
-      <Patch name="Steel Drums" hbank="99" lbank="0" prog="114" />
-      <Patch name="Woodblock" hbank="99" lbank="0" prog="115" />
-      <Patch name="Taiko" hbank="99" lbank="0" prog="116" />
-      <Patch name="Melo.Tom 1" hbank="99" lbank="0" prog="117" />
-      <Patch name="Synth Drum" hbank="99" lbank="0" prog="118" />
-      <Patch name="Reverse Cym" hbank="99" lbank="0" prog="119" />
-      <Patch name="GtFret Noise" hbank="99" lbank="0" prog="120" />
-      <Patch name="Breath Noise" hbank="99" lbank="0" prog="121" />
-      <Patch name="Seashore" hbank="99" lbank="0" prog="122" />
-      <Patch name="Bird Tweet" hbank="99" lbank="0" prog="123" />
-      <Patch name="Telephone" hbank="99" lbank="0" prog="124" />
-      <Patch name="Helicopter" hbank="99" lbank="0" prog="125" />
-      <Patch name="Applause" hbank="99" lbank="0" prog="126" />
-      <Patch name="Gunshot" hbank="99" lbank="0" prog="127" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Enhanced Var #01">
-      <Patch name="SD Piano w" hbank="99" lbank="0" prog="0" />
-      <Patch name="Enh.Piano 2w" hbank="99" lbank="0" prog="1" />
-      <Patch name="Enh.E Grandw" hbank="99" lbank="0" prog="2" />
-      <Patch name="Brite Honkyw" hbank="99" lbank="0" prog="3" />
-      <Patch name="NY Rhodes" hbank="99" lbank="0" prog="4" />
-      <Patch name="Phase FM EP" hbank="99" lbank="0" prog="5" />
-      <Patch name="Enh.Coupl hp" hbank="99" lbank="0" prog="6" />
-      <Patch name="Wah Ana.Clav" hbank="99" lbank="0" prog="7" />
-      <Patch name="Trem.Vibra w" hbank="99" lbank="0" prog="11" />
-      <Patch name="Enh.Marimbaw" hbank="99" lbank="0" prog="12" />
-      <Patch name="Echo Church" hbank="99" lbank="0" prog="14" />
-      <Patch name="Gospel Spin" hbank="99" lbank="0" prog="16" />
-      <Patch name="Jazzy Spin 2" hbank="99" lbank="0" prog="17" />
-      <Patch name="Amb.Church 2" hbank="99" lbank="0" prog="19" />
-      <Patch name="Enh.Theater" hbank="99" lbank="0" prog="20" />
-      <Patch name="Enh.ItMuset" hbank="99" lbank="0" prog="21" />
-      <Patch name="Enh.Ukulele" hbank="99" lbank="0" prog="24" />
-      <Patch name="3D 12-Str.Gt" hbank="99" lbank="0" prog="25" />
-      <Patch name="Hawaian Gt" hbank="99" lbank="0" prog="26" />
-      <Patch name="Jazz Chorus" hbank="99" lbank="0" prog="27" />
-      <Patch name="Enh.Funk Gt" hbank="99" lbank="0" prog="28" />
-      <Patch name="Gt.PinchLead" hbank="99" lbank="0" prog="29" />
-      <Patch name="Feedbacker" hbank="99" lbank="0" prog="30" />
-      <Patch name="Amp.FeedBack" hbank="99" lbank="0" prog="31" />
-      <Patch name="Comp Finger" hbank="99" lbank="0" prog="33" />
-      <Patch name="P.Shift Bass" hbank="99" lbank="0" prog="38" />
-      <Patch name="Enh.Beef Bs" hbank="99" lbank="0" prog="39" />
-      <Patch name="Enh.Slow Vln" hbank="99" lbank="0" prog="40" />
-      <Patch name="Enh.Yangqin" hbank="99" lbank="0" prog="46" />
-      <Patch name="St.Orchestr2" hbank="99" lbank="0" prog="48" />
-      <Patch name="PhaseSyn.Str" hbank="99" lbank="0" prog="50" />
-      <Patch name="St.Sm Choir2" hbank="99" lbank="0" prog="52" />
-      <Patch name="Enh.Hamming" hbank="99" lbank="0" prog="53" />
-      <Patch name="Lead Ana.Vox" hbank="99" lbank="0" prog="54" />
-      <Patch name="PhaseBassHit" hbank="99" lbank="0" prog="55" />
-      <Patch name="Warm Trumpet" hbank="99" lbank="0" prog="56" />
-      <Patch name="Enh.Bone 2" hbank="99" lbank="0" prog="57" />
-      <Patch name="Enh.MutedTp2" hbank="99" lbank="0" prog="59" />
-      <Patch name="Warm Horns" hbank="99" lbank="0" prog="60" />
-      <Patch name="Enh.Brs Sect" hbank="99" lbank="0" prog="61" />
-      <Patch name="Lead Brass" hbank="99" lbank="0" prog="62" />
-      <Patch name="Phase Horn" hbank="99" lbank="0" prog="63" />
-      <Patch name="Phase Square" hbank="99" lbank="0" prog="80" />
-      <Patch name="Flanging Saw" hbank="99" lbank="0" prog="81" />
-      <Patch name="Phase Wire" hbank="99" lbank="0" prog="84" />
-      <Patch name="Suffle Lead" hbank="99" lbank="0" prog="87" />
-      <Patch name="Chorus Sine" hbank="99" lbank="0" prog="89" />
-      <Patch name="Pan Itopia" hbank="99" lbank="0" prog="91" />
-      <Patch name="Phase Mallet" hbank="99" lbank="0" prog="98" />
-      <Patch name="Delay Bell" hbank="99" lbank="0" prog="102" />
-      <Patch name="FantasySitar" hbank="99" lbank="0" prog="104" />
-      <Patch name="St.T Koto 2" hbank="99" lbank="0" prog="107" />
-      <Patch name="Castanet" hbank="99" lbank="0" prog="115" />
-      <Patch name="Concert BD" hbank="99" lbank="0" prog="116" />
-      <Patch name="Melo.Tom 2" hbank="99" lbank="0" prog="117" />
-      <Patch name="808 tom" hbank="99" lbank="0" prog="118" />
-      <Patch name="Gt.Cut Noise" hbank="99" lbank="0" prog="120" />
-      <Patch name="Fl.Key Click" hbank="99" lbank="0" prog="121" />
-      <Patch name="Rain" hbank="99" lbank="0" prog="122" />
-      <Patch name="Dog" hbank="99" lbank="0" prog="123" />
-      <Patch name="Telephone 2" hbank="99" lbank="0" prog="124" />
-      <Patch name="Car-Engine" hbank="99" lbank="0" prog="125" />
-      <Patch name="Laughing" hbank="99" lbank="0" prog="126" />
-      <Patch name="Machine Gun" hbank="99" lbank="0" prog="127" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Enhanced Var #02">
-      <Patch name="Classic Pf" hbank="99" lbank="0" prog="0" />
-      <Patch name="Phase Dyno" hbank="99" lbank="0" prog="4" />
-      <Patch name="Wah FM EP" hbank="99" lbank="0" prog="5" />
-      <Patch name="Enh.Harpsi w" hbank="99" lbank="0" prog="6" />
-      <Patch name="Trm.Carillon" hbank="99" lbank="0" prog="14" />
-      <Patch name="96 Year" hbank="99" lbank="0" prog="16" />
-      <Patch name="Jazzy Spin 3" hbank="99" lbank="0" prog="17" />
-      <Patch name="Amb.Church 3" hbank="99" lbank="0" prog="19" />
-      <Patch name="Enh.Nylon o" hbank="99" lbank="0" prog="24" />
-      <Patch name="Enh.Mandolin" hbank="99" lbank="0" prog="25" />
-      <Patch name="335 Drive" hbank="99" lbank="0" prog="27" />
-      <Patch name="Wah Funk Pop" hbank="99" lbank="0" prog="28" />
-      <Patch name="Muted OD" hbank="99" lbank="0" prog="30" />
-      <Patch name="Acid Dist Bs" hbank="99" lbank="0" prog="38" />
-      <Patch name="Fat JpSaw Bs" hbank="99" lbank="0" prog="39" />
-      <Patch name="St.OctStr 2" hbank="99" lbank="0" prog="48" />
-      <Patch name="Dly.6th Hit" hbank="99" lbank="0" prog="55" />
-      <Patch name="Enh.Br Bone" hbank="99" lbank="0" prog="57" />
-      <Patch name="Phase OctBrs" hbank="99" lbank="0" prog="62" />
-      <Patch name="Fat Pro Bras" hbank="99" lbank="0" prog="63" />
-      <Patch name="Sine Lead" hbank="99" lbank="0" prog="80" />
-      <Patch name="Doctor Lead" hbank="99" lbank="0" prog="81" />
-      <Patch name="Delay Pan" hbank="99" lbank="0" prog="102" />
-      <Patch name="Elec Perc" hbank="99" lbank="0" prog="118" />
-      <Patch name="Slap_St.Bass" hbank="99" lbank="0" prog="120" />
-      <Patch name="Thunder" hbank="99" lbank="0" prog="122" />
-      <Patch name="Horse Gallop" hbank="99" lbank="0" prog="123" />
-      <Patch name="Door Creak" hbank="99" lbank="0" prog="124" />
-      <Patch name="Car-Stop" hbank="99" lbank="0" prog="125" />
-      <Patch name="Screaming" hbank="99" lbank="0" prog="126" />
-      <Patch name="Lasergun" hbank="99" lbank="0" prog="127" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Enhanced Var #03">
-      <Patch name="Whirly" hbank="99" lbank="0" prog="4" />
-      <Patch name="Enh.Legend" hbank="99" lbank="0" prog="5" />
-      <Patch name="Enh.Harpsi o" hbank="99" lbank="0" prog="6" />
-      <Patch name="Tone Wh.Solo" hbank="99" lbank="0" prog="16" />
-      <Patch name="Enh.Gut Gt" hbank="99" lbank="0" prog="24" />
-      <Patch name="DelayedSteel" hbank="99" lbank="0" prog="25" />
-      <Patch name="Solo Jazz Gt" hbank="99" lbank="0" prog="28" />
-      <Patch name="PhaseClaviBs" hbank="99" lbank="0" prog="38" />
-      <Patch name="Enh.MG Bass" hbank="99" lbank="0" prog="39" />
-      <Patch name="Dly.Euro Hit" hbank="99" lbank="0" prog="55" />
-      <Patch name="SuperJP Brs2" hbank="99" lbank="0" prog="62" />
-      <Patch name="Fat Saw Lead" hbank="99" lbank="0" prog="81" />
-      <Patch name="Wind" hbank="99" lbank="0" prog="122" />
-      <Patch name="Bird Tweet 2" hbank="99" lbank="0" prog="123" />
-      <Patch name="Door" hbank="99" lbank="0" prog="124" />
-      <Patch name="Car-Pass" hbank="99" lbank="0" prog="125" />
-      <Patch name="Punch" hbank="99" lbank="0" prog="126" />
-      <Patch name="Explosion" hbank="99" lbank="0" prog="127" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Enhanced Var #04">
-      <Patch name="Phasing EP" hbank="99" lbank="0" prog="5" />
-      <Patch name="Enh.Hammer" hbank="99" lbank="0" prog="38" />
-      <Patch name="PhaseSeqence" hbank="99" lbank="0" prog="81" />
-      <Patch name="Stream" hbank="99" lbank="0" prog="122" />
-      <Patch name="Scratch" hbank="99" lbank="0" prog="124" />
-      <Patch name="Car-Crash" hbank="99" lbank="0" prog="125" />
-      <Patch name="Heart Beat" hbank="99" lbank="0" prog="126" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Enhanced Var #05">
-      <Patch name="Bubble" hbank="99" lbank="0" prog="122" />
-      <Patch name="Wind Chimes" hbank="99" lbank="0" prog="124" />
-      <Patch name="Siren" hbank="99" lbank="0" prog="125" />
-      <Patch name="Footsteps" hbank="99" lbank="0" prog="126" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Enhanced Var #06">
-      <Patch name="Train" hbank="99" lbank="0" prog="125" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Enhanced Var #07">
-      <Patch name="Jetplane" hbank="99" lbank="0" prog="125" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Enhanced Var #08">
-      <Patch name="Starship" hbank="99" lbank="0" prog="125" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Enhanced Var #09">
-      <Patch name="Burst Noise" hbank="99" lbank="0" prog="125" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Enhanced Drums">
-      <Patch name="Amb.Standard" hbank="107" lbank="0" prog="0" drum="1" />
-      <Patch name="Amb.Room" hbank="107" lbank="0" prog="8" drum="1" />
-      <Patch name="Gated Power" hbank="107" lbank="0" prog="16" drum="1" />
-      <Patch name="Techno Set" hbank="107" lbank="0" prog="24" drum="1" />
-      <Patch name="Bully Set" hbank="107" lbank="0" prog="25" drum="1" />
-      <Patch name="Amb.Jazz" hbank="107" lbank="0" prog="32" drum="1" />
-      <Patch name="Amb.Brush" hbank="107" lbank="0" prog="40" drum="1" />
-      <Patch name="OrchestraSet" hbank="107" lbank="0" prog="48" drum="1" />
-      <Patch name="SFX Set" hbank="107" lbank="0" prog="56" drum="1" />
-    </PatchGroup>
-    <PatchGroup name="SD90 Special1 Capital Tones">
+    <PatchGroup name="Special 1">
       <Patch name="D.L.A.Pad" hbank="80" lbank="0" prog="0" />
       <Patch name="BrushingSaw" hbank="80" lbank="0" prog="1" />
       <Patch name="Xtremities" hbank="80" lbank="0" prog="2" />
@@ -1200,7 +952,7 @@
       <Patch name="Tone Wh.Solo" hbank="80" lbank="0" prog="47" />
       <Patch name="Purple Spin" hbank="80" lbank="0" prog="48" />
       <Patch name="RingingOrgan" hbank="80" lbank="0" prog="49" />
-      <Patch name="60&apos;s LeadOrg" hbank="80" lbank="0" prog="50" />
+      <Patch name="60's LeadOrg" hbank="80" lbank="0" prog="50" />
       <Patch name="DistLead Org" hbank="80" lbank="0" prog="51" />
       <Patch name="Assalt Organ" hbank="80" lbank="0" prog="52" />
       <Patch name="Perky Spin" hbank="80" lbank="0" prog="53" />
@@ -1266,7 +1018,7 @@
       <Patch name="Power DistGt" hbank="80" lbank="0" prog="113" />
       <Patch name="Triple Gt" hbank="80" lbank="0" prog="114" />
       <Patch name="Reverse Harm" hbank="80" lbank="0" prog="115" />
-      <Patch name="Drivin&apos;Uprit" hbank="80" lbank="0" prog="116" />
+      <Patch name="Drivin'Uprit" hbank="80" lbank="0" prog="116" />
       <Patch name="Enh.Aco Bass" hbank="80" lbank="0" prog="117" />
       <Patch name="Pre Bass" hbank="80" lbank="0" prog="118" />
       <Patch name="Comp Finger" hbank="80" lbank="0" prog="119" />
@@ -1279,7 +1031,7 @@
       <Patch name="3D TB-303" hbank="80" lbank="0" prog="126" />
       <Patch name="Acid Dist Bs" hbank="80" lbank="0" prog="127" />
     </PatchGroup>
-    <PatchGroup name="SD90 Special2 Capital Tones">
+    <PatchGroup name="Special 2">
       <Patch name="Blown Bass" hbank="81" lbank="0" prog="0" />
       <Patch name="Enh.Violin" hbank="81" lbank="0" prog="1" />
       <Patch name="Solo Violin" hbank="81" lbank="0" prog="2" />
@@ -1319,7 +1071,7 @@
       <Patch name="Enh.Alto Sax" hbank="81" lbank="0" prog="36" />
       <Patch name="Enh.TenorSax" hbank="81" lbank="0" prog="37" />
       <Patch name="Enh.Bari Sax" hbank="81" lbank="0" prog="38" />
-      <Patch name="Sax&apos;s Sect" hbank="81" lbank="0" prog="39" />
+      <Patch name="Sax's Sect" hbank="81" lbank="0" prog="39" />
       <Patch name="Reed Romance" hbank="81" lbank="0" prog="40" />
       <Patch name="U.S.Patrol" hbank="81" lbank="0" prog="41" />
       <Patch name="Enh.Oboe" hbank="81" lbank="0" prog="42" />
@@ -1356,7 +1108,7 @@
       <Patch name="Koto Power" hbank="81" lbank="0" prog="73" />
       <Patch name="Dulcid Solo" hbank="81" lbank="0" prog="74" />
       <Patch name="Wine Guitar" hbank="81" lbank="0" prog="75" />
-      <Patch name="Leapin&apos; Keys" hbank="81" lbank="0" prog="76" />
+      <Patch name="Leapin' Keys" hbank="81" lbank="0" prog="76" />
       <Patch name="New Fantasia" hbank="81" lbank="0" prog="77" />
       <Patch name="MilleniumStr" hbank="81" lbank="0" prog="78" />
       <Patch name="OB Borealis" hbank="81" lbank="0" prog="79" />
@@ -1404,53 +1156,2048 @@
       <Patch name="FantasySitar" hbank="81" lbank="0" prog="121" />
       <Patch name="Rising Sun" hbank="81" lbank="0" prog="122" />
       <Patch name="Green Tea" hbank="81" lbank="0" prog="123" />
-      <Patch name="Jimmy&apos;s Koto" hbank="81" lbank="0" prog="124" />
+      <Patch name="Jimmy's Koto" hbank="81" lbank="0" prog="124" />
       <Patch name="Fly 2 India" hbank="81" lbank="0" prog="125" />
       <Patch name="IndianSpirit" hbank="81" lbank="0" prog="126" />
       <Patch name="Gt/BsNz MENU" hbank="81" lbank="0" prog="127" />
     </PatchGroup>
+    <PatchGroup name="Drums">
+      <Patch name="Standard Set" hbank="104" lbank="0" prog="0" drum="1" />
+      <Patch name="Room Set" hbank="104" lbank="0" prog="8" drum="1" />
+      <Patch name="Power Set" hbank="104" lbank="0" prog="16" drum="1" />
+      <Patch name="Electric Set" hbank="104" lbank="0" prog="24" drum="1" />
+      <Patch name="Analog Set" hbank="104" lbank="0" prog="25" drum="1" />
+      <Patch name="Jazz Set" hbank="104" lbank="0" prog="32" drum="1" />
+      <Patch name="Brush Set" hbank="104" lbank="0" prog="40" drum="1" />
+      <Patch name="OrchestraSet" hbank="104" lbank="0" prog="48" drum="1" />
+      <Patch name="SFX Set" hbank="104" lbank="0" prog="56" drum="1" />
+      <Patch name="StandardSet2" hbank="105" lbank="0" prog="0" drum="1" />
+      <Patch name="Room Set 2" hbank="105" lbank="0" prog="8" drum="1" />
+      <Patch name="Power Set 2" hbank="105" lbank="0" prog="16" drum="1" />
+      <Patch name="Dance Set" hbank="105" lbank="0" prog="24" drum="1" />
+      <Patch name="Rave Set" hbank="105" lbank="0" prog="25" drum="1" />
+      <Patch name="Jazz Set 2" hbank="105" lbank="0" prog="32" drum="1" />
+      <Patch name="Brush Set 2" hbank="105" lbank="0" prog="40" drum="1" />
+      <Patch name="St.Standard" hbank="106" lbank="0" prog="0" drum="1" />
+      <Patch name="St.Room" hbank="106" lbank="0" prog="8" drum="1" />
+      <Patch name="St.Power" hbank="106" lbank="0" prog="16" drum="1" />
+      <Patch name="Rust Set" hbank="106" lbank="0" prog="24" drum="1" />
+      <Patch name="Analog2 Set" hbank="106" lbank="0" prog="25" drum="1" />
+      <Patch name="St.Jazz" hbank="106" lbank="0" prog="32" drum="1" />
+      <Patch name="St.Brush" hbank="106" lbank="0" prog="40" drum="1" />
+      <Patch name="Amb.Standard" hbank="107" lbank="0" prog="0" drum="1" />
+      <Patch name="Amb.Room" hbank="107" lbank="0" prog="8" drum="1" />
+      <Patch name="Gated Power" hbank="107" lbank="0" prog="16" drum="1" />
+      <Patch name="Techno Set" hbank="107" lbank="0" prog="24" drum="1" />
+      <Patch name="Bully Set" hbank="107" lbank="0" prog="25" drum="1" />
+      <Patch name="Amb.Jazz" hbank="107" lbank="0" prog="32" drum="1" />
+      <Patch name="Amb.Brush" hbank="107" lbank="0" prog="40" drum="1" />
+    </PatchGroup>
     <Controller name="Modulation" l="1" />
     <Controller name="Portamento Time" l="5" />
-    <Controller name="Main Volume" l="7" init="100" drumInit="100" />
-    <Controller name="Panpot" l="10" init="64" drumInit="64" />
-    <Controller name="Expression" l="11" />
+    <Controller name="Main Volume" l="7" init="127" />
+    <Controller name="Pan" l="10" min="-64" max="63" init="0" />
+    <Controller name="Expression" l="11" init="127" />
     <Controller name="Hold 1" l="64" />
     <Controller name="Portamento" l="65" />
     <Controller name="Sostenuto" l="66" />
-    <Controller name="Soft" l="67" />
+    <Controller name="Soft Pedal" l="67" />
     <Controller name="Legato Foot Switch" l="68" />
-    <Controller name="Resonance" l="71" />
-    <Controller name="Release Time" l="72" />
-    <Controller name="Attack time" l="73" />
-    <Controller name="Cuttoff" l="74" />
-    <Controller name="Decay Time" l="75" />
-    <Controller name="Vibrato Rate" l="76" />
-    <Controller name="Vibrato Delay" l="78" />
-    <Controller name="General Purpose Controller 5" l="80" />
-    <Controller name="General Purpose Controller 6" l="81" />
-    <Controller name="General Purpose Controller 7" l="82" />
-    <Controller name="General Purpose Controller 8" l="83" />
+    <Controller name="Resonance" l="71" min="-64" max="63" init="0" />
+    <Controller name="Release Time" l="72" min="-64" max="63" init="0" />
+    <Controller name="Attack Time" l="73" min="-64" max="63" init="0" />
+    <Controller name="Cutoff" l="74" min="-64" max="63" init="0" />
+    <Controller name="Decay Time" l="75" min="-64" max="63" init="0" />
+    <Controller name="Vibrato Rate" l="76" min="-64" max="63" init="0" />
+    <Controller name="Vibrato Depth" l="77" min="-64" max="63" init="0" />
+    <Controller name="Vibrato Delay" l="78" min="-64" max="63" init="0" />
+    <Controller name="General Purpose 5" l="80" />
+    <Controller name="General Purpose 6" l="81" />
+    <Controller name="General Purpose 7" l="82" />
+    <Controller name="General Purpose 8" l="83" />
     <Controller name="Portamento Control" l="84" />
     <Controller name="Effect 1 (Reverb Send Level)" l="91" />
     <Controller name="Effect 3 (Chorus Send Level)" l="93" />
-    <Controller name="All Sounds Off" l="120" max="0" />
-    <Controller name="Reset All Controller" l="121" max="0" />
-    <Controller name="All Notes Off" l="123" max="0" />
-    <Controller name="OMNI Off" l="124" max="0" />
-    <Controller name="OMNI On" l="125" max="0" />
-    <Controller name="MONO" l="126" max="0" />
-    <Controller name="POLY" l="127" max="0" />
+    <Controller name="Pitch Bend Sensitivity" type="RPN" h="0" l="0" min="0" max="24" init="2" />
+    <Controller name="Master Fine Tuning" type="RPN14" h="0" l="1" min="-8192" max="8191" init="0" />
+    <Controller name="Master Coarse Tuning" type="RPN" h="0" l="2" min="-48" max="48" init="0" />
+    <Controller name="All Sound Off" l="120" />
+    <Controller name="Reset Controllers Off" l="121" />
+    <Controller name="All Notes Off" l="123" />
+    <Controller name="Omni Mode Off" l="124" />
+    <Controller name="Omni Mode On" l="125" />
+    <Controller name="Mono Mode On" l="126" />
+    <Controller name="Poly Mode On" l="127" />
     <Controller name="Pitch" type="Pitch" />
     <Controller name="Program" type="Program" />
+    <Controller name="Poly Aftertouch" type="PolyAftertouch" />
     <Controller name="Aftertouch" type="Aftertouch" />
-    <Controller name="PolyAftertouch" type="PolyAftertouch" />
-    <SysEx name="Native mode">
-      <data>41 10 00 48 12 00 00 00
-00 00 00</data>
-      </SysEx>
-    <Init>
-    </Init>
     <Drummaps>
+      <entry>
+        <patch_collection prog="0-7" lbank="0" hbank="104" />
+        <drummap>
+          <entry pitch="27"><name>High Q</name></entry>
+          <entry pitch="28"><name>Slap</name></entry>
+          <entry pitch="29"><name>Scratch Push</name></entry>
+          <entry pitch="30"><name>Scratch Pull</name></entry>
+          <entry pitch="31"><name>Sticks</name></entry>
+          <entry pitch="32"><name>Square Click</name></entry>
+          <entry pitch="33"><name>Metron Click</name></entry>
+          <entry pitch="34"><name>Metron Bell</name></entry>
+          <entry pitch="35"><name>Kick Drum 2</name></entry>
+          <entry pitch="36"><name>Kick Drum 1</name></entry>
+          <entry pitch="37"><name>Side Stick</name></entry>
+          <entry pitch="38"><name>Aco.Snare</name></entry>
+          <entry pitch="39"><name>Hand Clap</name></entry>
+          <entry pitch="40"><name>Elec.Snare</name></entry>
+          <entry pitch="41"><name>Low Tom 2</name></entry>
+          <entry pitch="42"><name>ClosedHi-hat</name></entry>
+          <entry pitch="43"><name>Low Tom 1</name></entry>
+          <entry pitch="44"><name>Pedal Hi-hat</name></entry>
+          <entry pitch="45"><name>Mid Tom 2</name></entry>
+          <entry pitch="46"><name>Open Hi-hat</name></entry>
+          <entry pitch="47"><name>Mid Tom 1</name></entry>
+          <entry pitch="48"><name>High Tom 2</name></entry>
+          <entry pitch="49"><name>CrashCymbal1</name></entry>
+          <entry pitch="50"><name>High Tom 1</name></entry>
+          <entry pitch="51"><name>Ride Cymbal1</name></entry>
+          <entry pitch="52"><name>China Cymbal</name></entry>
+          <entry pitch="53"><name>Ride Bell</name></entry>
+          <entry pitch="54"><name>Tambourine</name></entry>
+          <entry pitch="55"><name>SplashCymbal</name></entry>
+          <entry pitch="56"><name>Cowbell</name></entry>
+          <entry pitch="57"><name>CrashCymbal2</name></entry>
+          <entry pitch="58"><name>Vibra-slap</name></entry>
+          <entry pitch="59"><name>Ride Cymbal2</name></entry>
+          <entry pitch="60"><name>High Bongo</name></entry>
+          <entry pitch="61"><name>Low Bongo</name></entry>
+          <entry pitch="62"><name>MuteHi Conga</name></entry>
+          <entry pitch="63"><name>OpenHi Conga</name></entry>
+          <entry pitch="64"><name>Low Conga</name></entry>
+          <entry pitch="65"><name>High Timbale</name></entry>
+          <entry pitch="66"><name>Low Timbale</name></entry>
+          <entry pitch="67"><name>High Agogo</name></entry>
+          <entry pitch="68"><name>Low Agogo</name></entry>
+          <entry pitch="69"><name>Cabasa</name></entry>
+          <entry pitch="70"><name>Maracas</name></entry>
+          <entry pitch="71"><name>ShortWhistle</name></entry>
+          <entry pitch="72"><name>Long Whistle</name></entry>
+          <entry pitch="73"><name>Short Guiro</name></entry>
+          <entry pitch="74"><name>Long Guiro</name></entry>
+          <entry pitch="75"><name>Claves</name></entry>
+          <entry pitch="76"><name>Hi WoodBlock</name></entry>
+          <entry pitch="77"><name>LowWoodBlock</name></entry>
+          <entry pitch="78"><name>Mute Cuica</name></entry>
+          <entry pitch="79"><name>Open Cuica</name></entry>
+          <entry pitch="80"><name>MuteTriangle</name></entry>
+          <entry pitch="81"><name>OpenTriangle</name></entry>
+          <entry pitch="82"><name>Shaker</name></entry>
+          <entry pitch="83"><name>Jingle Bell</name></entry>
+          <entry pitch="84"><name>Bell Tree</name></entry>
+          <entry pitch="85"><name>Castanets</name></entry>
+          <entry pitch="86"><name>Mute Surdo</name></entry>
+          <entry pitch="87"><name>Open Surdo</name></entry>
+        </drummap>
+      </entry>
+      <entry>
+        <patch_collection prog="8-15" lbank="0" hbank="104" />
+        <drummap>
+          <entry pitch="27"><name>High Q</name></entry>
+          <entry pitch="28"><name>Slap</name></entry>
+          <entry pitch="29"><name>Scratch Push</name></entry>
+          <entry pitch="30"><name>Scratch Pull</name></entry>
+          <entry pitch="31"><name>Sticks</name></entry>
+          <entry pitch="32"><name>Square Click</name></entry>
+          <entry pitch="33"><name>Metron Click</name></entry>
+          <entry pitch="34"><name>Metron Bell</name></entry>
+          <entry pitch="35"><name>Kick Drum 2</name></entry>
+          <entry pitch="36"><name>Kick Drum 1</name></entry>
+          <entry pitch="37"><name>Side Stick</name></entry>
+          <entry pitch="38"><name>Room Snare</name></entry>
+          <entry pitch="39"><name>Hand Clap</name></entry>
+          <entry pitch="40"><name>Elec.Snare</name></entry>
+          <entry pitch="41"><name>Room LowTom2</name></entry>
+          <entry pitch="42"><name>ClosedHi-hat</name></entry>
+          <entry pitch="43"><name>Room LowTom1</name></entry>
+          <entry pitch="44"><name>Pedal Hi-hat</name></entry>
+          <entry pitch="45"><name>Room MidTom2</name></entry>
+          <entry pitch="46"><name>Open Hi-hat</name></entry>
+          <entry pitch="47"><name>Room MidTom1</name></entry>
+          <entry pitch="48"><name>Room Hi Tom2</name></entry>
+          <entry pitch="49"><name>CrashCymbal1</name></entry>
+          <entry pitch="50"><name>Room Hi Tom1</name></entry>
+          <entry pitch="51"><name>Ride Cymbal1</name></entry>
+          <entry pitch="52"><name>China Cymbal</name></entry>
+          <entry pitch="53"><name>Ride Bell</name></entry>
+          <entry pitch="54"><name>Tambourine</name></entry>
+          <entry pitch="55"><name>SplashCymbal</name></entry>
+          <entry pitch="56"><name>Cowbell</name></entry>
+          <entry pitch="57"><name>CrashCymbal2</name></entry>
+          <entry pitch="58"><name>Vibra-slap</name></entry>
+          <entry pitch="59"><name>Ride Cymbal2</name></entry>
+          <entry pitch="60"><name>High Bongo</name></entry>
+          <entry pitch="61"><name>Low Bongo</name></entry>
+          <entry pitch="62"><name>MuteHi Conga</name></entry>
+          <entry pitch="63"><name>OpenHi Conga</name></entry>
+          <entry pitch="64"><name>Low Conga</name></entry>
+          <entry pitch="65"><name>High Timbale</name></entry>
+          <entry pitch="66"><name>Low Timbale</name></entry>
+          <entry pitch="67"><name>High Agogo</name></entry>
+          <entry pitch="68"><name>Low Agogo</name></entry>
+          <entry pitch="69"><name>Cabasa</name></entry>
+          <entry pitch="70"><name>Maracas</name></entry>
+          <entry pitch="71"><name>ShortWhistle</name></entry>
+          <entry pitch="72"><name>Long Whistle</name></entry>
+          <entry pitch="73"><name>Short Guiro</name></entry>
+          <entry pitch="74"><name>Long Guiro</name></entry>
+          <entry pitch="75"><name>Claves</name></entry>
+          <entry pitch="76"><name>Hi WoodBlock</name></entry>
+          <entry pitch="77"><name>LowWoodBlock</name></entry>
+          <entry pitch="78"><name>Mute Cuica</name></entry>
+          <entry pitch="79"><name>Open Cuica</name></entry>
+          <entry pitch="80"><name>MuteTriangle</name></entry>
+          <entry pitch="81"><name>OpenTriangle</name></entry>
+          <entry pitch="82"><name>Shaker</name></entry>
+          <entry pitch="83"><name>Jingle Bell</name></entry>
+          <entry pitch="84"><name>Bell Tree</name></entry>
+          <entry pitch="85"><name>Castanets</name></entry>
+          <entry pitch="86"><name>Mute Surdo</name></entry>
+          <entry pitch="87"><name>Open Surdo</name></entry>
+        </drummap>
+      </entry>
+      <entry>
+        <patch_collection prog="16-23" lbank="0" hbank="104" />
+        <drummap>
+          <entry pitch="27"><name>High Q</name></entry>
+          <entry pitch="28"><name>Slap</name></entry>
+          <entry pitch="29"><name>Scratch Push</name></entry>
+          <entry pitch="30"><name>Scratch Pull</name></entry>
+          <entry pitch="31"><name>Sticks</name></entry>
+          <entry pitch="32"><name>Square Click</name></entry>
+          <entry pitch="33"><name>Metron Click</name></entry>
+          <entry pitch="34"><name>Metron Bell</name></entry>
+          <entry pitch="35"><name>Power Kick 2</name></entry>
+          <entry pitch="36"><name>Power Kick 1</name></entry>
+          <entry pitch="37"><name>Side Stick</name></entry>
+          <entry pitch="38"><name>PowerSnareDr</name></entry>
+          <entry pitch="39"><name>Hand Clap</name></entry>
+          <entry pitch="40"><name>Elec.Snare</name></entry>
+          <entry pitch="41"><name>PowerLowTom2</name></entry>
+          <entry pitch="42"><name>ClosedHi-hat</name></entry>
+          <entry pitch="43"><name>PowerLowTom1</name></entry>
+          <entry pitch="44"><name>Pedal Hi-hat</name></entry>
+          <entry pitch="45"><name>PowerMIdTom2</name></entry>
+          <entry pitch="46"><name>Open Hi-hat</name></entry>
+          <entry pitch="47"><name>PowerMIdTom1</name></entry>
+          <entry pitch="48"><name>Power HiTom2</name></entry>
+          <entry pitch="49"><name>CrashCymbal1</name></entry>
+          <entry pitch="50"><name>Power HiTom1</name></entry>
+          <entry pitch="51"><name>Ride Cymbal1</name></entry>
+          <entry pitch="52"><name>China Cymbal</name></entry>
+          <entry pitch="53"><name>Ride Bell</name></entry>
+          <entry pitch="54"><name>Tambourine</name></entry>
+          <entry pitch="55"><name>SplashCymbal</name></entry>
+          <entry pitch="56"><name>Cowbell</name></entry>
+          <entry pitch="57"><name>CrashCymbal2</name></entry>
+          <entry pitch="58"><name>Vibra-slap</name></entry>
+          <entry pitch="59"><name>Ride Cymbal2</name></entry>
+          <entry pitch="60"><name>High Bongo</name></entry>
+          <entry pitch="61"><name>Low Bongo</name></entry>
+          <entry pitch="62"><name>MuteHi Conga</name></entry>
+          <entry pitch="63"><name>OpenHi Conga</name></entry>
+          <entry pitch="64"><name>Low Conga</name></entry>
+          <entry pitch="65"><name>High Timbale</name></entry>
+          <entry pitch="66"><name>Low Timbale</name></entry>
+          <entry pitch="67"><name>High Agogo</name></entry>
+          <entry pitch="68"><name>Low Agogo</name></entry>
+          <entry pitch="69"><name>Cabasa</name></entry>
+          <entry pitch="70"><name>Maracas</name></entry>
+          <entry pitch="71"><name>ShortWhistle</name></entry>
+          <entry pitch="72"><name>Long Whistle</name></entry>
+          <entry pitch="73"><name>Short Guiro</name></entry>
+          <entry pitch="74"><name>Long Guiro</name></entry>
+          <entry pitch="75"><name>Claves</name></entry>
+          <entry pitch="76"><name>Hi WoodBlock</name></entry>
+          <entry pitch="77"><name>LowWoodBlock</name></entry>
+          <entry pitch="78"><name>Mute Cuica</name></entry>
+          <entry pitch="79"><name>Open Cuica</name></entry>
+          <entry pitch="80"><name>MuteTriangle</name></entry>
+          <entry pitch="81"><name>OpenTriangle</name></entry>
+          <entry pitch="82"><name>Shaker</name></entry>
+          <entry pitch="83"><name>Jingle Bell</name></entry>
+          <entry pitch="84"><name>Bell Tree</name></entry>
+          <entry pitch="85"><name>Castanets</name></entry>
+          <entry pitch="86"><name>Mute Surdo</name></entry>
+          <entry pitch="87"><name>Open Surdo</name></entry>
+        </drummap>
+      </entry>
+      <entry>
+        <patch_collection prog="24" lbank="0" hbank="104" />
+        <drummap>
+          <entry pitch="27"><name>High Q</name></entry>
+          <entry pitch="28"><name>Slap</name></entry>
+          <entry pitch="29"><name>Scratch Push</name></entry>
+          <entry pitch="30"><name>Scratch Pull</name></entry>
+          <entry pitch="31"><name>Sticks</name></entry>
+          <entry pitch="32"><name>Square Click</name></entry>
+          <entry pitch="33"><name>Metron Click</name></entry>
+          <entry pitch="34"><name>Metron Bell</name></entry>
+          <entry pitch="35"><name>Elec.Kick 2</name></entry>
+          <entry pitch="36"><name>Elec.Kick 1</name></entry>
+          <entry pitch="37"><name>Side Stick</name></entry>
+          <entry pitch="38"><name>E.SnareDrum1</name></entry>
+          <entry pitch="39"><name>Hand Clap</name></entry>
+          <entry pitch="40"><name>E.SnareDrum2</name></entry>
+          <entry pitch="41"><name>E.Low Tom 2</name></entry>
+          <entry pitch="42"><name>ClosedHi-hat</name></entry>
+          <entry pitch="43"><name>E.Low Tom 1</name></entry>
+          <entry pitch="44"><name>Pedal Hi-hat</name></entry>
+          <entry pitch="45"><name>E.Mid Tom 2</name></entry>
+          <entry pitch="46"><name>Open Hi-hat</name></entry>
+          <entry pitch="47"><name>E.Mid Tom 1</name></entry>
+          <entry pitch="48"><name>E.Hi Tom 2</name></entry>
+          <entry pitch="49"><name>CrashCymbal1</name></entry>
+          <entry pitch="50"><name>E.Hi Tom 1</name></entry>
+          <entry pitch="51"><name>Ride Cymbal1</name></entry>
+          <entry pitch="52"><name>Reverse Cym.</name></entry>
+          <entry pitch="53"><name>Ride Bell</name></entry>
+          <entry pitch="54"><name>Tambourine</name></entry>
+          <entry pitch="55"><name>SplashCymbal</name></entry>
+          <entry pitch="56"><name>Cowbell</name></entry>
+          <entry pitch="57"><name>CrashCymbal2</name></entry>
+          <entry pitch="58"><name>Vibra-slap</name></entry>
+          <entry pitch="59"><name>Ride Cymbal2</name></entry>
+          <entry pitch="60"><name>High Bongo</name></entry>
+          <entry pitch="61"><name>Low Bongo</name></entry>
+          <entry pitch="62"><name>MuteHi Conga</name></entry>
+          <entry pitch="63"><name>OpenHi Conga</name></entry>
+          <entry pitch="64"><name>Low Conga</name></entry>
+          <entry pitch="65"><name>High Timbale</name></entry>
+          <entry pitch="66"><name>Low Timbale</name></entry>
+          <entry pitch="67"><name>High Agogo</name></entry>
+          <entry pitch="68"><name>Low Agogo</name></entry>
+          <entry pitch="69"><name>Cabasa</name></entry>
+          <entry pitch="70"><name>Maracas</name></entry>
+          <entry pitch="71"><name>ShortWhistle</name></entry>
+          <entry pitch="72"><name>Long Whistle</name></entry>
+          <entry pitch="73"><name>Short Guiro</name></entry>
+          <entry pitch="74"><name>Long Guiro</name></entry>
+          <entry pitch="75"><name>Claves</name></entry>
+          <entry pitch="76"><name>Hi WoodBlock</name></entry>
+          <entry pitch="77"><name>LowWoodBlock</name></entry>
+          <entry pitch="78"><name>Mute Cuica</name></entry>
+          <entry pitch="79"><name>Open Cuica</name></entry>
+          <entry pitch="80"><name>MuteTriangle</name></entry>
+          <entry pitch="81"><name>OpenTriangle</name></entry>
+          <entry pitch="82"><name>Shaker</name></entry>
+          <entry pitch="83"><name>Jingle Bell</name></entry>
+          <entry pitch="84"><name>Bell Tree</name></entry>
+          <entry pitch="85"><name>Castanets</name></entry>
+          <entry pitch="86"><name>Mute Surdo</name></entry>
+          <entry pitch="87"><name>Open Surdo</name></entry>
+        </drummap>
+      </entry>
+      <entry>
+        <patch_collection prog="25-31" lbank="0" hbank="104" />
+        <drummap>
+          <entry pitch="27"><name>High Q</name></entry>
+          <entry pitch="28"><name>Slap</name></entry>
+          <entry pitch="29"><name>Scratch Push</name></entry>
+          <entry pitch="30"><name>Scratch Pull</name></entry>
+          <entry pitch="31"><name>Sticks</name></entry>
+          <entry pitch="32"><name>Square Click</name></entry>
+          <entry pitch="33"><name>Metron Click</name></entry>
+          <entry pitch="34"><name>Metron Bell</name></entry>
+          <entry pitch="35"><name>Ana.Kick 2</name></entry>
+          <entry pitch="36"><name>Ana.Kick 1</name></entry>
+          <entry pitch="37"><name>Ana.Rim Sho</name></entry>
+          <entry pitch="38"><name>Ana.Snare 1</name></entry>
+          <entry pitch="39"><name>Hand Clap</name></entry>
+          <entry pitch="40"><name>Elec.Snare</name></entry>
+          <entry pitch="41"><name>Ana.Low Tom2</name></entry>
+          <entry pitch="42"><name>Closed Hi-ha</name></entry>
+          <entry pitch="43"><name>Ana.Low Tom1</name></entry>
+          <entry pitch="44"><name>ClosedHi-hat</name></entry>
+          <entry pitch="45"><name>Ana.Mid Tom2</name></entry>
+          <entry pitch="46"><name>Closed Hi-ha</name></entry>
+          <entry pitch="47"><name>Ana.Mid Tom1</name></entry>
+          <entry pitch="48"><name>Ana.Hi Tom2</name></entry>
+          <entry pitch="49"><name>Ana.Cymbal</name></entry>
+          <entry pitch="50"><name>Ana.Hi Tom1</name></entry>
+          <entry pitch="51"><name>Ride Cymbal1</name></entry>
+          <entry pitch="52"><name>China Cymbal</name></entry>
+          <entry pitch="53"><name>Ride Bell</name></entry>
+          <entry pitch="54"><name>Tambourine</name></entry>
+          <entry pitch="55"><name>SplashCymbal</name></entry>
+          <entry pitch="56"><name>Ana.Cowbell</name></entry>
+          <entry pitch="57"><name>CrashCymbal2</name></entry>
+          <entry pitch="58"><name>Vibra-slap</name></entry>
+          <entry pitch="59"><name>Ride Cymbal2</name></entry>
+          <entry pitch="60"><name>High Bongo</name></entry>
+          <entry pitch="61"><name>Low Bongo</name></entry>
+          <entry pitch="62"><name>Ana.Hi Conga</name></entry>
+          <entry pitch="63"><name>Ana.MidConga</name></entry>
+          <entry pitch="64"><name>Ana.LowConga</name></entry>
+          <entry pitch="65"><name>High Timbale</name></entry>
+          <entry pitch="66"><name>Low Timbale</name></entry>
+          <entry pitch="67"><name>High Agogo</name></entry>
+          <entry pitch="68"><name>Low Agogo</name></entry>
+          <entry pitch="69"><name>Cabasa</name></entry>
+          <entry pitch="70"><name>Ana.Maracas</name></entry>
+          <entry pitch="71"><name>ShortWhistle</name></entry>
+          <entry pitch="72"><name>Long Whistle</name></entry>
+          <entry pitch="73"><name>Short Guiro</name></entry>
+          <entry pitch="74"><name>Long Guiro</name></entry>
+          <entry pitch="75"><name>Ana.Claves</name></entry>
+          <entry pitch="76"><name>Hi WoodBlock</name></entry>
+          <entry pitch="77"><name>LowWoodBlock</name></entry>
+          <entry pitch="78"><name>Mute Cuica</name></entry>
+          <entry pitch="79"><name>Open Cuica</name></entry>
+          <entry pitch="80"><name>MuteTriangle</name></entry>
+          <entry pitch="81"><name>OpenTriangle</name></entry>
+          <entry pitch="82"><name>Shaker</name></entry>
+          <entry pitch="83"><name>Jingle Bell</name></entry>
+          <entry pitch="84"><name>Bell Tree</name></entry>
+          <entry pitch="85"><name>Castanets</name></entry>
+          <entry pitch="86"><name>Mute Surdo</name></entry>
+          <entry pitch="87"><name>Open Surdo</name></entry>
+        </drummap>
+      </entry>
+      <entry>
+        <patch_collection prog="32-39" lbank="0" hbank="104" />
+        <drummap>
+          <entry pitch="27"><name>High Q</name></entry>
+          <entry pitch="28"><name>Slap</name></entry>
+          <entry pitch="29"><name>Scratch Push</name></entry>
+          <entry pitch="30"><name>Scratch Pull</name></entry>
+          <entry pitch="31"><name>Sticks</name></entry>
+          <entry pitch="32"><name>Square Click</name></entry>
+          <entry pitch="33"><name>Metron Click</name></entry>
+          <entry pitch="34"><name>Metron Bell</name></entry>
+          <entry pitch="35"><name>Jazz Kick 2</name></entry>
+          <entry pitch="36"><name>Jazz Kick 1</name></entry>
+          <entry pitch="37"><name>Side Stick</name></entry>
+          <entry pitch="38"><name>Aco.Snare</name></entry>
+          <entry pitch="39"><name>Hand Clap</name></entry>
+          <entry pitch="40"><name>Elec.Snare</name></entry>
+          <entry pitch="41"><name>Low Tom 2</name></entry>
+          <entry pitch="42"><name>ClosedHi-hat</name></entry>
+          <entry pitch="43"><name>Low Tom 1</name></entry>
+          <entry pitch="44"><name>Pedal Hi-hat</name></entry>
+          <entry pitch="45"><name>Mid Tom 2</name></entry>
+          <entry pitch="46"><name>Open Hi-hat</name></entry>
+          <entry pitch="47"><name>Mid Tom 1</name></entry>
+          <entry pitch="48"><name>High Tom 2</name></entry>
+          <entry pitch="49"><name>CrashCymbal1</name></entry>
+          <entry pitch="50"><name>High Tom 1</name></entry>
+          <entry pitch="51"><name>Ride Cymbal1</name></entry>
+          <entry pitch="52"><name>China Cymbal</name></entry>
+          <entry pitch="53"><name>Ride Bell</name></entry>
+          <entry pitch="54"><name>Tambourine</name></entry>
+          <entry pitch="55"><name>SplashCymbal</name></entry>
+          <entry pitch="56"><name>Cowbell</name></entry>
+          <entry pitch="57"><name>CrashCymbal2</name></entry>
+          <entry pitch="58"><name>Vibra-slap</name></entry>
+          <entry pitch="59"><name>Ride Cymbal2</name></entry>
+          <entry pitch="60"><name>High Bongo</name></entry>
+          <entry pitch="61"><name>Low Bongo</name></entry>
+          <entry pitch="62"><name>MuteHi Conga</name></entry>
+          <entry pitch="63"><name>OpenHi Conga</name></entry>
+          <entry pitch="64"><name>Low Conga</name></entry>
+          <entry pitch="65"><name>High Timbale</name></entry>
+          <entry pitch="66"><name>Low Timbale</name></entry>
+          <entry pitch="67"><name>High Agogo</name></entry>
+          <entry pitch="68"><name>Low Agogo</name></entry>
+          <entry pitch="69"><name>Cabasa</name></entry>
+          <entry pitch="70"><name>Maracas</name></entry>
+          <entry pitch="71"><name>ShortWhistle</name></entry>
+          <entry pitch="72"><name>Long Whistle</name></entry>
+          <entry pitch="73"><name>Short Guiro</name></entry>
+          <entry pitch="74"><name>Long Guiro</name></entry>
+          <entry pitch="75"><name>Claves</name></entry>
+          <entry pitch="76"><name>Hi WoodBlock</name></entry>
+          <entry pitch="77"><name>LowWoodBlock</name></entry>
+          <entry pitch="78"><name>Mute Cuica</name></entry>
+          <entry pitch="79"><name>Open Cuica</name></entry>
+          <entry pitch="80"><name>MuteTriangle</name></entry>
+          <entry pitch="81"><name>OpenTriangle</name></entry>
+          <entry pitch="82"><name>Shaker</name></entry>
+          <entry pitch="83"><name>Jingle Bell</name></entry>
+          <entry pitch="84"><name>Bell Tree</name></entry>
+          <entry pitch="85"><name>Castanets</name></entry>
+          <entry pitch="86"><name>Mute Surdo</name></entry>
+          <entry pitch="87"><name>Open Surdo</name></entry>
+        </drummap>
+      </entry>
+      <entry>
+        <patch_collection prog="40-47" lbank="0" hbank="104" />
+        <drummap>
+          <entry pitch="27"><name>High Q</name></entry>
+          <entry pitch="28"><name>Slap</name></entry>
+          <entry pitch="29"><name>Scratch Push</name></entry>
+          <entry pitch="30"><name>Scratch Pull</name></entry>
+          <entry pitch="31"><name>Sticks</name></entry>
+          <entry pitch="32"><name>Square Click</name></entry>
+          <entry pitch="33"><name>Metron Click</name></entry>
+          <entry pitch="34"><name>Metron Bell</name></entry>
+          <entry pitch="35"><name>Jazz Kick 2</name></entry>
+          <entry pitch="36"><name>Jazz Kick 1</name></entry>
+          <entry pitch="37"><name>Side Stick</name></entry>
+          <entry pitch="38"><name>Brush Tap</name></entry>
+          <entry pitch="39"><name>Brush Slap</name></entry>
+          <entry pitch="40"><name>Brush Swirl</name></entry>
+          <entry pitch="41"><name>BrushLowTom2</name></entry>
+          <entry pitch="42"><name>Closed Hi-ha</name></entry>
+          <entry pitch="43"><name>BrushLowTom1</name></entry>
+          <entry pitch="44"><name>ClosedHi-hat</name></entry>
+          <entry pitch="45"><name>BrushMidTom2</name></entry>
+          <entry pitch="46"><name>Closed Hi-ha</name></entry>
+          <entry pitch="47"><name>BrushMidTom1</name></entry>
+          <entry pitch="48"><name>Brush HiTom2</name></entry>
+          <entry pitch="49"><name>Brush Crash1</name></entry>
+          <entry pitch="50"><name>Brush HiTom1</name></entry>
+          <entry pitch="51"><name>Brush Ride 1</name></entry>
+          <entry pitch="52"><name>China Cymbal</name></entry>
+          <entry pitch="53"><name>BrushRideBel</name></entry>
+          <entry pitch="54"><name>Tambourine</name></entry>
+          <entry pitch="55"><name>SplashCymbal</name></entry>
+          <entry pitch="56"><name>Cowbell</name></entry>
+          <entry pitch="57"><name>Brush Crash2</name></entry>
+          <entry pitch="58"><name>Vibra-slap</name></entry>
+          <entry pitch="59"><name>Ride Cymbal2</name></entry>
+          <entry pitch="60"><name>High Bongo</name></entry>
+          <entry pitch="61"><name>Low Bongo</name></entry>
+          <entry pitch="62"><name>MuteHi Conga</name></entry>
+          <entry pitch="63"><name>OpenHi Conga</name></entry>
+          <entry pitch="64"><name>Low Conga</name></entry>
+          <entry pitch="65"><name>High Timbale</name></entry>
+          <entry pitch="66"><name>Low Timbale</name></entry>
+          <entry pitch="67"><name>High Agogo</name></entry>
+          <entry pitch="68"><name>Low Agogo</name></entry>
+          <entry pitch="69"><name>Cabasa</name></entry>
+          <entry pitch="70"><name>Maracas</name></entry>
+          <entry pitch="71"><name>ShortWhistle</name></entry>
+          <entry pitch="72"><name>Long Whistle</name></entry>
+          <entry pitch="73"><name>Short Guiro</name></entry>
+          <entry pitch="74"><name>Long Guiro</name></entry>
+          <entry pitch="75"><name>Claves</name></entry>
+          <entry pitch="76"><name>Hi WoodBlock</name></entry>
+          <entry pitch="77"><name>LowWoodBlock</name></entry>
+          <entry pitch="78"><name>Mute Cuica</name></entry>
+          <entry pitch="79"><name>Open Cuica</name></entry>
+          <entry pitch="80"><name>MuteTriangle</name></entry>
+          <entry pitch="81"><name>OpenTriangle</name></entry>
+          <entry pitch="82"><name>Shaker</name></entry>
+          <entry pitch="83"><name>Jingle Bell</name></entry>
+          <entry pitch="84"><name>Bell Tree</name></entry>
+          <entry pitch="85"><name>Castanets</name></entry>
+          <entry pitch="86"><name>Mute Surdo</name></entry>
+          <entry pitch="87"><name>Open Surdo</name></entry>
+        </drummap>
+      </entry>
+      <entry>
+        <patch_collection prog="48-55" lbank="0" hbank="104" />
+        <drummap>
+          <entry pitch="27"><name>ClosedHi-hat</name></entry>
+          <entry pitch="28"><name>Pedal Hi-hat</name></entry>
+          <entry pitch="29"><name>Open Hi-hat</name></entry>
+          <entry pitch="30"><name>Ride Cymbal1</name></entry>
+          <entry pitch="31"><name>Sticks</name></entry>
+          <entry pitch="32"><name>Square Click</name></entry>
+          <entry pitch="33"><name>Metron Click</name></entry>
+          <entry pitch="34"><name>Metron Bell</name></entry>
+          <entry pitch="35"><name>Concert BD 2</name></entry>
+          <entry pitch="36"><name>Concert BD 1</name></entry>
+          <entry pitch="37"><name>Side Stick</name></entry>
+          <entry pitch="38"><name>Concert SD</name></entry>
+          <entry pitch="39"><name>Castanets</name></entry>
+          <entry pitch="40"><name>Concert SD</name></entry>
+          <entry pitch="41"><name>Timpani F</name></entry>
+          <entry pitch="42"><name>Timpani F#</name></entry>
+          <entry pitch="43"><name>Timpani G</name></entry>
+          <entry pitch="44"><name>Timpani G#</name></entry>
+          <entry pitch="45"><name>Timpani A</name></entry>
+          <entry pitch="46"><name>Timpani A#</name></entry>
+          <entry pitch="47"><name>Timpani B</name></entry>
+          <entry pitch="48"><name>Timpani c</name></entry>
+          <entry pitch="49"><name>Timpani c#</name></entry>
+          <entry pitch="50"><name>Timpani d</name></entry>
+          <entry pitch="51"><name>Timpani d#</name></entry>
+          <entry pitch="52"><name>Timpani e</name></entry>
+          <entry pitch="53"><name>Timpani f</name></entry>
+          <entry pitch="54"><name>Tambourine</name></entry>
+          <entry pitch="55"><name>SplashCymbal</name></entry>
+          <entry pitch="56"><name>Cowbell</name></entry>
+          <entry pitch="57"><name>Concert Cym2</name></entry>
+          <entry pitch="58"><name>Vibra-slap</name></entry>
+          <entry pitch="59"><name>Concert Cym1</name></entry>
+          <entry pitch="60"><name>High Bongo</name></entry>
+          <entry pitch="61"><name>Low Bongo</name></entry>
+          <entry pitch="62"><name>MuteHi Conga</name></entry>
+          <entry pitch="63"><name>OpenHi Conga</name></entry>
+          <entry pitch="64"><name>Low Conga</name></entry>
+          <entry pitch="65"><name>High Timbale</name></entry>
+          <entry pitch="66"><name>Low Timbale</name></entry>
+          <entry pitch="67"><name>High Agogo</name></entry>
+          <entry pitch="68"><name>Low Agogo</name></entry>
+          <entry pitch="69"><name>Cabasa</name></entry>
+          <entry pitch="70"><name>Maracas</name></entry>
+          <entry pitch="71"><name>ShortWhistle</name></entry>
+          <entry pitch="72"><name>Long Whistle</name></entry>
+          <entry pitch="73"><name>Short Guiro</name></entry>
+          <entry pitch="74"><name>Long Guiro</name></entry>
+          <entry pitch="75"><name>Claves</name></entry>
+          <entry pitch="76"><name>Hi WoodBlock</name></entry>
+          <entry pitch="77"><name>LowWoodBlock</name></entry>
+          <entry pitch="78"><name>Mute Cuica</name></entry>
+          <entry pitch="79"><name>Open Cuica</name></entry>
+          <entry pitch="80"><name>MuteTriangle</name></entry>
+          <entry pitch="81"><name>OpenTriangle</name></entry>
+          <entry pitch="82"><name>Shaker</name></entry>
+          <entry pitch="83"><name>Jingle Bell</name></entry>
+          <entry pitch="84"><name>Bell Tree</name></entry>
+          <entry pitch="85"><name>Castanets</name></entry>
+          <entry pitch="86"><name>Mute Surdo</name></entry>
+          <entry pitch="87"><name>Open Surdo</name></entry>
+        </drummap>
+      </entry>
+      <entry>
+        <patch_collection prog="56-126" lbank="0" hbank="104" />
+        <drummap>
+          <entry pitch="39"><name>High Q</name></entry>
+          <entry pitch="40"><name>Slap</name></entry>
+          <entry pitch="41"><name>Scratch Push</name></entry>
+          <entry pitch="42"><name>Scratch Pull</name></entry>
+          <entry pitch="43"><name>Sticks</name></entry>
+          <entry pitch="44"><name>Square Click</name></entry>
+          <entry pitch="45"><name>Metron Click</name></entry>
+          <entry pitch="46"><name>Metron Bell</name></entry>
+          <entry pitch="47"><name>GtFret Noise</name></entry>
+          <entry pitch="48"><name>Cut Noise Up</name></entry>
+          <entry pitch="49"><name>Cut Noise Dw</name></entry>
+          <entry pitch="50"><name>Slap_St.Bass</name></entry>
+          <entry pitch="51"><name>Fl.Key Click</name></entry>
+          <entry pitch="52"><name>Laughing</name></entry>
+          <entry pitch="53"><name>Scream</name></entry>
+          <entry pitch="54"><name>Punch</name></entry>
+          <entry pitch="55"><name>Heart Beat</name></entry>
+          <entry pitch="56"><name>Footsteps 1</name></entry>
+          <entry pitch="57"><name>Footsteps 2</name></entry>
+          <entry pitch="58"><name>Applause</name></entry>
+          <entry pitch="59"><name>Door Creak</name></entry>
+          <entry pitch="60"><name>Door</name></entry>
+          <entry pitch="61"><name>Scratch</name></entry>
+          <entry pitch="62"><name>Wind Chimes</name></entry>
+          <entry pitch="63"><name>Car-Engine</name></entry>
+          <entry pitch="64"><name>Car-Stop</name></entry>
+          <entry pitch="65"><name>Car-Pass</name></entry>
+          <entry pitch="66"><name>Car-Crash</name></entry>
+          <entry pitch="67"><name>Siren</name></entry>
+          <entry pitch="68"><name>Train</name></entry>
+          <entry pitch="69"><name>Jetplane</name></entry>
+          <entry pitch="70"><name>Helicopter</name></entry>
+          <entry pitch="71"><name>Starship</name></entry>
+          <entry pitch="72"><name>Gun Shot</name></entry>
+          <entry pitch="73"><name>Machine Gun</name></entry>
+          <entry pitch="74"><name>Lasergun</name></entry>
+          <entry pitch="75"><name>Explosion</name></entry>
+          <entry pitch="76"><name>Dog</name></entry>
+          <entry pitch="77"><name>Horse-Gallop</name></entry>
+          <entry pitch="78"><name>Birds</name></entry>
+          <entry pitch="79"><name>Rain</name></entry>
+          <entry pitch="80"><name>Thunder</name></entry>
+          <entry pitch="81"><name>Wind</name></entry>
+          <entry pitch="82"><name>Seashore</name></entry>
+          <entry pitch="83"><name>Stream</name></entry>
+          <entry pitch="84"><name>Bubble</name></entry>
+        </drummap>
+      </entry>
+      <entry>
+        <patch_collection prog="0-7" lbank="0" hbank="105" />
+        <drummap>
+          <entry pitch="27"><name>High Q</name></entry>
+          <entry pitch="28"><name>Slap</name></entry>
+          <entry pitch="29"><name>Scratch Push</name></entry>
+          <entry pitch="30"><name>Scratch Pull</name></entry>
+          <entry pitch="31"><name>Sticks</name></entry>
+          <entry pitch="32"><name>Square Click</name></entry>
+          <entry pitch="33"><name>Metron Click</name></entry>
+          <entry pitch="34"><name>Metron Bell</name></entry>
+          <entry pitch="35"><name>Kick Drum 2</name></entry>
+          <entry pitch="36"><name>Kick Drum 1</name></entry>
+          <entry pitch="37"><name>Side Stick</name></entry>
+          <entry pitch="38"><name>Aco. Snare</name></entry>
+          <entry pitch="39"><name>Hand Clap</name></entry>
+          <entry pitch="40"><name>Elec. Snare</name></entry>
+          <entry pitch="41"><name>Low Tom 2</name></entry>
+          <entry pitch="42"><name>ClosedHi-hat</name></entry>
+          <entry pitch="43"><name>Low Tom 1</name></entry>
+          <entry pitch="44"><name>Pedal Hi-hat</name></entry>
+          <entry pitch="45"><name>Mid Tom 2</name></entry>
+          <entry pitch="46"><name>Open Hi-hat</name></entry>
+          <entry pitch="47"><name>Mid Tom 1</name></entry>
+          <entry pitch="48"><name>High Tom 2</name></entry>
+          <entry pitch="49"><name>CrashCymbal1</name></entry>
+          <entry pitch="50"><name>High Tom 1</name></entry>
+          <entry pitch="51"><name>Ride Cymbal1</name></entry>
+          <entry pitch="52"><name>China Cymbal</name></entry>
+          <entry pitch="53"><name>Ride Bell</name></entry>
+          <entry pitch="54"><name>Tambourine</name></entry>
+          <entry pitch="55"><name>SplashCymbal</name></entry>
+          <entry pitch="56"><name>Cowbell</name></entry>
+          <entry pitch="57"><name>CrashCymbal2</name></entry>
+          <entry pitch="58"><name>Vibra-slap</name></entry>
+          <entry pitch="59"><name>Ride Cymbal2</name></entry>
+          <entry pitch="60"><name>High Bongo</name></entry>
+          <entry pitch="61"><name>Low Bongo</name></entry>
+          <entry pitch="62"><name>MuteHi Conga</name></entry>
+          <entry pitch="63"><name>OpenHi Conga</name></entry>
+          <entry pitch="64"><name>Low Conga</name></entry>
+          <entry pitch="65"><name>High Timbale</name></entry>
+          <entry pitch="66"><name>Low Timbale</name></entry>
+          <entry pitch="67"><name>High Agogo</name></entry>
+          <entry pitch="68"><name>Low Agogo</name></entry>
+          <entry pitch="69"><name>Cabasa</name></entry>
+          <entry pitch="70"><name>Maracas</name></entry>
+          <entry pitch="71"><name>ShortWhistle</name></entry>
+          <entry pitch="72"><name>Long Whistle</name></entry>
+          <entry pitch="73"><name>Short Guiro</name></entry>
+          <entry pitch="74"><name>Long Guiro</name></entry>
+          <entry pitch="75"><name>Claves</name></entry>
+          <entry pitch="76"><name>Hi WoodBlock</name></entry>
+          <entry pitch="77"><name>LowWoodBlock</name></entry>
+          <entry pitch="78"><name>Mute Cuica</name></entry>
+          <entry pitch="79"><name>Open Cuica</name></entry>
+          <entry pitch="80"><name>MuteTriangle</name></entry>
+          <entry pitch="81"><name>OpenTriangle</name></entry>
+          <entry pitch="82"><name>Shaker</name></entry>
+          <entry pitch="83"><name>Jingle Bell</name></entry>
+          <entry pitch="84"><name>Bell Tree</name></entry>
+          <entry pitch="85"><name>Castanets</name></entry>
+          <entry pitch="86"><name>Mute Surdo</name></entry>
+          <entry pitch="87"><name>Open Surdo</name></entry>
+        </drummap>
+      </entry>
+      <entry>
+        <patch_collection prog="8-15" lbank="0" hbank="105" />
+        <drummap>
+          <entry pitch="27"><name>High Q</name></entry>
+          <entry pitch="28"><name>Slap</name></entry>
+          <entry pitch="29"><name>Scratch Push</name></entry>
+          <entry pitch="30"><name>Scratch Pull</name></entry>
+          <entry pitch="31"><name>Sticks</name></entry>
+          <entry pitch="32"><name>Square Click</name></entry>
+          <entry pitch="33"><name>Metron Click</name></entry>
+          <entry pitch="34"><name>Metron Bell</name></entry>
+          <entry pitch="35"><name>Kick Drum 2</name></entry>
+          <entry pitch="36"><name>Kick Drum 1</name></entry>
+          <entry pitch="37"><name>Side Stick</name></entry>
+          <entry pitch="38"><name>Room Snare</name></entry>
+          <entry pitch="39"><name>Hand Clap</name></entry>
+          <entry pitch="40"><name>Elec.Snare</name></entry>
+          <entry pitch="41"><name>Room LowTom2</name></entry>
+          <entry pitch="42"><name>ClosedHi-hat</name></entry>
+          <entry pitch="43"><name>Room LowTom1</name></entry>
+          <entry pitch="44"><name>Pedal Hi-hat</name></entry>
+          <entry pitch="45"><name>Room MidTom2</name></entry>
+          <entry pitch="46"><name>Open Hi-hat</name></entry>
+          <entry pitch="47"><name>Room MidTom1</name></entry>
+          <entry pitch="48"><name>Room Hi Tom2</name></entry>
+          <entry pitch="49"><name>CrashCymbal1</name></entry>
+          <entry pitch="50"><name>Room Hi Tom1</name></entry>
+          <entry pitch="51"><name>Ride Cymbal1</name></entry>
+          <entry pitch="52"><name>China Cymbal</name></entry>
+          <entry pitch="53"><name>Ride Bell</name></entry>
+          <entry pitch="54"><name>Tambourine</name></entry>
+          <entry pitch="55"><name>SplashCymbal</name></entry>
+          <entry pitch="56"><name>Cowbell</name></entry>
+          <entry pitch="57"><name>CrashCymbal2</name></entry>
+          <entry pitch="58"><name>Vibra-slap</name></entry>
+          <entry pitch="59"><name>Ride Cymbal2</name></entry>
+          <entry pitch="60"><name>High Bongo</name></entry>
+          <entry pitch="61"><name>Low Bongo</name></entry>
+          <entry pitch="62"><name>MuteHi Conga</name></entry>
+          <entry pitch="63"><name>OpenHi Conga</name></entry>
+          <entry pitch="64"><name>Low Conga</name></entry>
+          <entry pitch="65"><name>High Timbale</name></entry>
+          <entry pitch="66"><name>Low Timbale</name></entry>
+          <entry pitch="67"><name>High Agogo</name></entry>
+          <entry pitch="68"><name>Low Agogo</name></entry>
+          <entry pitch="69"><name>Cabasa</name></entry>
+          <entry pitch="70"><name>Maracas</name></entry>
+          <entry pitch="71"><name>ShortWhistle</name></entry>
+          <entry pitch="72"><name>Long Whistle</name></entry>
+          <entry pitch="73"><name>Short Guiro</name></entry>
+          <entry pitch="74"><name>Long Guiro</name></entry>
+          <entry pitch="75"><name>Claves</name></entry>
+          <entry pitch="76"><name>Hi WoodBlock</name></entry>
+          <entry pitch="77"><name>LowWoodBlock</name></entry>
+          <entry pitch="78"><name>Mute Cuica</name></entry>
+          <entry pitch="79"><name>Open Cuica</name></entry>
+          <entry pitch="80"><name>MuteTriangle</name></entry>
+          <entry pitch="81"><name>OpenTriangle</name></entry>
+          <entry pitch="82"><name>Shaker</name></entry>
+          <entry pitch="83"><name>Jingle Bell</name></entry>
+          <entry pitch="84"><name>Bell Tree</name></entry>
+          <entry pitch="85"><name>Castanets</name></entry>
+          <entry pitch="86"><name>Mute Surdo</name></entry>
+          <entry pitch="87"><name>Open Surdo</name></entry>
+        </drummap>
+      </entry>
+      <entry>
+        <patch_collection prog="16-23" lbank="0" hbank="105" />
+        <drummap>
+          <entry pitch="27"><name>High Q</name></entry>
+          <entry pitch="28"><name>Slap</name></entry>
+          <entry pitch="29"><name>Scratch Push</name></entry>
+          <entry pitch="30"><name>Scratch Pull</name></entry>
+          <entry pitch="31"><name>Sticks</name></entry>
+          <entry pitch="32"><name>Square Click</name></entry>
+          <entry pitch="33"><name>Metron Click</name></entry>
+          <entry pitch="34"><name>Metron Bell</name></entry>
+          <entry pitch="35"><name>Power Kick 2</name></entry>
+          <entry pitch="36"><name>Power Kick 1</name></entry>
+          <entry pitch="37"><name>Side Stick</name></entry>
+          <entry pitch="38"><name>PowerSnareDr</name></entry>
+          <entry pitch="39"><name>Hand Clap</name></entry>
+          <entry pitch="40"><name>Elec.Snare</name></entry>
+          <entry pitch="41"><name>PowerLowTom2</name></entry>
+          <entry pitch="42"><name>ClosedHi-hat</name></entry>
+          <entry pitch="43"><name>PowerLowTom1</name></entry>
+          <entry pitch="44"><name>Pedal Hi-hat</name></entry>
+          <entry pitch="45"><name>PowerMIdTom2</name></entry>
+          <entry pitch="46"><name>Open Hi-hat</name></entry>
+          <entry pitch="47"><name>PowerMIdTom1</name></entry>
+          <entry pitch="48"><name>Power HiTom2</name></entry>
+          <entry pitch="49"><name>CrashCymbal1</name></entry>
+          <entry pitch="50"><name>Power HiTom1</name></entry>
+          <entry pitch="51"><name>Ride Cymbal1</name></entry>
+          <entry pitch="52"><name>China Cymbal</name></entry>
+          <entry pitch="53"><name>Ride Bell</name></entry>
+          <entry pitch="54"><name>Tambourine</name></entry>
+          <entry pitch="55"><name>SplashCymbal</name></entry>
+          <entry pitch="56"><name>Cowbell</name></entry>
+          <entry pitch="57"><name>CrashCymbal2</name></entry>
+          <entry pitch="58"><name>Vibra-slap</name></entry>
+          <entry pitch="59"><name>Ride Cymbal2</name></entry>
+          <entry pitch="60"><name>High Bongo</name></entry>
+          <entry pitch="61"><name>Low Bongo</name></entry>
+          <entry pitch="62"><name>MuteHi Conga</name></entry>
+          <entry pitch="63"><name>OpenHi Conga</name></entry>
+          <entry pitch="64"><name>Low Conga</name></entry>
+          <entry pitch="65"><name>High Timbale</name></entry>
+          <entry pitch="66"><name>Low Timbale</name></entry>
+          <entry pitch="67"><name>High Agogo</name></entry>
+          <entry pitch="68"><name>Low Agogo</name></entry>
+          <entry pitch="69"><name>Cabasa</name></entry>
+          <entry pitch="70"><name>Maracas</name></entry>
+          <entry pitch="71"><name>ShortWhistle</name></entry>
+          <entry pitch="72"><name>Long Whistle</name></entry>
+          <entry pitch="73"><name>Short Guiro</name></entry>
+          <entry pitch="74"><name>Long Guiro</name></entry>
+          <entry pitch="75"><name>Claves</name></entry>
+          <entry pitch="76"><name>Hi WoodBlock</name></entry>
+          <entry pitch="77"><name>LowWoodBlock</name></entry>
+          <entry pitch="78"><name>Mute Cuica</name></entry>
+          <entry pitch="79"><name>Open Cuica</name></entry>
+          <entry pitch="80"><name>MuteTriangle</name></entry>
+          <entry pitch="81"><name>OpenTriangle</name></entry>
+          <entry pitch="82"><name>Shaker</name></entry>
+          <entry pitch="83"><name>Jingle Bell</name></entry>
+          <entry pitch="84"><name>Bell Tree</name></entry>
+          <entry pitch="85"><name>Castanets</name></entry>
+          <entry pitch="86"><name>Mute Surdo</name></entry>
+          <entry pitch="87"><name>Open Surdo</name></entry>
+        </drummap>
+      </entry>
+      <entry>
+        <patch_collection prog="24" lbank="0" hbank="105" />
+        <drummap>
+          <entry pitch="27"><name>High Q</name></entry>
+          <entry pitch="28"><name>Slap</name></entry>
+          <entry pitch="29"><name>Scratch Push</name></entry>
+          <entry pitch="30"><name>Scratch Pull</name></entry>
+          <entry pitch="31"><name>Sticks</name></entry>
+          <entry pitch="32"><name>Square Click</name></entry>
+          <entry pitch="33"><name>Metron Click</name></entry>
+          <entry pitch="34"><name>Metron Bell</name></entry>
+          <entry pitch="35"><name>Dance Kick</name></entry>
+          <entry pitch="36"><name>Techno Kick</name></entry>
+          <entry pitch="37"><name>Side Stick</name></entry>
+          <entry pitch="38"><name>Dance Snare</name></entry>
+          <entry pitch="39"><name>Hand Clap</name></entry>
+          <entry pitch="40"><name>Raga Snare</name></entry>
+          <entry pitch="41"><name>Ana.Low Tom2</name></entry>
+          <entry pitch="42"><name>Closed Hi-ha</name></entry>
+          <entry pitch="43"><name>Ana.Low Tom1</name></entry>
+          <entry pitch="44"><name>ClosedHi-hat</name></entry>
+          <entry pitch="45"><name>Ana.Mid Tom2</name></entry>
+          <entry pitch="46"><name>Open Hi-hat</name></entry>
+          <entry pitch="47"><name>Ana.Mid Tom1</name></entry>
+          <entry pitch="48"><name>Ana.Hi Tom2</name></entry>
+          <entry pitch="49"><name>CrashCymbal1</name></entry>
+          <entry pitch="50"><name>Ana.Hi Tom1</name></entry>
+          <entry pitch="51"><name>Ride Cymbal1</name></entry>
+          <entry pitch="52"><name>Reverse Cym.</name></entry>
+          <entry pitch="53"><name>Ride Bell</name></entry>
+          <entry pitch="54"><name>Tambourine</name></entry>
+          <entry pitch="55"><name>SplashCymbal</name></entry>
+          <entry pitch="56"><name>Cowbell</name></entry>
+          <entry pitch="57"><name>CrashCymbal2</name></entry>
+          <entry pitch="58"><name>Vibra-slap</name></entry>
+          <entry pitch="59"><name>Ride Cymbal2</name></entry>
+          <entry pitch="60"><name>High Bongo</name></entry>
+          <entry pitch="61"><name>Low Bongo</name></entry>
+          <entry pitch="62"><name>MuteHi Conga</name></entry>
+          <entry pitch="63"><name>OpenHi Conga</name></entry>
+          <entry pitch="64"><name>Low Conga</name></entry>
+          <entry pitch="65"><name>High Timbale</name></entry>
+          <entry pitch="66"><name>Low Timbale</name></entry>
+          <entry pitch="67"><name>High Agogo</name></entry>
+          <entry pitch="68"><name>Low Agogo</name></entry>
+          <entry pitch="69"><name>Cabasa</name></entry>
+          <entry pitch="70"><name>Maracas</name></entry>
+          <entry pitch="71"><name>ShortWhistle</name></entry>
+          <entry pitch="72"><name>Long Whistle</name></entry>
+          <entry pitch="73"><name>Short Guiro</name></entry>
+          <entry pitch="74"><name>Long Guiro</name></entry>
+          <entry pitch="75"><name>Claves</name></entry>
+          <entry pitch="76"><name>Hi WoodBlock</name></entry>
+          <entry pitch="77"><name>LowWoodBlock</name></entry>
+          <entry pitch="78"><name>Mute Cuica</name></entry>
+          <entry pitch="79"><name>Open Cuica</name></entry>
+          <entry pitch="80"><name>MuteTriangle</name></entry>
+          <entry pitch="81"><name>OpenTriangle</name></entry>
+          <entry pitch="82"><name>Shaker</name></entry>
+          <entry pitch="83"><name>Jingle Bell</name></entry>
+          <entry pitch="84"><name>Bell Tree</name></entry>
+          <entry pitch="85"><name>Castanets</name></entry>
+          <entry pitch="86"><name>Mute Surdo</name></entry>
+          <entry pitch="87"><name>Open Surdo</name></entry>
+        </drummap>
+      </entry>
+      <entry>
+        <patch_collection prog="25-31" lbank="0" hbank="105" />
+        <drummap>
+          <entry pitch="27"><name>High Q</name></entry>
+          <entry pitch="28"><name>Slap</name></entry>
+          <entry pitch="29"><name>Scratch Push</name></entry>
+          <entry pitch="30"><name>Scratch Pull</name></entry>
+          <entry pitch="31"><name>Sticks</name></entry>
+          <entry pitch="32"><name>Square Click</name></entry>
+          <entry pitch="33"><name>Metron Click</name></entry>
+          <entry pitch="34"><name>Metron Bell</name></entry>
+          <entry pitch="35"><name>808 Kick</name></entry>
+          <entry pitch="36"><name>Round Kick</name></entry>
+          <entry pitch="37"><name>Ana.Rim Shot</name></entry>
+          <entry pitch="38"><name>808 Snare</name></entry>
+          <entry pitch="39"><name>Hand Clap</name></entry>
+          <entry pitch="40"><name>Elec.Snare</name></entry>
+          <entry pitch="41"><name>808LowTom 2</name></entry>
+          <entry pitch="42"><name>Closed Hi-ha</name></entry>
+          <entry pitch="43"><name>808LowTom 1</name></entry>
+          <entry pitch="44"><name>Closed Hi-ha</name></entry>
+          <entry pitch="45"><name>808MidTom 2</name></entry>
+          <entry pitch="46"><name>ClosedHi-hat</name></entry>
+          <entry pitch="47"><name>808MidTom 1</name></entry>
+          <entry pitch="48"><name>808Hi Tom 2</name></entry>
+          <entry pitch="49"><name>Ana.Cymbal</name></entry>
+          <entry pitch="50"><name>808Hi Tom 1</name></entry>
+          <entry pitch="51"><name>Ride Cymbal1</name></entry>
+          <entry pitch="52"><name>China Cymbal</name></entry>
+          <entry pitch="53"><name>Ride Bell</name></entry>
+          <entry pitch="54"><name>Tambourine</name></entry>
+          <entry pitch="55"><name>SplashCymbal</name></entry>
+          <entry pitch="56"><name>Ana.Cowbell</name></entry>
+          <entry pitch="57"><name>CrashCymbal2</name></entry>
+          <entry pitch="58"><name>Vibra-slap</name></entry>
+          <entry pitch="59"><name>Ride Cymbal2</name></entry>
+          <entry pitch="60"><name>High Bongo</name></entry>
+          <entry pitch="61"><name>Low Bongo</name></entry>
+          <entry pitch="62"><name>Ana.Hi Conga</name></entry>
+          <entry pitch="63"><name>Ana.MidConga</name></entry>
+          <entry pitch="64"><name>Ana.LowConga</name></entry>
+          <entry pitch="65"><name>High Timbale</name></entry>
+          <entry pitch="66"><name>Low Timbale</name></entry>
+          <entry pitch="67"><name>High Agogo</name></entry>
+          <entry pitch="68"><name>Low Agogo</name></entry>
+          <entry pitch="69"><name>Cabasa</name></entry>
+          <entry pitch="70"><name>Ana.Maracas</name></entry>
+          <entry pitch="71"><name>ShortWhistle</name></entry>
+          <entry pitch="72"><name>Long Whistle</name></entry>
+          <entry pitch="73"><name>Short Guiro</name></entry>
+          <entry pitch="74"><name>Long Guiro</name></entry>
+          <entry pitch="75"><name>Ana.Claves</name></entry>
+          <entry pitch="76"><name>Hi WoodBlock</name></entry>
+          <entry pitch="77"><name>LowWoodBlock</name></entry>
+          <entry pitch="78"><name>Mute Cuica</name></entry>
+          <entry pitch="79"><name>Open Cuica</name></entry>
+          <entry pitch="80"><name>MuteTriangle</name></entry>
+          <entry pitch="81"><name>OpenTriangle</name></entry>
+          <entry pitch="82"><name>Shaker</name></entry>
+          <entry pitch="83"><name>Jingle Bell</name></entry>
+          <entry pitch="84"><name>Bell Tree</name></entry>
+          <entry pitch="85"><name>Castanets</name></entry>
+          <entry pitch="86"><name>Mute Surdo</name></entry>
+          <entry pitch="87"><name>Open Surdo</name></entry>
+        </drummap>
+      </entry>
+      <entry>
+        <patch_collection prog="32-39" lbank="0" hbank="105" />
+        <drummap>
+          <entry pitch="27"><name>High Q</name></entry>
+          <entry pitch="28"><name>Slap</name></entry>
+          <entry pitch="29"><name>Scratch Push</name></entry>
+          <entry pitch="30"><name>Scratch Pull</name></entry>
+          <entry pitch="31"><name>Sticks</name></entry>
+          <entry pitch="32"><name>Square Click</name></entry>
+          <entry pitch="33"><name>Metron Click</name></entry>
+          <entry pitch="34"><name>Metron Bell</name></entry>
+          <entry pitch="35"><name>Jazz Kick 2</name></entry>
+          <entry pitch="36"><name>Jazz Kick 1</name></entry>
+          <entry pitch="37"><name>Side Stick</name></entry>
+          <entry pitch="38"><name>Jazz Snare</name></entry>
+          <entry pitch="39"><name>Hand Clap</name></entry>
+          <entry pitch="40"><name>Elec.Snare</name></entry>
+          <entry pitch="41"><name>Low Tom 2</name></entry>
+          <entry pitch="42"><name>ClosedHi-hat</name></entry>
+          <entry pitch="43"><name>Low Tom 1</name></entry>
+          <entry pitch="44"><name>Pedal Hi-hat</name></entry>
+          <entry pitch="45"><name>Mid Tom 2</name></entry>
+          <entry pitch="46"><name>Open Hi-hat</name></entry>
+          <entry pitch="47"><name>Mid Tom 1</name></entry>
+          <entry pitch="48"><name>High Tom 2</name></entry>
+          <entry pitch="49"><name>CrashCymbal1</name></entry>
+          <entry pitch="50"><name>High Tom 1</name></entry>
+          <entry pitch="51"><name>Ride Cymbal1</name></entry>
+          <entry pitch="52"><name>China Cymbal</name></entry>
+          <entry pitch="53"><name>Ride Bell</name></entry>
+          <entry pitch="54"><name>Tambourine</name></entry>
+          <entry pitch="55"><name>SplashCymbal</name></entry>
+          <entry pitch="56"><name>Cowbell</name></entry>
+          <entry pitch="57"><name>CrashCymbal2</name></entry>
+          <entry pitch="58"><name>Vibra-slap</name></entry>
+          <entry pitch="59"><name>Ride Cymbal2</name></entry>
+          <entry pitch="60"><name>High Bongo</name></entry>
+          <entry pitch="61"><name>Low Bongo</name></entry>
+          <entry pitch="62"><name>MuteHi Conga</name></entry>
+          <entry pitch="63"><name>OpenHi Conga</name></entry>
+          <entry pitch="64"><name>Low Conga</name></entry>
+          <entry pitch="65"><name>High Timbale</name></entry>
+          <entry pitch="66"><name>Low Timbale</name></entry>
+          <entry pitch="67"><name>High Agogo</name></entry>
+          <entry pitch="68"><name>Low Agogo</name></entry>
+          <entry pitch="69"><name>Cabasa</name></entry>
+          <entry pitch="70"><name>Maracas</name></entry>
+          <entry pitch="71"><name>ShortWhistle</name></entry>
+          <entry pitch="72"><name>Long Whistle</name></entry>
+          <entry pitch="73"><name>Short Guiro</name></entry>
+          <entry pitch="74"><name>Long Guiro</name></entry>
+          <entry pitch="75"><name>Claves</name></entry>
+          <entry pitch="76"><name>Hi WoodBlock</name></entry>
+          <entry pitch="77"><name>LowWoodBlock</name></entry>
+          <entry pitch="78"><name>Mute Cuica</name></entry>
+          <entry pitch="79"><name>Open Cuica</name></entry>
+          <entry pitch="80"><name>MuteTriangle</name></entry>
+          <entry pitch="81"><name>OpenTriangle</name></entry>
+          <entry pitch="82"><name>Shaker</name></entry>
+          <entry pitch="83"><name>Jingle Bell</name></entry>
+          <entry pitch="84"><name>Bell Tree</name></entry>
+          <entry pitch="85"><name>Castanets</name></entry>
+          <entry pitch="86"><name>Mute Surdo</name></entry>
+          <entry pitch="87"><name>Open Surdo</name></entry>
+        </drummap>
+      </entry>
+      <entry>
+        <patch_collection prog="40-47" lbank="0" hbank="105" />
+        <drummap>
+          <entry pitch="27"><name>High Q</name></entry>
+          <entry pitch="28"><name>Slap</name></entry>
+          <entry pitch="29"><name>Scratch Push</name></entry>
+          <entry pitch="30"><name>Scratch Pull</name></entry>
+          <entry pitch="31"><name>Sticks</name></entry>
+          <entry pitch="32"><name>Square Click</name></entry>
+          <entry pitch="33"><name>Metron Click</name></entry>
+          <entry pitch="34"><name>Metron Bell</name></entry>
+          <entry pitch="35"><name>Jazz Kick 2</name></entry>
+          <entry pitch="36"><name>Jazz Kick 1</name></entry>
+          <entry pitch="37"><name>Side Stick</name></entry>
+          <entry pitch="38"><name>Brush Tap</name></entry>
+          <entry pitch="39"><name>Brush Slap</name></entry>
+          <entry pitch="40"><name>Brush Swirl</name></entry>
+          <entry pitch="41"><name>BrushLowTom2</name></entry>
+          <entry pitch="42"><name>Closed Hi-ha</name></entry>
+          <entry pitch="43"><name>BrushLowTom1</name></entry>
+          <entry pitch="44"><name>Closed Hi-ha</name></entry>
+          <entry pitch="45"><name>BrushMidTom2</name></entry>
+          <entry pitch="46"><name>ClosedHi-hat</name></entry>
+          <entry pitch="47"><name>BrushMidTom1</name></entry>
+          <entry pitch="48"><name>Brush HiTom2</name></entry>
+          <entry pitch="49"><name>Brush Crash1</name></entry>
+          <entry pitch="50"><name>Brush HiTom1</name></entry>
+          <entry pitch="51"><name>Brush Ride 1</name></entry>
+          <entry pitch="52"><name>China Cymbal</name></entry>
+          <entry pitch="53"><name>BrushRideBel</name></entry>
+          <entry pitch="54"><name>Tambourine</name></entry>
+          <entry pitch="55"><name>SplashCymbal</name></entry>
+          <entry pitch="56"><name>Cowbell</name></entry>
+          <entry pitch="57"><name>Brush Crash2</name></entry>
+          <entry pitch="58"><name>Vibra-slap</name></entry>
+          <entry pitch="59"><name>Ride Cymbal2</name></entry>
+          <entry pitch="60"><name>High Bongo</name></entry>
+          <entry pitch="61"><name>Low Bongo</name></entry>
+          <entry pitch="62"><name>MuteHi Conga</name></entry>
+          <entry pitch="63"><name>OpenHi Conga</name></entry>
+          <entry pitch="64"><name>Low Conga</name></entry>
+          <entry pitch="65"><name>High Timbale</name></entry>
+          <entry pitch="66"><name>Low Timbale</name></entry>
+          <entry pitch="67"><name>High Agogo</name></entry>
+          <entry pitch="68"><name>Low Agogo</name></entry>
+          <entry pitch="69"><name>Cabasa</name></entry>
+          <entry pitch="70"><name>Maracas</name></entry>
+          <entry pitch="71"><name>ShortWhistle</name></entry>
+          <entry pitch="72"><name>Long Whistle</name></entry>
+          <entry pitch="73"><name>Short Guiro</name></entry>
+          <entry pitch="74"><name>Long Guiro</name></entry>
+          <entry pitch="75"><name>Claves</name></entry>
+          <entry pitch="76"><name>Hi WoodBlock</name></entry>
+          <entry pitch="77"><name>LowWoodBlock</name></entry>
+          <entry pitch="78"><name>Mute Cuica</name></entry>
+          <entry pitch="79"><name>Open Cuica</name></entry>
+          <entry pitch="80"><name>MuteTriangle</name></entry>
+          <entry pitch="81"><name>OpenTriangle</name></entry>
+          <entry pitch="82"><name>Shaker</name></entry>
+          <entry pitch="83"><name>Jingle Bell</name></entry>
+          <entry pitch="84"><name>Bell Tree</name></entry>
+          <entry pitch="85"><name>Castanets</name></entry>
+          <entry pitch="86"><name>Mute Surdo</name></entry>
+          <entry pitch="87"><name>Open Surdo</name></entry>
+        </drummap>
+      </entry>
+      <entry>
+        <patch_collection prog="0-7" lbank="0" hbank="106" />
+        <drummap>
+          <entry pitch="27"><name>High Q</name></entry>
+          <entry pitch="28"><name>Slap</name></entry>
+          <entry pitch="29"><name>Scratch Push</name></entry>
+          <entry pitch="30"><name>Scratch Pull</name></entry>
+          <entry pitch="31"><name>Sticks</name></entry>
+          <entry pitch="32"><name>Square Click</name></entry>
+          <entry pitch="33"><name>Metron Click</name></entry>
+          <entry pitch="34"><name>Metron Bell</name></entry>
+          <entry pitch="35"><name>Kick Drum 2</name></entry>
+          <entry pitch="36"><name>Kick Drum 1</name></entry>
+          <entry pitch="37"><name>Side Stick</name></entry>
+          <entry pitch="38"><name>Snare Drum 1</name></entry>
+          <entry pitch="39"><name>Hand Clap</name></entry>
+          <entry pitch="40"><name>Snare Drum 2</name></entry>
+          <entry pitch="41"><name>Low Tom 2</name></entry>
+          <entry pitch="42"><name>ClosedHi-hat</name></entry>
+          <entry pitch="43"><name>Low Tom 1</name></entry>
+          <entry pitch="44"><name>Pedal Hi-hat</name></entry>
+          <entry pitch="45"><name>Mid Tom 2</name></entry>
+          <entry pitch="46"><name>Open Hi-hat</name></entry>
+          <entry pitch="47"><name>Mid Tom 1</name></entry>
+          <entry pitch="48"><name>High Tom 2</name></entry>
+          <entry pitch="49"><name>CrashCymbal1</name></entry>
+          <entry pitch="50"><name>High Tom 1</name></entry>
+          <entry pitch="51"><name>Ride Cymbal1</name></entry>
+          <entry pitch="52"><name>China Cymbal</name></entry>
+          <entry pitch="53"><name>Ride Bell</name></entry>
+          <entry pitch="54"><name>Tambourine</name></entry>
+          <entry pitch="55"><name>SplashCymbal</name></entry>
+          <entry pitch="56"><name>Cowbell</name></entry>
+          <entry pitch="57"><name>CrashCymbal2</name></entry>
+          <entry pitch="58"><name>Vibra-slap</name></entry>
+          <entry pitch="59"><name>Ride Cymbal2</name></entry>
+          <entry pitch="60"><name>High Bongo</name></entry>
+          <entry pitch="61"><name>Low Bongo</name></entry>
+          <entry pitch="62"><name>MuteHi Conga</name></entry>
+          <entry pitch="63"><name>OpenHi Conga</name></entry>
+          <entry pitch="64"><name>Low Conga</name></entry>
+          <entry pitch="65"><name>High Timbale</name></entry>
+          <entry pitch="66"><name>Low Timbale</name></entry>
+          <entry pitch="67"><name>High Agogo</name></entry>
+          <entry pitch="68"><name>Low Agogo</name></entry>
+          <entry pitch="69"><name>Cabasa</name></entry>
+          <entry pitch="70"><name>Maracas</name></entry>
+          <entry pitch="71"><name>ShortWhistle</name></entry>
+          <entry pitch="72"><name>Long Whistle</name></entry>
+          <entry pitch="73"><name>Short Guiro</name></entry>
+          <entry pitch="74"><name>Long Guiro</name></entry>
+          <entry pitch="75"><name>Claves</name></entry>
+          <entry pitch="76"><name>Hi WoodBlock</name></entry>
+          <entry pitch="77"><name>LowWoodBlock</name></entry>
+          <entry pitch="78"><name>Mute Cuica</name></entry>
+          <entry pitch="79"><name>Open Cuica</name></entry>
+          <entry pitch="80"><name>MuteTriangle</name></entry>
+          <entry pitch="81"><name>OpenTriangle</name></entry>
+          <entry pitch="82"><name>Shaker</name></entry>
+          <entry pitch="83"><name>Jingle Bell</name></entry>
+          <entry pitch="84"><name>Bell Tree</name></entry>
+          <entry pitch="85"><name>Castanets</name></entry>
+          <entry pitch="86"><name>Mute Surdo</name></entry>
+          <entry pitch="87"><name>Open Surdo</name></entry>
+        </drummap>
+      </entry>
+      <entry>
+        <patch_collection prog="8-15" lbank="0" hbank="106" />
+        <drummap>
+          <entry pitch="27"><name>High Q</name></entry>
+          <entry pitch="28"><name>Slap</name></entry>
+          <entry pitch="29"><name>Scratch Push</name></entry>
+          <entry pitch="30"><name>Scratch Pull</name></entry>
+          <entry pitch="31"><name>Sticks</name></entry>
+          <entry pitch="32"><name>Square Click</name></entry>
+          <entry pitch="33"><name>Metron Click</name></entry>
+          <entry pitch="34"><name>Metron Bell</name></entry>
+          <entry pitch="35"><name>Rock Kick Dr</name></entry>
+          <entry pitch="36"><name>Kick Drum 1</name></entry>
+          <entry pitch="37"><name>Side Stick</name></entry>
+          <entry pitch="38"><name>Rock SnareDr</name></entry>
+          <entry pitch="39"><name>Hand Clap</name></entry>
+          <entry pitch="40"><name>Snare Drum 2</name></entry>
+          <entry pitch="41"><name>Room LowTom2</name></entry>
+          <entry pitch="42"><name>ClosedHi-hat</name></entry>
+          <entry pitch="43"><name>Room LowTom1</name></entry>
+          <entry pitch="44"><name>Pedal Hi-hat</name></entry>
+          <entry pitch="45"><name>Room MidTom2</name></entry>
+          <entry pitch="46"><name>Open Hi-hat</name></entry>
+          <entry pitch="47"><name>Room MidTom1</name></entry>
+          <entry pitch="48"><name>Room Hi Tom2</name></entry>
+          <entry pitch="49"><name>CrashCymbal1</name></entry>
+          <entry pitch="50"><name>Room Hi Tom1</name></entry>
+          <entry pitch="51"><name>Ride Cymbal1</name></entry>
+          <entry pitch="52"><name>China Cymbal</name></entry>
+          <entry pitch="53"><name>Ride Bell</name></entry>
+          <entry pitch="54"><name>Tambourine</name></entry>
+          <entry pitch="55"><name>SplashCymbal</name></entry>
+          <entry pitch="56"><name>Cowbell</name></entry>
+          <entry pitch="57"><name>CrashCymbal2</name></entry>
+          <entry pitch="58"><name>Vibra-slap</name></entry>
+          <entry pitch="59"><name>Ride Cymbal2</name></entry>
+          <entry pitch="60"><name>High Bongo</name></entry>
+          <entry pitch="61"><name>Low Bongo</name></entry>
+          <entry pitch="62"><name>MuteHi Conga</name></entry>
+          <entry pitch="63"><name>OpenHi Conga</name></entry>
+          <entry pitch="64"><name>Low Conga</name></entry>
+          <entry pitch="65"><name>High Timbale</name></entry>
+          <entry pitch="66"><name>Low Timbale</name></entry>
+          <entry pitch="67"><name>High Agogo</name></entry>
+          <entry pitch="68"><name>Low Agogo</name></entry>
+          <entry pitch="69"><name>Cabasa</name></entry>
+          <entry pitch="70"><name>Maracas</name></entry>
+          <entry pitch="71"><name>ShortWhistle</name></entry>
+          <entry pitch="72"><name>Long Whistle</name></entry>
+          <entry pitch="73"><name>Short Guiro</name></entry>
+          <entry pitch="74"><name>Long Guiro</name></entry>
+          <entry pitch="75"><name>Claves</name></entry>
+          <entry pitch="76"><name>Hi WoodBlock</name></entry>
+          <entry pitch="77"><name>LowWoodBlock</name></entry>
+          <entry pitch="78"><name>Mute Cuica</name></entry>
+          <entry pitch="79"><name>Open Cuica</name></entry>
+          <entry pitch="80"><name>MuteTriangle</name></entry>
+          <entry pitch="81"><name>OpenTriangle</name></entry>
+          <entry pitch="82"><name>Shaker</name></entry>
+          <entry pitch="83"><name>Jingle Bell</name></entry>
+          <entry pitch="84"><name>Bell Tree</name></entry>
+          <entry pitch="85"><name>Castanets</name></entry>
+          <entry pitch="86"><name>Mute Surdo</name></entry>
+          <entry pitch="87"><name>Open Surdo</name></entry>
+        </drummap>
+      </entry>
+      <entry>
+        <patch_collection prog="16-23" lbank="0" hbank="106" />
+        <drummap>
+          <entry pitch="27"><name>High Q</name></entry>
+          <entry pitch="28"><name>Slap</name></entry>
+          <entry pitch="29"><name>Scratch Push</name></entry>
+          <entry pitch="30"><name>Scratch Pull</name></entry>
+          <entry pitch="31"><name>Sticks</name></entry>
+          <entry pitch="32"><name>Square Click</name></entry>
+          <entry pitch="33"><name>Metron Click</name></entry>
+          <entry pitch="34"><name>Metron Bell</name></entry>
+          <entry pitch="35"><name>Rock Kick Dr</name></entry>
+          <entry pitch="36"><name>Round Kick</name></entry>
+          <entry pitch="37"><name>Side Stick</name></entry>
+          <entry pitch="38"><name>Rock SnareDr</name></entry>
+          <entry pitch="39"><name>Hand Clap</name></entry>
+          <entry pitch="40"><name>Piccolo SN</name></entry>
+          <entry pitch="41"><name>PowerLowTom2</name></entry>
+          <entry pitch="42"><name>ClosedHi-hat</name></entry>
+          <entry pitch="43"><name>PowerLowTom1</name></entry>
+          <entry pitch="44"><name>Pedal Hi-hat</name></entry>
+          <entry pitch="45"><name>PowerMIdTom2</name></entry>
+          <entry pitch="46"><name>Open Hi-hat</name></entry>
+          <entry pitch="47"><name>PowerMIdTom1</name></entry>
+          <entry pitch="48"><name>Power HiTom2</name></entry>
+          <entry pitch="49"><name>CrashCymbal1</name></entry>
+          <entry pitch="50"><name>Power HiTom1</name></entry>
+          <entry pitch="51"><name>Ride Cymbal1</name></entry>
+          <entry pitch="52"><name>China Cymbal</name></entry>
+          <entry pitch="53"><name>Ride Bell</name></entry>
+          <entry pitch="54"><name>Tambourine</name></entry>
+          <entry pitch="55"><name>SplashCymbal</name></entry>
+          <entry pitch="56"><name>Cowbell</name></entry>
+          <entry pitch="57"><name>CrashCymbal2</name></entry>
+          <entry pitch="58"><name>Vibra-slap</name></entry>
+          <entry pitch="59"><name>Ride Cymbal2</name></entry>
+          <entry pitch="60"><name>High Bongo</name></entry>
+          <entry pitch="61"><name>Low Bongo</name></entry>
+          <entry pitch="62"><name>MuteHi Conga</name></entry>
+          <entry pitch="63"><name>OpenHi Conga</name></entry>
+          <entry pitch="64"><name>Low Conga</name></entry>
+          <entry pitch="65"><name>High Timbale</name></entry>
+          <entry pitch="66"><name>Low Timbale</name></entry>
+          <entry pitch="67"><name>High Agogo</name></entry>
+          <entry pitch="68"><name>Low Agogo</name></entry>
+          <entry pitch="69"><name>Cabasa</name></entry>
+          <entry pitch="70"><name>Maracas</name></entry>
+          <entry pitch="71"><name>ShortWhistle</name></entry>
+          <entry pitch="72"><name>Long Whistle</name></entry>
+          <entry pitch="73"><name>Short Guiro</name></entry>
+          <entry pitch="74"><name>Long Guiro</name></entry>
+          <entry pitch="75"><name>Claves</name></entry>
+          <entry pitch="76"><name>Hi WoodBlock</name></entry>
+          <entry pitch="77"><name>LowWoodBlock</name></entry>
+          <entry pitch="78"><name>Mute Cuica</name></entry>
+          <entry pitch="79"><name>Open Cuica</name></entry>
+          <entry pitch="80"><name>MuteTriangle</name></entry>
+          <entry pitch="81"><name>OpenTriangle</name></entry>
+          <entry pitch="82"><name>Shaker</name></entry>
+          <entry pitch="83"><name>Jingle Bell</name></entry>
+          <entry pitch="84"><name>Bell Tree</name></entry>
+          <entry pitch="85"><name>Castanets</name></entry>
+          <entry pitch="86"><name>Mute Surdo</name></entry>
+          <entry pitch="87"><name>Open Surdo</name></entry>
+        </drummap>
+      </entry>
+      <entry>
+        <patch_collection prog="24" lbank="0" hbank="106" />
+        <drummap>
+          <entry pitch="27"><name>High Q</name></entry>
+          <entry pitch="28"><name>Slap</name></entry>
+          <entry pitch="29"><name>Scratch Push</name></entry>
+          <entry pitch="30"><name>Scratch Pull</name></entry>
+          <entry pitch="31"><name>Sticks</name></entry>
+          <entry pitch="32"><name>Square Click</name></entry>
+          <entry pitch="33"><name>Metron Click</name></entry>
+          <entry pitch="34"><name>Metron Bell</name></entry>
+          <entry pitch="35"><name>70s Kick 1</name></entry>
+          <entry pitch="36"><name>Dance Kick</name></entry>
+          <entry pitch="37"><name>Side Stick</name></entry>
+          <entry pitch="38"><name>Old Fill SN</name></entry>
+          <entry pitch="39"><name>Hand Clap</name></entry>
+          <entry pitch="40"><name>Rock SN</name></entry>
+          <entry pitch="41"><name>Elec.Tom L2</name></entry>
+          <entry pitch="42"><name>Closed Hi-ha</name></entry>
+          <entry pitch="43"><name>Elec.Tom L1</name></entry>
+          <entry pitch="44"><name>ClosedHi-hat</name></entry>
+          <entry pitch="45"><name>Elec.Tom M2</name></entry>
+          <entry pitch="46"><name>Open Hi-hat</name></entry>
+          <entry pitch="47"><name>Elec.Tom M1</name></entry>
+          <entry pitch="48"><name>Elec.Tom H2</name></entry>
+          <entry pitch="49"><name>CrashCymbal1</name></entry>
+          <entry pitch="50"><name>Elec.Tom H1</name></entry>
+          <entry pitch="51"><name>Ride Cymbal1</name></entry>
+          <entry pitch="52"><name>Reverse Cym.</name></entry>
+          <entry pitch="53"><name>Ride Bell</name></entry>
+          <entry pitch="54"><name>Tambourine</name></entry>
+          <entry pitch="55"><name>SplashCymbal</name></entry>
+          <entry pitch="56"><name>Cowbell</name></entry>
+          <entry pitch="57"><name>CrashCymbal2</name></entry>
+          <entry pitch="58"><name>Vibra-slap</name></entry>
+          <entry pitch="59"><name>Ride Cymbal2</name></entry>
+          <entry pitch="60"><name>High Bongo</name></entry>
+          <entry pitch="61"><name>Low Bongo</name></entry>
+          <entry pitch="62"><name>MuteHi Conga</name></entry>
+          <entry pitch="63"><name>OpenHi Conga</name></entry>
+          <entry pitch="64"><name>Low Conga</name></entry>
+          <entry pitch="65"><name>High Timbale</name></entry>
+          <entry pitch="66"><name>Low Timbale</name></entry>
+          <entry pitch="67"><name>High Agogo</name></entry>
+          <entry pitch="68"><name>Low Agogo</name></entry>
+          <entry pitch="69"><name>Cabasa</name></entry>
+          <entry pitch="70"><name>Maracas</name></entry>
+          <entry pitch="71"><name>ShortWhistle</name></entry>
+          <entry pitch="72"><name>Long Whistle</name></entry>
+          <entry pitch="73"><name>Short Guiro</name></entry>
+          <entry pitch="74"><name>Long Guiro</name></entry>
+          <entry pitch="75"><name>Claves</name></entry>
+          <entry pitch="76"><name>Hi WoodBlock</name></entry>
+          <entry pitch="77"><name>LowWoodBlock</name></entry>
+          <entry pitch="78"><name>Mute Cuica</name></entry>
+          <entry pitch="79"><name>Open Cuica</name></entry>
+          <entry pitch="80"><name>MuteTriangle</name></entry>
+          <entry pitch="81"><name>OpenTriangle</name></entry>
+          <entry pitch="82"><name>Shaker</name></entry>
+          <entry pitch="83"><name>Jingle Bell</name></entry>
+          <entry pitch="84"><name>Bell Tree</name></entry>
+          <entry pitch="85"><name>Castanets</name></entry>
+          <entry pitch="86"><name>Mute Surdo</name></entry>
+          <entry pitch="87"><name>Open Surdo</name></entry>
+        </drummap>
+      </entry>
+      <entry>
+        <patch_collection prog="25-31" lbank="0" hbank="106" />
+        <drummap>
+          <entry pitch="27"><name>High Q</name></entry>
+          <entry pitch="28"><name>Slap</name></entry>
+          <entry pitch="29"><name>Scratch Push</name></entry>
+          <entry pitch="30"><name>Scratch Pull</name></entry>
+          <entry pitch="31"><name>Sticks</name></entry>
+          <entry pitch="32"><name>Square Click</name></entry>
+          <entry pitch="33"><name>Metron Click</name></entry>
+          <entry pitch="34"><name>Metron Bell</name></entry>
+          <entry pitch="35"><name>909 Kick 2</name></entry>
+          <entry pitch="36"><name>909 Kick 1</name></entry>
+          <entry pitch="37"><name>Ana.Rim Shot</name></entry>
+          <entry pitch="38"><name>909 Snare 1</name></entry>
+          <entry pitch="39"><name>Hand Clap</name></entry>
+          <entry pitch="40"><name>909 Snare 2</name></entry>
+          <entry pitch="41"><name>Ana.Low Tom2</name></entry>
+          <entry pitch="42"><name>Closed Hi-ha</name></entry>
+          <entry pitch="43"><name>Ana.Low Tom1</name></entry>
+          <entry pitch="44"><name>ClosedHi-hat</name></entry>
+          <entry pitch="45"><name>Ana.Mid Tom2</name></entry>
+          <entry pitch="46"><name>Open Hi-hat</name></entry>
+          <entry pitch="47"><name>Ana.Mid Tom1</name></entry>
+          <entry pitch="48"><name>Ana.Hi Tom2</name></entry>
+          <entry pitch="49"><name>CrashCymbal1</name></entry>
+          <entry pitch="50"><name>Ana.Hi Tom1</name></entry>
+          <entry pitch="51"><name>Ride Cymbal1</name></entry>
+          <entry pitch="52"><name>China Cymbal</name></entry>
+          <entry pitch="53"><name>Ride Bell</name></entry>
+          <entry pitch="54"><name>Tambourine</name></entry>
+          <entry pitch="55"><name>SplashCymbal</name></entry>
+          <entry pitch="56"><name>Ana.Cowbell</name></entry>
+          <entry pitch="57"><name>CrashCymbal2</name></entry>
+          <entry pitch="58"><name>Vibra-slap</name></entry>
+          <entry pitch="59"><name>Ride Cymbal2</name></entry>
+          <entry pitch="60"><name>High Bongo</name></entry>
+          <entry pitch="61"><name>Low Bongo</name></entry>
+          <entry pitch="62"><name>Ana.Hi Conga</name></entry>
+          <entry pitch="63"><name>Ana.MidConga</name></entry>
+          <entry pitch="64"><name>Ana.LowConga</name></entry>
+          <entry pitch="65"><name>High Timbale</name></entry>
+          <entry pitch="66"><name>Low Timbale</name></entry>
+          <entry pitch="67"><name>High Agogo</name></entry>
+          <entry pitch="68"><name>Low Agogo</name></entry>
+          <entry pitch="69"><name>Cabasa</name></entry>
+          <entry pitch="70"><name>Ana.Maracas</name></entry>
+          <entry pitch="71"><name>ShortWhistle</name></entry>
+          <entry pitch="72"><name>Long Whistle</name></entry>
+          <entry pitch="73"><name>Short Guiro</name></entry>
+          <entry pitch="74"><name>Long Guiro</name></entry>
+          <entry pitch="75"><name>Ana.Claves</name></entry>
+          <entry pitch="76"><name>Hi WoodBlock</name></entry>
+          <entry pitch="77"><name>LowWoodBlock</name></entry>
+          <entry pitch="78"><name>Mute Cuica</name></entry>
+          <entry pitch="79"><name>Open Cuica</name></entry>
+          <entry pitch="80"><name>MuteTriangle</name></entry>
+          <entry pitch="81"><name>OpenTriangle</name></entry>
+          <entry pitch="82"><name>Shaker</name></entry>
+          <entry pitch="83"><name>Jingle Bell</name></entry>
+          <entry pitch="84"><name>Bell Tree</name></entry>
+          <entry pitch="85"><name>Castanets</name></entry>
+          <entry pitch="86"><name>Mute Surdo</name></entry>
+          <entry pitch="87"><name>Open Surdo</name></entry>
+        </drummap>
+      </entry>
+      <entry>
+        <patch_collection prog="32-39" lbank="0" hbank="106" />
+        <drummap>
+          <entry pitch="27"><name>High Q</name></entry>
+          <entry pitch="28"><name>Slap</name></entry>
+          <entry pitch="29"><name>Scratch Push</name></entry>
+          <entry pitch="30"><name>Scratch Pull</name></entry>
+          <entry pitch="31"><name>Sticks</name></entry>
+          <entry pitch="32"><name>Square Click</name></entry>
+          <entry pitch="33"><name>Metron Click</name></entry>
+          <entry pitch="34"><name>Metron Bell</name></entry>
+          <entry pitch="35"><name>Jazz Kick 2</name></entry>
+          <entry pitch="36"><name>Jazz Kick 1</name></entry>
+          <entry pitch="37"><name>Side Stick</name></entry>
+          <entry pitch="38"><name>Snare Drum 1</name></entry>
+          <entry pitch="39"><name>Hand Clap</name></entry>
+          <entry pitch="40"><name>Snare Drum 2</name></entry>
+          <entry pitch="41"><name>Low Tom 2</name></entry>
+          <entry pitch="42"><name>ClosedHi-hat</name></entry>
+          <entry pitch="43"><name>Low Tom 1</name></entry>
+          <entry pitch="44"><name>Pedal Hi-hat</name></entry>
+          <entry pitch="45"><name>Mid Tom 2</name></entry>
+          <entry pitch="46"><name>Open Hi-hat</name></entry>
+          <entry pitch="47"><name>Mid Tom 1</name></entry>
+          <entry pitch="48"><name>High Tom 2</name></entry>
+          <entry pitch="49"><name>CrashCymbal1</name></entry>
+          <entry pitch="50"><name>High Tom 1</name></entry>
+          <entry pitch="51"><name>Ride Cymbal1</name></entry>
+          <entry pitch="52"><name>China Cymbal</name></entry>
+          <entry pitch="53"><name>Ride Bell</name></entry>
+          <entry pitch="54"><name>Tambourine</name></entry>
+          <entry pitch="55"><name>SplashCymbal</name></entry>
+          <entry pitch="56"><name>Cowbell</name></entry>
+          <entry pitch="57"><name>CrashCymbal2</name></entry>
+          <entry pitch="58"><name>Vibra-slap</name></entry>
+          <entry pitch="59"><name>Ride Cymbal2</name></entry>
+          <entry pitch="60"><name>High Bongo</name></entry>
+          <entry pitch="61"><name>Low Bongo</name></entry>
+          <entry pitch="62"><name>MuteHi Conga</name></entry>
+          <entry pitch="63"><name>OpenHi Conga</name></entry>
+          <entry pitch="64"><name>Low Conga</name></entry>
+          <entry pitch="65"><name>High Timbale</name></entry>
+          <entry pitch="66"><name>Low Timbale</name></entry>
+          <entry pitch="67"><name>High Agogo</name></entry>
+          <entry pitch="68"><name>Low Agogo</name></entry>
+          <entry pitch="69"><name>Cabasa</name></entry>
+          <entry pitch="70"><name>Maracas</name></entry>
+          <entry pitch="71"><name>ShortWhistle</name></entry>
+          <entry pitch="72"><name>Long Whistle</name></entry>
+          <entry pitch="73"><name>Short Guiro</name></entry>
+          <entry pitch="74"><name>Long Guiro</name></entry>
+          <entry pitch="75"><name>Claves</name></entry>
+          <entry pitch="76"><name>Hi WoodBlock</name></entry>
+          <entry pitch="77"><name>LowWoodBlock</name></entry>
+          <entry pitch="78"><name>Mute Cuica</name></entry>
+          <entry pitch="79"><name>Open Cuica</name></entry>
+          <entry pitch="80"><name>MuteTriangle</name></entry>
+          <entry pitch="81"><name>OpenTriangle</name></entry>
+          <entry pitch="82"><name>Shaker</name></entry>
+          <entry pitch="83"><name>Jingle Bell</name></entry>
+          <entry pitch="84"><name>Bell Tree</name></entry>
+          <entry pitch="85"><name>Castanets</name></entry>
+          <entry pitch="86"><name>Mute Surdo</name></entry>
+          <entry pitch="87"><name>Open Surdo</name></entry>
+        </drummap>
+      </entry>
+      <entry>
+        <patch_collection prog="40-47" lbank="0" hbank="106" />
+        <drummap>
+          <entry pitch="27"><name>High Q</name></entry>
+          <entry pitch="28"><name>Slap</name></entry>
+          <entry pitch="29"><name>Scratch Push</name></entry>
+          <entry pitch="30"><name>Scratch Pull</name></entry>
+          <entry pitch="31"><name>Sticks</name></entry>
+          <entry pitch="32"><name>Square Click</name></entry>
+          <entry pitch="33"><name>Metron Click</name></entry>
+          <entry pitch="34"><name>Metron Bell</name></entry>
+          <entry pitch="35"><name>Jazz Kick 2</name></entry>
+          <entry pitch="36"><name>Jazz Kick 1</name></entry>
+          <entry pitch="37"><name>Side Stick</name></entry>
+          <entry pitch="38"><name>Brush Tap</name></entry>
+          <entry pitch="39"><name>Brush Slap</name></entry>
+          <entry pitch="40"><name>Brush Swirl</name></entry>
+          <entry pitch="41"><name>BrushLowTom2</name></entry>
+          <entry pitch="42"><name>Closed Hi-ha</name></entry>
+          <entry pitch="43"><name>BrushLowTom1</name></entry>
+          <entry pitch="44"><name>ClosedHi-hat</name></entry>
+          <entry pitch="45"><name>BrushMidTom2</name></entry>
+          <entry pitch="46"><name>Closed Hi-ha</name></entry>
+          <entry pitch="47"><name>BrushMidTom1</name></entry>
+          <entry pitch="48"><name>Brush HiTom2</name></entry>
+          <entry pitch="49"><name>Brush Crash1</name></entry>
+          <entry pitch="50"><name>Brush HiTom1</name></entry>
+          <entry pitch="51"><name>Brush Ride 1</name></entry>
+          <entry pitch="52"><name>China Cymbal</name></entry>
+          <entry pitch="53"><name>BrushRideBel</name></entry>
+          <entry pitch="54"><name>Tambourine</name></entry>
+          <entry pitch="55"><name>SplashCymbal</name></entry>
+          <entry pitch="56"><name>Cowbell</name></entry>
+          <entry pitch="57"><name>Brush Crash2</name></entry>
+          <entry pitch="58"><name>Vibra-slap</name></entry>
+          <entry pitch="59"><name>Ride Cymbal2</name></entry>
+          <entry pitch="60"><name>High Bongo</name></entry>
+          <entry pitch="61"><name>Low Bongo</name></entry>
+          <entry pitch="62"><name>MuteHi Conga</name></entry>
+          <entry pitch="63"><name>OpenHi Conga</name></entry>
+          <entry pitch="64"><name>Low Conga</name></entry>
+          <entry pitch="65"><name>High Timbale</name></entry>
+          <entry pitch="66"><name>Low Timbale</name></entry>
+          <entry pitch="67"><name>High Agogo</name></entry>
+          <entry pitch="68"><name>Low Agogo</name></entry>
+          <entry pitch="69"><name>Cabasa</name></entry>
+          <entry pitch="70"><name>Maracas</name></entry>
+          <entry pitch="71"><name>ShortWhistle</name></entry>
+          <entry pitch="72"><name>Long Whistle</name></entry>
+          <entry pitch="73"><name>Short Guiro</name></entry>
+          <entry pitch="74"><name>Long Guiro</name></entry>
+          <entry pitch="75"><name>Claves</name></entry>
+          <entry pitch="76"><name>Hi WoodBlock</name></entry>
+          <entry pitch="77"><name>LowWoodBlock</name></entry>
+          <entry pitch="78"><name>Mute Cuica</name></entry>
+          <entry pitch="79"><name>Open Cuica</name></entry>
+          <entry pitch="80"><name>MuteTriangle</name></entry>
+          <entry pitch="81"><name>OpenTriangle</name></entry>
+          <entry pitch="82"><name>Shaker</name></entry>
+          <entry pitch="83"><name>Jingle Bell</name></entry>
+          <entry pitch="84"><name>Bell Tree</name></entry>
+          <entry pitch="85"><name>Castanets</name></entry>
+          <entry pitch="86"><name>Mute Surdo</name></entry>
+          <entry pitch="87"><name>Open Surdo</name></entry>
+        </drummap>
+      </entry>
+      <entry>
+        <patch_collection prog="0-7" lbank="0" hbank="107" />
+        <drummap>
+          <entry pitch="27"><name>High Q</name></entry>
+          <entry pitch="28"><name>Slap</name></entry>
+          <entry pitch="29"><name>Scratch Push</name></entry>
+          <entry pitch="30"><name>Scratch Pull</name></entry>
+          <entry pitch="31"><name>Sticks</name></entry>
+          <entry pitch="32"><name>Square Click</name></entry>
+          <entry pitch="33"><name>Metron Click</name></entry>
+          <entry pitch="34"><name>Metron Bell</name></entry>
+          <entry pitch="35"><name>Kick Drum 2</name></entry>
+          <entry pitch="36"><name>Kick Drum 1</name></entry>
+          <entry pitch="37"><name>Side Stick</name></entry>
+          <entry pitch="38"><name>Snare Drum 1</name></entry>
+          <entry pitch="39"><name>Hand Clap</name></entry>
+          <entry pitch="40"><name>Snare Drum 2</name></entry>
+          <entry pitch="41"><name>Low Tom 2</name></entry>
+          <entry pitch="42"><name>ClosedHi-hat</name></entry>
+          <entry pitch="43"><name>Low Tom 1</name></entry>
+          <entry pitch="44"><name>Pedal Hi-hat</name></entry>
+          <entry pitch="45"><name>Mid Tom 2</name></entry>
+          <entry pitch="46"><name>Open Hi-hat</name></entry>
+          <entry pitch="47"><name>Mid Tom 1</name></entry>
+          <entry pitch="48"><name>High Tom 2</name></entry>
+          <entry pitch="49"><name>CrashCymbal1</name></entry>
+          <entry pitch="50"><name>High Tom 1</name></entry>
+          <entry pitch="51"><name>Ride Cymbal1</name></entry>
+          <entry pitch="52"><name>China Cymbal</name></entry>
+          <entry pitch="53"><name>Ride Bell</name></entry>
+          <entry pitch="54"><name>Tambourine</name></entry>
+          <entry pitch="55"><name>SplashCymbal</name></entry>
+          <entry pitch="56"><name>Cowbell</name></entry>
+          <entry pitch="57"><name>CrashCymbal2</name></entry>
+          <entry pitch="58"><name>Vibra-slap</name></entry>
+          <entry pitch="59"><name>Ride Cymbal2</name></entry>
+          <entry pitch="60"><name>High Bongo</name></entry>
+          <entry pitch="61"><name>Low Bongo</name></entry>
+          <entry pitch="62"><name>MuteHi Conga</name></entry>
+          <entry pitch="63"><name>OpenHi Conga</name></entry>
+          <entry pitch="64"><name>Low Conga</name></entry>
+          <entry pitch="65"><name>High Timbale</name></entry>
+          <entry pitch="66"><name>Low Timbale</name></entry>
+          <entry pitch="67"><name>High Agogo</name></entry>
+          <entry pitch="68"><name>Low Agogo</name></entry>
+          <entry pitch="69"><name>Cabasa</name></entry>
+          <entry pitch="70"><name>Maracas</name></entry>
+          <entry pitch="71"><name>ShortWhistle</name></entry>
+          <entry pitch="72"><name>Long Whistle</name></entry>
+          <entry pitch="73"><name>Short Guiro</name></entry>
+          <entry pitch="74"><name>Long Guiro</name></entry>
+          <entry pitch="75"><name>Claves</name></entry>
+          <entry pitch="76"><name>Hi WoodBlock</name></entry>
+          <entry pitch="77"><name>LowWoodBlock</name></entry>
+          <entry pitch="78"><name>Mute Cuica</name></entry>
+          <entry pitch="79"><name>Open Cuica</name></entry>
+          <entry pitch="80"><name>MuteTriangle</name></entry>
+          <entry pitch="81"><name>OpenTriangle</name></entry>
+          <entry pitch="82"><name>Shaker</name></entry>
+          <entry pitch="83"><name>Jingle Bell</name></entry>
+          <entry pitch="84"><name>Bell Tree</name></entry>
+          <entry pitch="85"><name>Castanets</name></entry>
+          <entry pitch="86"><name>Mute Surdo</name></entry>
+          <entry pitch="87"><name>Open Surdo</name></entry>
+        </drummap>
+      </entry>
+      <entry>
+        <patch_collection prog="8-15" lbank="0" hbank="107" />
+        <drummap>
+          <entry pitch="27"><name>High Q</name></entry>
+          <entry pitch="28"><name>Slap</name></entry>
+          <entry pitch="29"><name>Scratch Push</name></entry>
+          <entry pitch="30"><name>Scratch Pull</name></entry>
+          <entry pitch="31"><name>Sticks</name></entry>
+          <entry pitch="32"><name>Square Click</name></entry>
+          <entry pitch="33"><name>Metron Click</name></entry>
+          <entry pitch="34"><name>Metron Bell</name></entry>
+          <entry pitch="35"><name>Rock Kick Dr</name></entry>
+          <entry pitch="36"><name>Kick Drum 1</name></entry>
+          <entry pitch="37"><name>Side Stick</name></entry>
+          <entry pitch="38"><name>Rock SnareDr</name></entry>
+          <entry pitch="39"><name>Hand Clap</name></entry>
+          <entry pitch="40"><name>Snare Drum 2</name></entry>
+          <entry pitch="41"><name>Room LowTom2</name></entry>
+          <entry pitch="42"><name>ClosedHi-hat</name></entry>
+          <entry pitch="43"><name>Room LowTom1</name></entry>
+          <entry pitch="44"><name>Pedal Hi-hat</name></entry>
+          <entry pitch="45"><name>Room MidTom2</name></entry>
+          <entry pitch="46"><name>Open Hi-hat</name></entry>
+          <entry pitch="47"><name>Room MidTom1</name></entry>
+          <entry pitch="48"><name>Room Hi Tom2</name></entry>
+          <entry pitch="49"><name>CrashCymbal1</name></entry>
+          <entry pitch="50"><name>Room Hi Tom1</name></entry>
+          <entry pitch="51"><name>Ride Cymbal1</name></entry>
+          <entry pitch="52"><name>China Cymbal</name></entry>
+          <entry pitch="53"><name>Ride Bell</name></entry>
+          <entry pitch="54"><name>Tambourine</name></entry>
+          <entry pitch="55"><name>SplashCymbal</name></entry>
+          <entry pitch="56"><name>Cowbell</name></entry>
+          <entry pitch="57"><name>CrashCymbal2</name></entry>
+          <entry pitch="58"><name>Vibra-slap</name></entry>
+          <entry pitch="59"><name>Ride Cymbal2</name></entry>
+          <entry pitch="60"><name>High Bongo</name></entry>
+          <entry pitch="61"><name>Low Bongo</name></entry>
+          <entry pitch="62"><name>MuteHi Conga</name></entry>
+          <entry pitch="63"><name>OpenHi Conga</name></entry>
+          <entry pitch="64"><name>Low Conga</name></entry>
+          <entry pitch="65"><name>High Timbale</name></entry>
+          <entry pitch="66"><name>Low Timbale</name></entry>
+          <entry pitch="67"><name>High Agogo</name></entry>
+          <entry pitch="68"><name>Low Agogo</name></entry>
+          <entry pitch="69"><name>Cabasa</name></entry>
+          <entry pitch="70"><name>Maracas</name></entry>
+          <entry pitch="71"><name>ShortWhistle</name></entry>
+          <entry pitch="72"><name>Long Whistle</name></entry>
+          <entry pitch="73"><name>Short Guiro</name></entry>
+          <entry pitch="74"><name>Long Guiro</name></entry>
+          <entry pitch="75"><name>Claves</name></entry>
+          <entry pitch="76"><name>Hi WoodBlock</name></entry>
+          <entry pitch="77"><name>LowWoodBlock</name></entry>
+          <entry pitch="78"><name>Mute Cuica</name></entry>
+          <entry pitch="79"><name>Open Cuica</name></entry>
+          <entry pitch="80"><name>MuteTriangle</name></entry>
+          <entry pitch="81"><name>OpenTriangle</name></entry>
+          <entry pitch="82"><name>Shaker</name></entry>
+          <entry pitch="83"><name>Jingle Bell</name></entry>
+          <entry pitch="84"><name>Bell Tree</name></entry>
+          <entry pitch="85"><name>Castanets</name></entry>
+          <entry pitch="86"><name>Mute Surdo</name></entry>
+          <entry pitch="87"><name>Open Surdo</name></entry>
+        </drummap>
+      </entry>
+      <entry>
+        <patch_collection prog="16-23" lbank="0" hbank="107" />
+        <drummap>
+          <entry pitch="27"><name>High Q</name></entry>
+          <entry pitch="28"><name>Slap</name></entry>
+          <entry pitch="29"><name>Scratch Push</name></entry>
+          <entry pitch="30"><name>Scratch Pull</name></entry>
+          <entry pitch="31"><name>Sticks</name></entry>
+          <entry pitch="32"><name>Square Click</name></entry>
+          <entry pitch="33"><name>Metron Click</name></entry>
+          <entry pitch="34"><name>Metron Bell</name></entry>
+          <entry pitch="35"><name>Rock Kick Dr</name></entry>
+          <entry pitch="36"><name>Kick Drum 1</name></entry>
+          <entry pitch="37"><name>Side Stick</name></entry>
+          <entry pitch="38"><name>Rock SnareDr</name></entry>
+          <entry pitch="39"><name>Hand Clap</name></entry>
+          <entry pitch="40"><name>Snare Drum 2</name></entry>
+          <entry pitch="41"><name>Room LowTom2</name></entry>
+          <entry pitch="42"><name>ClosedHi-hat</name></entry>
+          <entry pitch="43"><name>Room LowTom1</name></entry>
+          <entry pitch="44"><name>Pedal Hi-hat</name></entry>
+          <entry pitch="45"><name>Room MidTom2</name></entry>
+          <entry pitch="46"><name>Open Hi-hat</name></entry>
+          <entry pitch="47"><name>Room MidTom1</name></entry>
+          <entry pitch="48"><name>Room Hi Tom2</name></entry>
+          <entry pitch="49"><name>CrashCymbal1</name></entry>
+          <entry pitch="50"><name>Room Hi Tom1</name></entry>
+          <entry pitch="51"><name>Ride Cymbal1</name></entry>
+          <entry pitch="52"><name>China Cymbal</name></entry>
+          <entry pitch="53"><name>Ride Bell</name></entry>
+          <entry pitch="54"><name>Tambourine</name></entry>
+          <entry pitch="55"><name>SplashCymbal</name></entry>
+          <entry pitch="56"><name>Cowbell</name></entry>
+          <entry pitch="57"><name>CrashCymbal2</name></entry>
+          <entry pitch="58"><name>Vibra-slap</name></entry>
+          <entry pitch="59"><name>Ride Cymbal2</name></entry>
+          <entry pitch="60"><name>High Bongo</name></entry>
+          <entry pitch="61"><name>Low Bongo</name></entry>
+          <entry pitch="62"><name>MuteHi Conga</name></entry>
+          <entry pitch="63"><name>OpenHi Conga</name></entry>
+          <entry pitch="64"><name>Low Conga</name></entry>
+          <entry pitch="65"><name>High Timbale</name></entry>
+          <entry pitch="66"><name>Low Timbale</name></entry>
+          <entry pitch="67"><name>High Agogo</name></entry>
+          <entry pitch="68"><name>Low Agogo</name></entry>
+          <entry pitch="69"><name>Cabasa</name></entry>
+          <entry pitch="70"><name>Maracas</name></entry>
+          <entry pitch="71"><name>ShortWhistle</name></entry>
+          <entry pitch="72"><name>Long Whistle</name></entry>
+          <entry pitch="73"><name>Short Guiro</name></entry>
+          <entry pitch="74"><name>Long Guiro</name></entry>
+          <entry pitch="75"><name>Claves</name></entry>
+          <entry pitch="76"><name>Hi WoodBlock</name></entry>
+          <entry pitch="77"><name>LowWoodBlock</name></entry>
+          <entry pitch="78"><name>Mute Cuica</name></entry>
+          <entry pitch="79"><name>Open Cuica</name></entry>
+          <entry pitch="80"><name>MuteTriangle</name></entry>
+          <entry pitch="81"><name>OpenTriangle</name></entry>
+          <entry pitch="82"><name>Shaker</name></entry>
+          <entry pitch="83"><name>Jingle Bell</name></entry>
+          <entry pitch="84"><name>Bell Tree</name></entry>
+          <entry pitch="85"><name>Castanets</name></entry>
+          <entry pitch="86"><name>Mute Surdo</name></entry>
+          <entry pitch="87"><name>Open Surdo</name></entry>
+        </drummap>
+      </entry>
+      <entry>
+        <patch_collection prog="24" lbank="0" hbank="107" />
+        <drummap>
+          <entry pitch="27"><name>High Q</name></entry>
+          <entry pitch="28"><name>Slap</name></entry>
+          <entry pitch="29"><name>Scratch Push</name></entry>
+          <entry pitch="30"><name>Scratch Pull</name></entry>
+          <entry pitch="31"><name>Sticks</name></entry>
+          <entry pitch="32"><name>Square Click</name></entry>
+          <entry pitch="33"><name>Metron Click</name></entry>
+          <entry pitch="34"><name>Metron Bell</name></entry>
+          <entry pitch="35"><name>909 Kick 1</name></entry>
+          <entry pitch="36"><name>909 Kick 2</name></entry>
+          <entry pitch="37"><name>Side Stick</name></entry>
+          <entry pitch="38"><name>Techno Snare</name></entry>
+          <entry pitch="39"><name>Hand Clap</name></entry>
+          <entry pitch="40"><name>Punch Snare</name></entry>
+          <entry pitch="41"><name>Elec.Tom L2</name></entry>
+          <entry pitch="42"><name>ClosedHi-hat</name></entry>
+          <entry pitch="43"><name>Elec.Tom L1</name></entry>
+          <entry pitch="44"><name>Closed Hi-ha</name></entry>
+          <entry pitch="45"><name>Elec.Tom M2</name></entry>
+          <entry pitch="46"><name>Open Hi-hat</name></entry>
+          <entry pitch="47"><name>Elec.Tom M1</name></entry>
+          <entry pitch="48"><name>Elec.Tom H2</name></entry>
+          <entry pitch="49"><name>CrashCymbal1</name></entry>
+          <entry pitch="50"><name>Elec.Tom H1</name></entry>
+          <entry pitch="51"><name>Ride Cymbal1</name></entry>
+          <entry pitch="52"><name>Reverse Cym.</name></entry>
+          <entry pitch="53"><name>Ride Bell</name></entry>
+          <entry pitch="54"><name>Tambourine</name></entry>
+          <entry pitch="55"><name>SplashCymbal</name></entry>
+          <entry pitch="56"><name>Cowbell</name></entry>
+          <entry pitch="57"><name>CrashCymbal2</name></entry>
+          <entry pitch="58"><name>Vibra-slap</name></entry>
+          <entry pitch="59"><name>Ride Cymbal2</name></entry>
+          <entry pitch="60"><name>High Bongo</name></entry>
+          <entry pitch="61"><name>Low Bongo</name></entry>
+          <entry pitch="62"><name>MuteHi Conga</name></entry>
+          <entry pitch="63"><name>OpenHi Conga</name></entry>
+          <entry pitch="64"><name>Low Conga</name></entry>
+          <entry pitch="65"><name>High Timbale</name></entry>
+          <entry pitch="66"><name>Low Timbale</name></entry>
+          <entry pitch="67"><name>High Agogo</name></entry>
+          <entry pitch="68"><name>Low Agogo</name></entry>
+          <entry pitch="69"><name>Cabasa</name></entry>
+          <entry pitch="70"><name>Maracas</name></entry>
+          <entry pitch="71"><name>ShortWhistle</name></entry>
+          <entry pitch="72"><name>Long Whistle</name></entry>
+          <entry pitch="73"><name>Short Guiro</name></entry>
+          <entry pitch="74"><name>Long Guiro</name></entry>
+          <entry pitch="75"><name>Claves</name></entry>
+          <entry pitch="76"><name>Hi WoodBlock</name></entry>
+          <entry pitch="77"><name>LowWoodBlock</name></entry>
+          <entry pitch="78"><name>Mute Cuica</name></entry>
+          <entry pitch="79"><name>Open Cuica</name></entry>
+          <entry pitch="80"><name>MuteTriangle</name></entry>
+          <entry pitch="81"><name>OpenTriangle</name></entry>
+          <entry pitch="82"><name>Shaker</name></entry>
+          <entry pitch="83"><name>Jingle Bell</name></entry>
+          <entry pitch="84"><name>Bell Tree</name></entry>
+          <entry pitch="85"><name>Castanets</name></entry>
+          <entry pitch="86"><name>Mute Surdo</name></entry>
+          <entry pitch="87"><name>Open Surdo</name></entry>
+        </drummap>
+      </entry>
+      <entry>
+        <patch_collection prog="25-31" lbank="0" hbank="107" />
+        <drummap>
+          <entry pitch="27"><name>High Q</name></entry>
+          <entry pitch="28"><name>Slap</name></entry>
+          <entry pitch="29"><name>Scratch Push</name></entry>
+          <entry pitch="30"><name>Scratch Pull</name></entry>
+          <entry pitch="31"><name>Sticks</name></entry>
+          <entry pitch="32"><name>Square Click</name></entry>
+          <entry pitch="33"><name>Metron Click</name></entry>
+          <entry pitch="34"><name>Metron Bell</name></entry>
+          <entry pitch="35"><name>909 Kick 3</name></entry>
+          <entry pitch="36"><name>909 Kick 4</name></entry>
+          <entry pitch="37"><name>Ana.Rim Shot</name></entry>
+          <entry pitch="38"><name>909 Snare</name></entry>
+          <entry pitch="39"><name>Hand Clap</name></entry>
+          <entry pitch="40"><name>808 Snare</name></entry>
+          <entry pitch="41"><name>Ana.Low Tom2</name></entry>
+          <entry pitch="42"><name>ClosedHi-hat</name></entry>
+          <entry pitch="43"><name>Ana.Low Tom1</name></entry>
+          <entry pitch="44"><name>Closed Hi-ha</name></entry>
+          <entry pitch="45"><name>Ana.Mid Tom2</name></entry>
+          <entry pitch="46"><name>Open Hi-hat</name></entry>
+          <entry pitch="47"><name>Ana.Mid Tom1</name></entry>
+          <entry pitch="48"><name>Ana.Hi Tom2</name></entry>
+          <entry pitch="49"><name>CrashCymbal1</name></entry>
+          <entry pitch="50"><name>Ana.Hi Tom1</name></entry>
+          <entry pitch="51"><name>Ride Cymbal1</name></entry>
+          <entry pitch="52"><name>China Cymbal</name></entry>
+          <entry pitch="53"><name>Ride Bell</name></entry>
+          <entry pitch="54"><name>Tambourine</name></entry>
+          <entry pitch="55"><name>SplashCymbal</name></entry>
+          <entry pitch="56"><name>Ana.Cowbell</name></entry>
+          <entry pitch="57"><name>CrashCymbal2</name></entry>
+          <entry pitch="58"><name>Vibra-slap</name></entry>
+          <entry pitch="59"><name>Ride Cymbal2</name></entry>
+          <entry pitch="60"><name>High Bongo</name></entry>
+          <entry pitch="61"><name>Low Bongo</name></entry>
+          <entry pitch="62"><name>Ana.Hi Conga</name></entry>
+          <entry pitch="63"><name>Ana.MidConga</name></entry>
+          <entry pitch="64"><name>Ana.LowConga</name></entry>
+          <entry pitch="65"><name>High Timbale</name></entry>
+          <entry pitch="66"><name>Low Timbale</name></entry>
+          <entry pitch="67"><name>High Agogo</name></entry>
+          <entry pitch="68"><name>Low Agogo</name></entry>
+          <entry pitch="69"><name>Cabasa</name></entry>
+          <entry pitch="70"><name>Ana.Maracas</name></entry>
+          <entry pitch="71"><name>ShortWhistle</name></entry>
+          <entry pitch="72"><name>Long Whistle</name></entry>
+          <entry pitch="73"><name>Short Guiro</name></entry>
+          <entry pitch="74"><name>Long Guiro</name></entry>
+          <entry pitch="75"><name>Ana.Claves</name></entry>
+          <entry pitch="76"><name>Hi WoodBlock</name></entry>
+          <entry pitch="77"><name>LowWoodBlock</name></entry>
+          <entry pitch="78"><name>Mute Cuica</name></entry>
+          <entry pitch="79"><name>Open Cuica</name></entry>
+          <entry pitch="80"><name>MuteTriangle</name></entry>
+          <entry pitch="81"><name>OpenTriangle</name></entry>
+          <entry pitch="82"><name>Shaker</name></entry>
+          <entry pitch="83"><name>Jingle Bell</name></entry>
+          <entry pitch="84"><name>Bell Tree</name></entry>
+          <entry pitch="85"><name>Castanets</name></entry>
+          <entry pitch="86"><name>Mute Surdo</name></entry>
+          <entry pitch="87"><name>Open Surdo</name></entry>
+        </drummap>
+      </entry>
+      <entry>
+        <patch_collection prog="32-39" lbank="0" hbank="107" />
+        <drummap>
+          <entry pitch="27"><name>High Q</name></entry>
+          <entry pitch="28"><name>Slap</name></entry>
+          <entry pitch="29"><name>Scratch Push</name></entry>
+          <entry pitch="30"><name>Scratch Pull</name></entry>
+          <entry pitch="31"><name>Sticks</name></entry>
+          <entry pitch="32"><name>Square Click</name></entry>
+          <entry pitch="33"><name>Metron Click</name></entry>
+          <entry pitch="34"><name>Metron Bell</name></entry>
+          <entry pitch="35"><name>Jazz Kick 2</name></entry>
+          <entry pitch="36"><name>Jazz Kick 1</name></entry>
+          <entry pitch="37"><name>Side Stick</name></entry>
+          <entry pitch="38"><name>Snare Drum 1</name></entry>
+          <entry pitch="39"><name>Hand Clap</name></entry>
+          <entry pitch="40"><name>Snare Drum 2</name></entry>
+          <entry pitch="41"><name>Low Tom 2</name></entry>
+          <entry pitch="42"><name>ClosedHi-hat</name></entry>
+          <entry pitch="43"><name>Low Tom 1</name></entry>
+          <entry pitch="44"><name>Pedal Hi-hat</name></entry>
+          <entry pitch="45"><name>Mid Tom 2</name></entry>
+          <entry pitch="46"><name>Open Hi-hat</name></entry>
+          <entry pitch="47"><name>Mid Tom 1</name></entry>
+          <entry pitch="48"><name>High Tom 2</name></entry>
+          <entry pitch="49"><name>CrashCymbal1</name></entry>
+          <entry pitch="50"><name>High Tom 1</name></entry>
+          <entry pitch="51"><name>Ride Cymbal1</name></entry>
+          <entry pitch="52"><name>China Cymbal</name></entry>
+          <entry pitch="53"><name>Ride Bell</name></entry>
+          <entry pitch="54"><name>Tambourine</name></entry>
+          <entry pitch="55"><name>SplashCymbal</name></entry>
+          <entry pitch="56"><name>Cowbell</name></entry>
+          <entry pitch="57"><name>CrashCymbal2</name></entry>
+          <entry pitch="58"><name>Vibra-slap</name></entry>
+          <entry pitch="59"><name>Ride Cymbal2</name></entry>
+          <entry pitch="60"><name>High Bongo</name></entry>
+          <entry pitch="61"><name>Low Bongo</name></entry>
+          <entry pitch="62"><name>MuteHi Conga</name></entry>
+          <entry pitch="63"><name>OpenHi Conga</name></entry>
+          <entry pitch="64"><name>Low Conga</name></entry>
+          <entry pitch="65"><name>High Timbale</name></entry>
+          <entry pitch="66"><name>Low Timbale</name></entry>
+          <entry pitch="67"><name>High Agogo</name></entry>
+          <entry pitch="68"><name>Low Agogo</name></entry>
+          <entry pitch="69"><name>Cabasa</name></entry>
+          <entry pitch="70"><name>Maracas</name></entry>
+          <entry pitch="71"><name>ShortWhistle</name></entry>
+          <entry pitch="72"><name>Long Whistle</name></entry>
+          <entry pitch="73"><name>Short Guiro</name></entry>
+          <entry pitch="74"><name>Long Guiro</name></entry>
+          <entry pitch="75"><name>Claves</name></entry>
+          <entry pitch="76"><name>Hi WoodBlock</name></entry>
+          <entry pitch="77"><name>LowWoodBlock</name></entry>
+          <entry pitch="78"><name>Mute Cuica</name></entry>
+          <entry pitch="79"><name>Open Cuica</name></entry>
+          <entry pitch="80"><name>MuteTriangle</name></entry>
+          <entry pitch="81"><name>OpenTriangle</name></entry>
+          <entry pitch="82"><name>Shaker</name></entry>
+          <entry pitch="83"><name>Jingle Bell</name></entry>
+          <entry pitch="84"><name>Bell Tree</name></entry>
+          <entry pitch="85"><name>Castanets</name></entry>
+          <entry pitch="86"><name>Mute Surdo</name></entry>
+          <entry pitch="87"><name>Open Surdo</name></entry>
+        </drummap>
+      </entry>
+      <entry>
+        <patch_collection prog="40-47" lbank="0" hbank="107" />
+        <drummap>
+          <entry pitch="27"><name>High Q</name></entry>
+          <entry pitch="28"><name>Slap</name></entry>
+          <entry pitch="29"><name>Scratch Push</name></entry>
+          <entry pitch="30"><name>Scratch Pull</name></entry>
+          <entry pitch="31"><name>Sticks</name></entry>
+          <entry pitch="32"><name>Square Click</name></entry>
+          <entry pitch="33"><name>Metron Click</name></entry>
+          <entry pitch="34"><name>Metron Bell</name></entry>
+          <entry pitch="35"><name>Jazz Kick 2</name></entry>
+          <entry pitch="36"><name>Jazz Kick 1</name></entry>
+          <entry pitch="37"><name>Side Stick</name></entry>
+          <entry pitch="38"><name>Brush Tap</name></entry>
+          <entry pitch="39"><name>Brush Slap</name></entry>
+          <entry pitch="40"><name>Brush Swirl</name></entry>
+          <entry pitch="41"><name>BrushLowTom2</name></entry>
+          <entry pitch="42"><name>ClosedHi-hat</name></entry>
+          <entry pitch="43"><name>BrushLowTom1</name></entry>
+          <entry pitch="44"><name>Closed Hi-ha</name></entry>
+          <entry pitch="45"><name>BrushMidTom2</name></entry>
+          <entry pitch="46"><name>Closed Hi-ha</name></entry>
+          <entry pitch="47"><name>BrushMidTom1</name></entry>
+          <entry pitch="48"><name>Brush HiTom2</name></entry>
+          <entry pitch="49"><name>Brush Crash1</name></entry>
+          <entry pitch="50"><name>Brush HiTom1</name></entry>
+          <entry pitch="51"><name>Brush Ride 1</name></entry>
+          <entry pitch="52"><name>China Cymbal</name></entry>
+          <entry pitch="53"><name>BrushRideBel</name></entry>
+          <entry pitch="54"><name>Tambourine</name></entry>
+          <entry pitch="55"><name>SplashCymbal</name></entry>
+          <entry pitch="56"><name>Cowbell</name></entry>
+          <entry pitch="57"><name>Brush Crash2</name></entry>
+          <entry pitch="58"><name>Vibra-slap</name></entry>
+          <entry pitch="59"><name>Ride Cymbal2</name></entry>
+          <entry pitch="60"><name>High Bongo</name></entry>
+          <entry pitch="61"><name>Low Bongo</name></entry>
+          <entry pitch="62"><name>MuteHi Conga</name></entry>
+          <entry pitch="63"><name>OpenHi Conga</name></entry>
+          <entry pitch="64"><name>Low Conga</name></entry>
+          <entry pitch="65"><name>High Timbale</name></entry>
+          <entry pitch="66"><name>Low Timbale</name></entry>
+          <entry pitch="67"><name>High Agogo</name></entry>
+          <entry pitch="68"><name>Low Agogo</name></entry>
+          <entry pitch="69"><name>Cabasa</name></entry>
+          <entry pitch="70"><name>Maracas</name></entry>
+          <entry pitch="71"><name>ShortWhistle</name></entry>
+          <entry pitch="72"><name>Long Whistle</name></entry>
+          <entry pitch="73"><name>Short Guiro</name></entry>
+          <entry pitch="74"><name>Long Guiro</name></entry>
+          <entry pitch="75"><name>Claves</name></entry>
+          <entry pitch="76"><name>Hi WoodBlock</name></entry>
+          <entry pitch="77"><name>LowWoodBlock</name></entry>
+          <entry pitch="78"><name>Mute Cuica</name></entry>
+          <entry pitch="79"><name>Open Cuica</name></entry>
+          <entry pitch="80"><name>MuteTriangle</name></entry>
+          <entry pitch="81"><name>OpenTriangle</name></entry>
+          <entry pitch="82"><name>Shaker</name></entry>
+          <entry pitch="83"><name>Jingle Bell</name></entry>
+          <entry pitch="84"><name>Bell Tree</name></entry>
+          <entry pitch="85"><name>Castanets</name></entry>
+          <entry pitch="86"><name>Mute Surdo</name></entry>
+          <entry pitch="87"><name>Open Surdo</name></entry>
+        </drummap>
+      </entry>
     </Drummaps>
   </MidiInstrument>
 </muse>


### PR DESCRIPTION
Current SD-90 IDF does not have LSB set for bank select for any of the patches, so selection among variation does not work.

This version also reorganizes the patch groups so that it is more ergonomic and consistent with other GM2 derived instruments. Patches are grouped by instrument type and then variations from all 4 sets are included in that group sorted by PC and then set (Classic, Contemporary, Solo, Enhanced). This keeps the related variations close together.

The drum sets are added per IDF 2.1 format.
Controller definitions updated.