### PR TITLE
Force the use of in-window menu

### DIFF
--- a/src/muse/main.cpp
+++ b/src/muse/main.cpp
@@ -836,6 +836,7 @@ int main(int argc, char* argv[])
           MusEGlobal::config.startSong = "";
         }
 
+	app.instance()->setAttribute(Qt::AA_DontUseNativeMenuBar, true);
         app.instance()->setAttribute(Qt::AA_DontShowIconsInMenus, !MusEGlobal::config.showIconsInMenus);
         app.instance()->setAttribute(Qt::AA_DontUseNativeDialogs, !MusEGlobal::config.useNativeStandardDialogs);
 


### PR DESCRIPTION
KDE global menu with MusE sucks.

Fixes #1292 (technically works around it).