### PR TITLE
Fix various typos

### DIFF
--- a/src/README.developer
+++ b/src/README.developer
@@ -6,7 +6,7 @@ Anyway, maybe some things should be a bit more clearly defined so I started this
 document with some pointers for best practices and procedures.
 
 * STYLE *
-whatever floats your boat. Okay, maybe try to keep it atleast somewhat consistent :)
+whatever floats your boat. Okay, maybe try to keep it at least somewhat consistent :)
 
 * TOOLS *
 MusE is highly dependent on Qt, mostly this is a good thing, especially as we want to
@@ -20,37 +20,37 @@ library, do check if Qt can provide the necessary functionality. Many times it c
 When making a release there are some steps that should always be done to make the
 packaging consistent and traceable.
 
-1. make sure that version info is updated.
+1. Make sure that version info is updated.
    CMakeLists.txt:SET(MusE_VERSION       "3.0.0pre1")
    CMakeLists.txt:SET(MusE_VERSION_FULL  "3.0.0pre1")
 
-2. add a release-line to the ChangeLog (search for old ones for some format hints)
+2. Add a release-line to the ChangeLog (search for old ones for some format hints)
 
-3. commit everything to git
+3. Commit everything to git
 
-4. now create the tarball from the build dir (could be a good idea to create a new build dir)
+4. Now create the tarball from the build dir (could be a good idea to create a new build dir)
    $ make clean (otherwise the tarball will way too big)
    $ make package_source
    feel free to ctrl-c out of this as soon as the .tar.gz build is done as it contines to make
    a lot of variants that we do not use.
 
-5. verify that the built package has the right name and can be built
+5. Verify that the built package has the right name and can be built
 
    NOTE: if you are making a point release (e.g. 3.0.1) the file name is based of the path so
    the package will be called muse-3.0.tar.gz while it really should be muse-3.0.1. Easiest 
    way to fix this (for now) is to untar the package, rename the folder (in this case) from 
    muse-3.0 to muse-3.0.1 and tar it back into muse-3.0.1.tar.gz.
 
-6. make a tag in git for this particular checkin when you are satisfied the release is correct
+6. Make a tag in git for this particular checkin when you are satisfied the release is correct
    From 4.0 release we use https://semver.org/ formatted tags.
    For instance 4.0 pre release 2 is 4.0.0-pre2.
    'git tag -l' lists all of the previous tags. 
    Use git tag -a <tag name> to create an annotated tag.
    To push the tag to master: git push --tags
 
-7. create a releasenote
+7. Create a releasenote
 
-8. upload both releasenote and tarball to the sourceforge page (or whatever is in fashion when 
+8. Upload both releasenote and tarball to the sourceforge page (or whatever is in fashion when 
    it's time).
    Update: Currently we upload to both sourceforge (because we always have and it's not a lot of work)
    and to the Releases page on github.
@@ -59,6 +59,6 @@ packaging consistent and traceable.
    The frontpage is html and resides a specific git repo.
    The news page is in the muse github wiki.
 
-10.Update wikipedia to reflect the new release.
+10. Update wikipedia to reflect the new release.
 
-11. send out a release mail
+11. Send out a release mail

--- a/src/README.softsynth
+++ b/src/README.softsynth
@@ -20,7 +20,7 @@
    Open Settings->MidiPorts/SoftSynth.
 
       - select a software synthesizer
-      - press "Add Instance" to create an istance of this
+      - press "Add Instance" to create an instance of this
         synthesizer; the synthi shows up in the list
         of instances with a unique name
 

--- a/src/grepmidi_qt/grepmidi.cpp
+++ b/src/grepmidi_qt/grepmidi.cpp
@@ -410,7 +410,7 @@ int main(int argc, char* argv[])
                   break;
 
                   default:
-                        printf("unkown error\n");
+                        printf("unknown error\n");
                         return -1;
             }
       }

--- a/src/muse/app.cpp
+++ b/src/muse/app.cpp
@@ -4478,7 +4478,7 @@ bool MusE::clearSong(bool clear_all)
     // Are any of the windows marked as 'delete on close'?
     // Then we MUST wait until they delete, otherwise crashes will happen
     //  when the song is cleared due to still-active signal/slot connections
-    //  and attempts by the various top levels to access non-existant tracks etc.
+    //  and attempts by the various top levels to access non-existent tracks etc.
     // It turns out that close() will call deleteLater() - NOT delete!
     // Simply calling processEvents() several times did not let them delete.
     // From help on QCoreApplication::processEvents():
@@ -4645,7 +4645,7 @@ bool MusE::clearSong(bool clear_all)
     // Are any of the windows marked as 'delete on close'?
     // Then we MUST wait until they delete, otherwise crashes will happen
     //  when the song is cleared due to still-active signal/slot connections
-    //  and attempts by the various top levels to access non-existant tracks etc.
+    //  and attempts by the various top levels to access non-existent tracks etc.
     // It turns out that close() will call deleteLater() - NOT delete!
     // Simply calling processEvents() several times did not let them delete.
     // From help on QCoreApplication::processEvents():

--- a/src/muse/audio.cpp
+++ b/src/muse/audio.cpp
@@ -323,7 +323,7 @@ bool Audio::start()
       // Before we seek the transport, tell the sync() routine that when it calls seek(), DON'T re-enable all controllers.
       // When loading a song and the audio is stopped before loading then restarted after, this allows synths and
       //  plugins to disable any controls where state data exists (custom data or control values).
-      // The state data takes priority over automation contollers.
+      // The state data takes priority over automation controllers.
       // Since this start() comes AFTER song loading, we need a way to prevent seekTransport(), below, from causing
       //  sync() to cause seek() to re-enable all the controllers.
       // Thus preserving the existing state of all the controller enable flags, just this one time only.

--- a/src/muse/audiotrack.cpp
+++ b/src/muse/audiotrack.cpp
@@ -688,7 +688,7 @@ void AudioTrack::setupPlugin(PluginI* plugin, int idx)
       }
     }
     else
-    // Plugin is missing. Grab the information from the plugin's persistent properies.
+    // Plugin is missing. Grab the information from the plugin's persistent properties.
     {
       const PluginConfiguration &pc = plugin->initialConfiguration();
       for(ciPluginControlList ipcl = pc._initParams.cbegin(); ipcl != pc._initParams.cend(); ++ipcl)

--- a/src/muse/functions.cpp
+++ b/src/muse/functions.cpp
@@ -1697,7 +1697,7 @@ bool merge_parts(const set<const Part*>& parts)
 		if (begin==INT_MAX || end==0)
 		{
 			printf("THIS SHOULD NEVER HAPPEN: begin==INT_MAX || end==0 in merge_parts()\n");
-			continue; // skip the actual work, as we cannot work under errorneous conditions.
+			continue; // skip the actual work, as we cannot work under erroneous conditions.
 		}
 		
 		// create and prepare the new part

--- a/src/muse/libdivide.h
+++ b/src/muse/libdivide.h
@@ -1807,7 +1807,7 @@ namespace libdivide_internal {
 
 // The following convenience macros are used to build a type of the base
 // divider class and give it as template arguments the C functions
-// related to the macro name and the macro type paramaters.
+// related to the macro name and the macro type parameters.
 
 #define BRANCHFULL_DIVIDER(INT, TYPE) \
     typedef base<INT, \
@@ -1942,7 +1942,7 @@ namespace libdivide_internal {
 
 // This is the main divider class for use by the user (C++ API).
 // The divider itself is stored in the div variable who's
-// type is chosen by the dispatcher based on the template paramaters.
+// type is chosen by the dispatcher based on the template parameters.
 template<typename T, int ALGO = BRANCHFULL>
 class divider
 {

--- a/src/muse/main.cpp
+++ b/src/muse/main.cpp
@@ -1048,7 +1048,7 @@ int main(int argc, char* argv[])
         AudioDriverSelect audioType = DriverConfigSetting;
         bool force_plugin_rescan = false;
         bool dont_plugin_rescan = false;
-        // A block because we don't want ths hanging around. Use it then lose it.
+        // A block because we don't want this hanging around. Use it then lose it.
         {
           QCommandLineParser parser;
           QString errorMessage;
@@ -1175,7 +1175,7 @@ int main(int argc, char* argv[])
         //  and should be letting Qt handle the locale stuff.
         // Usually when someone uses a c function in this app, they are not expecting
         //  (or are even aware of) any locale and usually expect the normal "C" locale.
-        // A check of virually all such calls in this app reveals that they are all used for simple
+        // A check of virtually all such calls in this app reveals that they are all used for simple
         //  things which do not - or even must not - require locale.
         // For project files for example, we NEVER want locale considerations because that would
         //  break portability, sharing files with other machines in other locales.

--- a/src/muse/song.cpp
+++ b/src/muse/song.cpp
@@ -4448,7 +4448,7 @@ void Song::beat()
             continue;
         }
 
-        // Some syncronization commands have the complete implementation in sync.cc
+        // Some synchronization commands have the complete implementation in sync.cc
         // some have the executive part here in the song class to be executed in the song thread.
         switch (command)
         {
@@ -4730,7 +4730,7 @@ void Song::clear(bool signal, bool clear_all)
       // p3.3.45 Clear all midi port devices.
       for(int i = 0; i < MusECore::MIDI_PORTS; ++i)
       {
-        // p3.3.50 Since midi ports are not deleted, clear all midi port in/out routes. They point to non-existant tracks now.
+        // p3.3.50 Since midi ports are not deleted, clear all midi port in/out routes. They point to non-existent tracks now.
         MusEGlobal::midiPorts[i].inRoutes()->clear();
         MusEGlobal::midiPorts[i].outRoutes()->clear();
         
@@ -4759,7 +4759,7 @@ void Song::clear(bool signal, bool clear_all)
             {
               // Since Jack midi devices are created dynamically, we must delete them.
               // The destructor unregisters the device from Jack, which also disconnects all device-to-jack routes.
-              // This will also delete all midi-track-to-device routes, they point to non-existant midi tracks 
+              // This will also delete all midi-track-to-device routes, they point to non-existent midi tracks 
               //  which were all deleted above
               delete (*imd);
               // Remove the device from the list.
@@ -4772,7 +4772,7 @@ void Song::clear(bool signal, bool clear_all)
           else if(dynamic_cast< MidiAlsaDevice* >(*imd))
           {
             // With alsa devices, we must not delete them (they're always in the list). But we must 
-            //  clear all routes. They point to non-existant midi tracks, which were all deleted above.
+            //  clear all routes. They point to non-existent midi tracks, which were all deleted above.
             (*imd)->inRoutes()->clear();
             (*imd)->outRoutes()->clear();
           }

--- a/src/muse/ticksynth.cpp
+++ b/src/muse/ticksynth.cpp
@@ -327,7 +327,7 @@ void MetronomeSynthIF::initSamples()
     accent1Samples = nullptr;
     accent2Samples = nullptr;
 
-    // Try loading all samples, absolute path samples has precedense over global path.
+    // Try loading all samples, absolute path samples has precedence over global path.
     MusECore::MetronomeSettings* metro_settings =
       MusEGlobal::metroUseSongSettings ? &MusEGlobal::metroSongSettings : &MusEGlobal::metroGlobalSettings;
 

--- a/src/muse/undo.cpp
+++ b/src/muse/undo.cpp
@@ -4869,7 +4869,7 @@ void Song::executeOperationGroup1(Undo& operations)
                               // Erase any items in the new list found at the frames given by the erase list.
                               for(ciCtrl ic = i->_eraseCtrlList->cbegin(); ic != i->_eraseCtrlList->cend(); ++ic)
                               {
-                                // TODO: It would be faster if we used 'group end' markers, either as an auxilliary
+                                // TODO: It would be faster if we used 'group end' markers, either as an auxiliary
                                 //        list or embedded in each controller list item. That way we could use
                                 //        the erase(start, end) to quickly erase whole sections - or the entire range.
                                 if(new_list->erase(ic->first) != 0)

--- a/src/muse/widgets/mlabel.h
+++ b/src/muse/widgets/mlabel.h
@@ -29,7 +29,7 @@ namespace MusEGui {
 
 //---------------------------------------------------------
 //   MLabel
-//    label widged which sends signal mousePressed
+//    label widget which sends signal mousePressed
 //    on mousePressEvent
 //---------------------------------------------------------
 


### PR DESCRIPTION
Found via:  
`codespell -q 3 -S "./src/share/locale,./muse3/share/locale,*.xpm,*.patch,*.diff,*.ts,*.pdf" -L 2st,3st,attribut,brite,daa,etxt,globaly,inports,lod,numer,numers,oder,ons,pevent,ressize,seh,ser,shold,sie,skool,sord,strack,udo,valu,worstcase`